### PR TITLE
docker: change user, add nvidia instructions and a cache folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,11 +32,16 @@ RUN apt-get update && \
     dpkg-reconfigure --frontend noninteractive tzdata && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Copy the project into the image
-ADD . /app
+# Create a non-root user
+RUN useradd -m -u 1000 mmoreuser
 
-# Sync the project into a new environment, using the frozen lockfile
+# Set up working directory and permissions
+RUN mkdir -p /app && chown -R mmoreuser:mmoreuser /app
 WORKDIR /app
+
+# Copy the project into the image and set ownership
+ADD . /app
+RUN chown -R mmoreuser:mmoreuser /app
 
 # Define the build argument with a default value of an empty string (optional)
 COPY pyproject.toml ./
@@ -50,6 +55,8 @@ ENV PATH="/app/.venv/bin:$PATH"
 RUN uv pip install -e . --system
 
 ENV DASK_DISTRIBUTED__WORKER__DAEMON=False
+
+USER mmoreuser
 
 ENTRYPOINT /bin/bash
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -102,8 +102,8 @@ sudo docker run -it -v ./examples:/app/examples -v ./.cache:/mmoreuser/.cache mm
 > ```
 >
 > ```sh
-> sudo apt-get update
-> sudo apt-get install -y nvidia-container-toolkit
+> sudo apt update
+> sudo apt install -y nvidia-container-toolkit
 > ```
 >
 > Modify the Docker daemon to use Nvidia:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -80,7 +80,39 @@ sudo docker build --build-arg PLATFORM=cpu -t mmore .
 ##### Step 3: Start an interactive session
 
 ```bash
+sudo docker run --gpus all -it -v ./examples:/app/examples mmore
+```
+
+To run for CPU-only platforms:
+```bash
 sudo docker run -it -v ./examples:/app/examples mmore
 ```
+
+> [!WARNING]
+> You may need the Nvidia toolkit so the containers can access your GPUs.
+> Read [this tutorial](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) if something breaks here!
+>
+> Configure the production repository:
+>
+> ```sh
+> curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
+>   && curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+>   sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+>   sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+> ```
+>
+> ```sh
+> sudo apt-get update
+> sudo apt-get install -y nvidia-container-toolkit
+> ```
+>
+> Modify the Docker daemon to use Nvidia:
+>
+> ```sh
+> sudo nvidia-ctk runtime configure --runtime=docker
+> sudo systemctl restart docker
+> ```
+>
+> Run the `docker run` command!
 
 *Note:* The `examples` folder is mapped to `/app/examples` inside the container, corresponding to the default path in `examples/process/config.yaml`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -80,12 +80,12 @@ sudo docker build --build-arg PLATFORM=cpu -t mmore .
 ##### Step 3: Start an interactive session
 
 ```bash
-sudo docker run --gpus all -it -v ./examples:/app/examples mmore
+sudo docker run --gpus all -it -v ./examples:/app/examples -v ./.cache:/root/.cache mmore
 ```
 
 For CPU-only platforms:
 ```bash
-sudo docker run -it -v ./examples:/app/examples mmore
+sudo docker run -it -v ./examples:/app/examples -v ./.cache:/root/.cache mmore
 ```
 
 > [!WARNING]

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -83,7 +83,7 @@ sudo docker build --build-arg PLATFORM=cpu -t mmore .
 sudo docker run --gpus all -it -v ./examples:/app/examples mmore
 ```
 
-To run for CPU-only platforms:
+For CPU-only platforms:
 ```bash
 sudo docker run -it -v ./examples:/app/examples mmore
 ```
@@ -113,6 +113,6 @@ sudo docker run -it -v ./examples:/app/examples mmore
 > sudo systemctl restart docker
 > ```
 >
-> Run the `docker run` command!
+> You can now use `docker run --gpus all`!
 
 *Note:* The `examples` folder is mapped to `/app/examples` inside the container, corresponding to the default path in `examples/process/config.yaml`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -80,12 +80,12 @@ sudo docker build --build-arg PLATFORM=cpu -t mmore .
 ##### Step 3: Start an interactive session
 
 ```bash
-sudo docker run --gpus all -it -v ./examples:/app/examples -v ./.cache:/root/.cache mmore
+sudo docker run --gpus all -it -v ./examples:/app/examples -v ./.cache:/mmoreuser/.cache mmore
 ```
 
 For CPU-only platforms:
 ```bash
-sudo docker run -it -v ./examples:/app/examples -v ./.cache:/root/.cache mmore
+sudo docker run -it -v ./examples:/app/examples -v ./.cache:/mmoreuser/.cache mmore
 ```
 
 > [!WARNING]


### PR DESCRIPTION
Using the provided command, Docker can't access GPUs and silently falls back on the CPU. I updated the command so it uses all GPUs and made it clear in the docs how to configure Docker for Nvidia.