### PR TITLE
Unique temporary file names by adding process ID prefix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
     "dask-cuda>=24.10.0",
     "cuda-python>=12.6.2",
     "ucx-py-cu12>=0.40.0",
+    "pytest>=8.3.4",
 ]
 requires-python = ">= 3.8"
 

--- a/src/mmore/process/dispatcher.py
+++ b/src/mmore/process/dispatcher.py
@@ -8,7 +8,6 @@ import logging
 import os
 from operator import itemgetter
 from .config import get
-from tempfile import NamedTemporaryFile
 from tqdm import tqdm
 from dask.distributed import as_completed
 

--- a/src/mmore/process/utils.py
+++ b/src/mmore/process/utils.py
@@ -104,10 +104,14 @@ def clean_image(image: Image.Image) -> bool:
     return True
 
 
-def _save_temp_image(image: Image.Image, base_path="output/images") -> str:
+def _save_temp_image(image: Image.Image, base_path=None) -> str:
     try:
+        # use systems temp dir if no path is provided 
+        temp_dir = base_path or tempfile.gettempdir()
+        pid = os.getpid() # add pid to avoid conflicts
+        unique_prefix = f"temp_{pid}_"
         temp_file = tempfile.NamedTemporaryFile(
-            delete=False, suffix=".png", dir=base_path
+            delete=False, suffix=".png", prefix=unique_prefix, dir=temp_dir
         )
         temp_file_path = temp_file.name
         image.save(temp_file_path, format="PNG")

--- a/tests/test_temp_files.py
+++ b/tests/test_temp_files.py
@@ -1,0 +1,27 @@
+import unittest
+from pathlib import Path
+from PIL import Image
+from src.mmore.process.utils import _save_temp_image
+from multiprocessing import Pool
+
+def create_temp_file(_):
+    image = Image.new("RGB", (100, 100), color="red")
+    return _save_temp_image(image)
+
+class TestTempFiles(unittest.TestCase):
+    def test_temp_file_uniqueness_parallel(self):
+        num_processes = 10
+        files_per_process = 1000 
+        total_files = num_processes * files_per_process
+
+        try:
+            with Pool(num_processes) as pool:
+                results = pool.map(create_temp_file, range(total_files))
+            self.assertEqual(len(results), len(set(results)), "Temporary file names should be unique")
+
+        finally:
+            for file_path in results:
+                Path(file_path).unlink()
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #1
This PR fixes the issue where temporary files (see [function](https://github.com/swiss-ai/mmore/commit/a106c175b2785b6973a58883b7e7e63d18c489b8#diff-e941ddf55057c6de480206f30b2fb3e7db3e2fdda8f1af4cef621f3c428d8a98R107)) could clash when multiple processes create files simultaneously. The solution adds a process ID (os.getpid()) as a prefix to each temporary file name.

Added a parallel processing test to simulate multiple processes creating files simultaneously and validated that all file names are unique.
 
To test, first `rye sync` and then run:
pytest tests/
