### PR TITLE
Filter images for pdf fast mode. Issue #21

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = [
     "ucx-py-cu12>=0.40.0",
     "pytest>=8.3.4",
     "httpx==0.27.2",
+    "emoji==1.6.3",
 ]
 requires-python = ">= 3.8"
 

--- a/src/mmore/process/processors/pdf_processor.py
+++ b/src/mmore/process/processors/pdf_processor.py
@@ -24,7 +24,8 @@ from src.mmore.process.utils import (
     create_sample,
     create_sample_list,
     merge_split_with_full_page_indexer,
-    create_sample_list_already_saved_images
+    create_sample_list_already_saved_images,
+    clean_images,
 )
 
 BATCH_SIZE = 1
@@ -132,20 +133,38 @@ class PDFProcessor(Processor):
 
     def process_fast_implementation(self, file_path: str) -> dict:
         pdf_doc = fitz.open(file_path)
-        all_text = []
+        extracted_text = []
         embedded_images = []
+        # Keep track of where each image corresponds in the text
+        # (each image will have a matching attachment_tag in extracted_text)
+        image_positions = []
 
         for page in pdf_doc:
             text = clean_text(page.get_text())
             if text.strip():
-                all_text.append(text)
+                extracted_text.append(text)
 
             for img_info in page.get_images(full=False):
                 image = self._extract_image_from_pdf(pdf_doc, img_info[0])
                 embedded_images.append(image)
-                all_text.append(self.config.attachment_tag)
+                extracted_text.append(self.config.attachment_tag)
+                image_positions.append(len(extracted_text) - 1)
 
-        return create_sample(all_text, embedded_images)
+        filtered_images, mask = clean_images(embedded_images) # if needed min_width, min_height and variance_threshold can be passed as arguments; current default 512, 512 and 100. 
+
+        # Remove attachment tags for images that were not kept
+        filtered_text = []
+        image_counter = 0
+        for token in extracted_text:
+            if token == self.config.attachment_tag:
+                # Keep this tag only if the image is retained
+                if mask[image_counter]:
+                    filtered_text.append(token)
+                image_counter += 1
+            else:
+                filtered_text.append(token)
+
+        return create_sample(filtered_text, filtered_images)
 
     def process_implementation(self, file_path: str, temp_dir: str = "tmp/") -> dict:
         def extract_image_in_page(page, current_image_index) -> Tuple[List[str], int]:

--- a/src/mmore/process/processors/pptx_processor.py
+++ b/src/mmore/process/processors/pptx_processor.py
@@ -72,7 +72,7 @@ class PPTXProcessor(Processor):
             # Extract images from shape
             if shape.shape_type == MSO_SHAPE_TYPE.PICTURE:
                 try:
-                    pil_image = Image.open(io.BytesIO(shape.image.blob)).convert("RGB")
+                    pil_image = Image.open(io.BytesIO(shape.image.blob)).convert("RGBA")
                     embedded_images.append(pil_image)
                     all_text.append(self.config.attachment_tag)
                 except Exception as e:

--- a/src/mmore/process/processors/pptx_processor.py
+++ b/src/mmore/process/processors/pptx_processor.py
@@ -3,7 +3,7 @@ import io
 from pptx import Presentation
 from pptx.enum.shapes import MSO_SHAPE_TYPE
 from PIL import Image
-from src.mmore.process.utils import clean_text, create_sample
+from src.mmore.process.utils import clean_text, create_sample, clean_image
 from src.mmore.type import FileDescriptor
 from .processor import Processor, ProcessorConfig
 from typing import List, Dict, Any
@@ -73,8 +73,10 @@ class PPTXProcessor(Processor):
             if shape.shape_type == MSO_SHAPE_TYPE.PICTURE:
                 try:
                     pil_image = Image.open(io.BytesIO(shape.image.blob)).convert("RGBA")
-                    embedded_images.append(pil_image)
-                    all_text.append(self.config.attachment_tag)
+                    if clean_image(pil_image):
+                        embedded_images.append(pil_image)
+                        all_text.append(self.config.attachment_tag)
+
                 except Exception as e:
                     logger.error(f"Failed to extract image from slide: {e}")
 

--- a/src/mmore/process/processors/spreadsheet_processor.py
+++ b/src/mmore/process/processors/spreadsheet_processor.py
@@ -6,7 +6,7 @@ from typing import List
 from PIL import Image as PILImage
 from openpyxl import load_workbook
 from openpyxl.drawing.image import Image as OpenPyXLImage
-from src.mmore.process.utils import clean_text, clean_images, create_sample
+from src.mmore.process.utils import clean_text, create_sample
 from src.mmore.type import FileDescriptor
 from .processor import Processor, ProcessorConfig
 
@@ -161,6 +161,5 @@ class SpreadsheetProcessor(Processor):
         text = _extract_text(file_path)
         cleaned_text = clean_text(text)
         images = _extract_images(file_path)
-        cleaned_images = [img for img in images if clean_image(img)]
-        
-        return create_sample([cleaned_text], cleaned_images, file_path)
+
+        return create_sample([cleaned_text], images, file_path)

--- a/src/mmore/process/processors/spreadsheet_processor.py
+++ b/src/mmore/process/processors/spreadsheet_processor.py
@@ -6,7 +6,7 @@ from typing import List
 from PIL import Image as PILImage
 from openpyxl import load_workbook
 from openpyxl.drawing.image import Image as OpenPyXLImage
-from src.mmore.process.utils import clean_text, clean_image, create_sample
+from src.mmore.process.utils import clean_text, clean_images, create_sample
 from src.mmore.type import FileDescriptor
 from .processor import Processor, ProcessorConfig
 

--- a/src/mmore/process/utils.py
+++ b/src/mmore/process/utils.py
@@ -116,55 +116,33 @@ def clean_text(text: str) -> str:
     )
 
 
-def clean_images(images: List[Image.Image], 
-                 min_width=512, 
-                 min_height=512, 
-                 variance_threshold=100) -> Tuple[List[Image.Image], List[bool]]:
+def clean_image(image: Image.Image, min_width=512, min_height=512, variance_threshold=100) -> bool:
     """
-    Filters a list of images based on size and visual content.
-
-    This function removes images that:
-    1. Do not meet the minimum width and height requirements.
-    2. Have a pixel intensity variance below a given threshold (e.g. full black/white).
+    Validates an image based on size and variance (whether its one-colored).
 
     Args:
-        images (List[PIL.Image.Image]): A list of PIL image objects to filter.
+        image (PIL.Image.Image): The image to validate.
         min_width (int, optional): The minimum width an image must have to be considered valid. Defaults to 512.
         min_height (int, optional): The minimum height an image must have to be considered valid. Defaults to 512.
-        variance_threshold (int, optional): The minimum variance in pixel intensity required. 
-                                            Images with a lower variance are considered "empty".
-                                            Defaults to 100.
+        variance_threshold (int, optional): The minimum variance in pixel intensity required. Images with lower variance are considered "empty". Defaults to 100.
 
     Returns:
-        Tuple[List[PIL.Image.Image], List[bool]]:
-            A tuple containing:
-            - A list of filtered images that passed all criteria.
-            - A corresponding boolean mask list indicating which original images were retained (True) or removed (False).
+        bool: True if the image meets all criteria, False otherwise.
     """
-    filtered = []
-    mask = []
-    for img in images:
-        w, h = img.size
+    w, h = image.size
 
-        # Check size criteria
-        if w < min_width or h < min_height:
-            mask.append(False)
-            continue
+    # Check size criteria
+    if w < min_width or h < min_height:
+        return False
 
-        # Check variance threshold
-        gray = img.convert("L")
-        arr = np.array(gray)
-        variance = arr.var()
-        if variance < variance_threshold:
-            # This means the image is mostly one color (e.g. full black or white) and can be considered empty, carries no information 
-            mask.append(False)
-            continue
+    # Check variance threshold
+    gray = image.convert("L")
+    arr = np.array(gray)
+    variance = arr.var()
+    if variance < variance_threshold:
+        return False
 
-        # If all checks pass, we keep the image
-        filtered.append(img)
-        mask.append(True)
-
-    return filtered, mask
+    return True
 
 def _save_temp_image(image: Image.Image, base_path=None) -> str:
     """


### PR DESCRIPTION
### Changes:
1. **`clean_images` function:**
   - Filters out images below minimum size thresholds (512x512).
   - Uses pixel intensity variance to discard noisy images.
   - Used for PDF and PPTX processors. 

2. **Fixed Warnings:**
   - Addressed some minor warnings.