### PR TITLE
fix: update marker-pdf to fix 'KeyError: encoder' in PDF ingest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
     "rarfile==4.2",
     "markdown==3.7",
     "markdownify==0.13.1",
-    "marker-pdf==1.6.0",
+    "marker-pdf==1.7.5",
     "moviepy==2.1.1",
     "openpyxl==3.1.5",
     "chonkie==0.2.1.post1",


### PR DESCRIPTION
See this issue: https://github.com/datalab-to/marker/issues/688