### PR TITLE
ci: create production-config with environment variables

### DIFF
--- a/.github/workflows/push-to-registry.yml
+++ b/.github/workflows/push-to-registry.yml
@@ -43,3 +43,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to:   type=gha,mode=max

--- a/.github/workflows/push-to-registry.yml
+++ b/.github/workflows/push-to-registry.yml
@@ -7,41 +7,49 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        user:
+          - { uid: 1000,    gid: 1000,    tag: "1000-1000"    }
+          - { uid: 84257,   gid: 272918,  tag: "84257-272918" }
+
     steps:
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          # list of Docker images to use as base name for tags
-          images: |
-            androz2091/swiss-ai-mmore
-          # generate Docker tags based on the following events/attributes
-          tags: |
-            type=schedule
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha            
-      -
-        name: Set up QEMU
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      -
-        name: Set up Docker Buildx
+
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      -
-        name: Login to Docker Hub
+
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build and push
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: androz2091/swiss-ai-mmore
+          tags: |
+            type=ref,event=branch
+            type=sha
+
+      - name: Build & push variant ${{ matrix.user.tag }}
         uses: docker/build-push-action@v6
         with:
+          context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            ${{ steps.meta.outputs.repository }}:${{ matrix.user.tag }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            PLATFORM=gpu
+            USER_UID=${{ matrix.user.uid }}
+            USER_GID=${{ matrix.user.gid }}
           cache-from: type=gha
           cache-to:   type=gha,mode=max

--- a/.github/workflows/push-to-registry.yml
+++ b/.github/workflows/push-to-registry.yml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       matrix:
         user:
-          - { uid: 1000,    gid: 1000,    tag: "1000-1000"    }
-          - { uid: 84257,   gid: 272918,  tag: "84257-272918" }
+          - { uid: 1000,    gid: 1000,    tag: "10001000"    }
+          - { uid: 84257,   gid: 272918,  tag: "84257272918" }
 
     steps:
       - name: Checkout
@@ -45,7 +45,7 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ steps.meta.outputs.repository }}:${{ matrix.user.tag }}
+            ${{ steps.meta.outputs.tags }}-${{ matrix.user.tag }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             PLATFORM=gpu

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ RUN echo "Using CPU-only image"
 FROM ${PLATFORM:-gpu} AS build
 ARG UV_ARGUMENTS
 
+ARG USER_UID=1000
+ARG USER_GID=1000
+
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       python3-venv python3-pip \
@@ -25,8 +28,8 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Create a non-root user
-RUN groupadd --gid 84257 mmoreuser \
- && useradd --uid 272918 --gid 84257 -m mmoreuser
+RUN groupadd --gid ${USER_GID} mmoreuser \
+ && useradd --uid ${USER_UID} --gid ${USER_GID} -m mmoreuser
 
 WORKDIR /app
 RUN python3 -m venv .venv \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,11 @@ ARG PLATFORM
 
 COPY --from=ghcr.io/astral-sh/uv:0.5.8 /uv /uvx /bin/
 
-RUN apt-get update && apt-get install -y python3-pip && pip3 install uv
+# Install Python, create virtualenv, and install UV
+RUN apt-get update \
+ && apt-get install -y python3-venv python3-pip \
+ && python3 -m venv /app/.venv \
+ && /app/.venv/bin/pip install uv
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -48,7 +52,6 @@ RUN chown -R mmoreuser:mmoreuser /app
 COPY pyproject.toml ./
 # RUN uv sync --frozen ${UV_ARGUMENTS}
 
-
 # make uv's python the default python for the image
 ENV PATH="/app/.venv/bin:$PATH"
 
@@ -60,4 +63,3 @@ ENV DASK_DISTRIBUTED__WORKER__DAEMON=False
 USER mmoreuser
 
 ENTRYPOINT ["/bin/bash"]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,10 @@ RUN groupadd --gid ${USER_GID} mmoreuser \
  && useradd --uid ${USER_UID} --gid ${USER_GID} -m mmoreuser
 
 WORKDIR /app
+RUN chown -R mmoreuser:mmoreuser /app
+
+USER mmoreuser
+
 RUN python3 -m venv .venv \
  && .venv/bin/pip install --no-cache-dir uv
 
@@ -42,7 +46,5 @@ RUN .venv/bin/uv pip install --no-cache ${UV_ARGUMENTS} -e .
 
 ENV PATH="/app/.venv/bin:$PATH"
 ENV DASK_DISTRIBUTED__WORKER__DAEMON=False
-
-USER mmoreuser
 
 ENTRYPOINT ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,8 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Create a non-root user
-RUN useradd -m -u 1000 mmoreuser
+RUN groupadd --gid 84257 mmoreuser \
+ && useradd --uid 272918 --gid 84257 -m mmoreuser
 
 # Set up working directory and permissions
 RUN mkdir -p /app && chown -R mmoreuser:mmoreuser /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ARG USER_GID=1000
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       python3-venv python3-pip \
-      tzdata nano curl ffmpeg libsm6 libxext6 chromium-browser nss3 gconf-2-4 \
+      tzdata nano curl ffmpeg libsm6 libxext6 chromium-browser libnss3 libgconf-2-4 \
       libxi6 libxrandr2 libxcomposite1 libxcursor1 libxdamage1 libxfixes3 libxrender1 \
       libasound2 libatk1.0-0 libgtk-3-0 libreoffice libjpeg-dev libpango-1.0-0 \
       libpangoft2-1.0-0 weasyprint && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,10 +36,9 @@ RUN python3 -m venv .venv \
  && .venv/bin/pip install --no-cache-dir uv
 
 COPY pyproject.toml poetry.lock* /app/
-
-RUN .venv/bin/pip install --no-cache-dir -e .
-
 COPY --chown=mmoreuser:mmoreuser . /app
+
+RUN .venv/bin/uv pip install --no-cache ${UV_ARGUMENTS} -e .
 
 ENV PATH="/app/.venv/bin:$PATH"
 ENV DASK_DISTRIBUTED__WORKER__DAEMON=False

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN python3 -m venv .venv \
 
 COPY pyproject.toml poetry.lock* /app/
 
-RUN .venv/bin/pip install --no-cache-dir -e . --system
+RUN .venv/bin/pip install --no-cache-dir -e .
 
 COPY --chown=mmoreuser:mmoreuser . /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,9 +56,9 @@ COPY pyproject.toml ./
 ENV PATH="/app/.venv/bin:$PATH"
 
 # install mpmath
-RUN uv pip install -e . --system
+RUN pip install -e . 
 
-ENV DASK_DISTRIBUTED__WORKER__DAEMON=False
+ENV DASK_DISTRIBUTED__WORKER__DAEMON=False DASK_DISTRIBUTED__WORKER__DAEMON=False
 
 USER mmoreuser
 

--- a/examples/process/config.yaml
+++ b/examples/process/config.yaml
@@ -1,11 +1,11 @@
-data_path: examples/sample_data/ #put absolute path!
+data_path: examples/sample_data/ #put absolute path or relative to the root of the module
 dispatcher_config:
-  output_path: examples/process/outputs/ #put absolute path!
+  output_path: examples/process/outputs/ #put absolute path or relative to the root of the module
   use_fast_processors: false
   distributed: false
   dashboard_backend_url: null
   extract_images: true
-  scheduler_file: /mmore/scheduler-file.json #put absolute path!
+  scheduler_file: null # for instance /path/to/mmore/scheduler-file.json
   process_batch_sizes:
     - URLProcessor: 40
     - DOCXProcessor: 100

--- a/production-config/index/config.yaml
+++ b/production-config/index/config.yaml
@@ -1,0 +1,12 @@
+indexer:
+  dense_model:
+    model_name: sentence-transformers/all-MiniLM-L6-v2
+    is_multimodal: false
+  sparse_model:
+    model_name: splade
+    is_multimodal: false
+  db:
+    uri: $ROOT_OUT_DIR/db/proc_demo.db
+    name: my_db
+collection_name: my_docs
+documents_path: '$ROOT_OUT_DIR/postprocessor/outputs/merged/final_pp.jsonl'

--- a/production-config/postprocessor/config.yaml
+++ b/production-config/postprocessor/config.yaml
@@ -1,0 +1,23 @@
+pp_modules:
+  - type: file_namer
+  - type: chunker
+    args:
+      chunking_strategy: sentence
+  - type: translator
+    args:
+      target_language: en
+      attachment_tag: <attachment>
+      confidence_threshold: 0.7
+      constrained_languages: 
+        - fr
+        - en
+  - type: metafuse
+    args:
+      metadata_keys:
+        - file_name
+      content_template: Content from {file_name}
+      position: beginning
+
+output:
+  output_path: $ROOT_OUT_DIR/postprocessor/outputs/merged/
+  save_each_step: True

--- a/production-config/process/config.yaml
+++ b/production-config/process/config.yaml
@@ -1,0 +1,37 @@
+data_path: $ROOT_IN_DIR/sample_data/ #put absolute path!
+dispatcher_config:
+  output_path: $ROOT_OUT_DIR/process/outputs/ #put absolute path!
+  use_fast_processors: false
+  distributed: false
+  dashboard_backend_url: null
+  extract_images: true
+  scheduler_file: /mmore/scheduler-file.json #put absolute path!
+  process_batch_sizes:
+    - URLProcessor: 40
+    - DOCXProcessor: 100
+    - PDFProcessor: 4000
+    - MediaProcessor: 40
+    - SpreadsheetProcessor: 100
+    - TXTProcessor: 100
+    - PPTXProcessor: 100
+    - MarkdownProcessor: 100
+    - EMLProcessor: 100
+    - HTMLProcessor: 100
+  processor_config:
+    MediaProcessor:
+      - normal_model: "openai/whisper-large-v3-turbo"
+      - fast_model: "openai/whisper-tiny"
+      - type: "automatic-speech-recognition"
+      - sample_rate: 10
+      - batch_size: 4
+
+    PDFProcessor:
+      - PDFTEXT_CPU_WORKERS: 0
+      - DETECTOR_BATCH_SIZE: 1
+      - DETECTOR_POSTPROCESSING_CPU_WORKERS: 0
+      - RECOGNITION_BATCH_SIZE: 1
+      - OCR_PARALLEL_WORKERS: 0
+      - TEXIFY_BATCH_SIZE: 1
+      - LAYOUT_BATCH_SIZE: 1
+      - ORDER_BATCH_SIZE: 1
+      - TABLE_REC_BATCH_SIZE: 1

--- a/production-config/rag/config.yaml
+++ b/production-config/rag/config.yaml
@@ -1,0 +1,15 @@
+rag:
+  llm: 
+    llm_name: OpenMeditron/meditron3-8b
+    max_new_tokens: 1200
+  retriever:
+    db:
+      uri: $ROOT_OUT_DIR/db/proc_demo.db
+      name: 'my_db'
+    hybrid_search_weight: 0.5
+    k: 5
+  system_prompt: "Use the following context to answer the questions.\n\nContext:\n{context}"
+mode: local
+mode_args:
+  input_file: $ROOT_IN_DIR/rag/queries.jsonl
+  output_file: $ROOT_OUT_DIR/rag/output.json

--- a/production-config/rag/config_api.yaml
+++ b/production-config/rag/config_api.yaml
@@ -1,0 +1,22 @@
+# RAG Config
+rag: 
+  # LLM Config
+  llm: 
+    llm_name: Qwen/Qwen3-8B # "epfl-llm/meditron-70b" # "gpt-4o-mini" # Anything supported
+    max_new_tokens: 1200
+    temperature: 0.8
+  # Retriever Config
+  retriever:
+    db:
+      uri: $ROOT_OUT_DIR/db/proc_demo.db
+      name: my_db
+    hybrid_search_weight: 0.5
+    k: 5
+  # Prompt Args
+  system_prompt: "Answer the question using the context.\n\nContext: {context}"
+# Mode Config
+mode: api
+mode_args:
+  endpoint: '/rag'
+  port: 8000
+  host: 'localhost'

--- a/production-config/rag/queries.jsonl
+++ b/production-config/rag/queries.jsonl
@@ -1,0 +1,4 @@
+{"input": "When was Barack Obama born?", "collection_name": "my_docs"}
+{"input": "Who founded Google?", "collection_name": "my_docs"}
+{"input": "Where is the Eiffel Tower located?", "collection_name": "my_docs"}
+{"input": "When will the artificial intelligence conference be held?", "collection_name": "my_docs"}

--- a/production-config/retriever_api/config.yaml
+++ b/production-config/retriever_api/config.yaml
@@ -1,0 +1,6 @@
+db:
+  uri: $ROOT_OUT_DIR/db/proc_demo.db
+  name: my_db
+hybrid_search_weight: 0.5
+k: 5
+collection_name: my_docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,10 @@ profile = "black"
 [project.scripts]
 mmore = "mmore.cli:main"
 
+[tool.setuptools]
+packages = ["mmore"]
+package-dir = {"" = "src"}
+
 [tool.pytest.ini_options]
 filterwarnings = ["ignore::Warning"]
 testpaths = ["tests"]

--- a/src/mmore/run_index.py
+++ b/src/mmore/run_index.py
@@ -1,5 +1,4 @@
 import argparse
-import json
 import logging
 from dataclasses import dataclass
 from typing import Optional, Union
@@ -26,17 +25,6 @@ class IndexConfig:
     indexer: IndexerConfig
     collection_name: str
     documents_path: str
-
-
-def load_results(path: str):
-    # Load the results computed and saved by 'run_process.py'
-    results = []
-    logger.info(f"Loading results from {path}")
-    with open(path, "rb") as f:
-        for line in f:
-            results.append(MultimodalSample.from_dict(json.loads(line)))
-    logger.info(f"Loaded {len(results)} results")
-    return results
 
 
 def index(

--- a/src/mmore/run_postprocess.py
+++ b/src/mmore/run_postprocess.py
@@ -32,6 +32,8 @@ def postprocess(config_file, input_data):
 
     # Load samples
     samples = _load_dataset(input_data)
+    if len(samples) == 0:
+        logger.warning("⚠️ Found no file to postprocess")
 
     # Run pipeline
     samples = pipeline(samples)

--- a/src/mmore/run_process.py
+++ b/src/mmore/run_process.py
@@ -83,6 +83,10 @@ def process(config_file: str):
     crawl_time = crawl_end_time - crawl_start_time
     logger.info(f"Crawling completed in {crawl_time:.2f} seconds")
 
+    if len(crawl_result) == 0:
+        logger.warning("⚠️ Found no file to process")
+        return
+
     dispatcher_config: DispatcherConfig = config.dispatcher_config
 
     url = dispatcher_config.dashboard_backend_url

--- a/src/mmore/type.py
+++ b/src/mmore/type.py
@@ -92,6 +92,10 @@ class MultimodalSample:
     @classmethod
     def from_jsonl(cls, file_path: str) -> List["MultimodalSample"]:
         samples = []
+        if not os.path.exists(file_path):
+            logger.warning(f"⚠️ File path {file_path} does not exist")
+            return samples
+
         with open(file_path, "r") as f:
             for line in f:
                 samples.append(cls.from_dict(json.loads(line)))

--- a/src/mmore/utils.py
+++ b/src/mmore/utils.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 
 T = TypeVar("T")
 
+
 def expand_env_vars(obj):
     if isinstance(obj, dict):
         return {key: expand_env_vars(value) for key, value in obj.items()}
@@ -22,6 +23,7 @@ def expand_env_vars(obj):
         return os.path.expandvars(obj)
     else:
         return obj
+
 
 def load_config(yaml_dict_or_path: Union[str, Dict, T], config_class: Type[T]) -> T:
     if isinstance(yaml_dict_or_path, config_class):

--- a/src/mmore/utils.py
+++ b/src/mmore/utils.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import TYPE_CHECKING, Dict, List, Type, TypeVar, Union, cast
 
 import yaml
@@ -12,6 +13,15 @@ if TYPE_CHECKING:
 
 T = TypeVar("T")
 
+def expand_env_vars(obj):
+    if isinstance(obj, dict):
+        return {key: expand_env_vars(value) for key, value in obj.items()}
+    elif isinstance(obj, list):
+        return [expand_env_vars(item) for item in obj]
+    elif isinstance(obj, str):
+        return os.path.expandvars(obj)
+    else:
+        return obj
 
 def load_config(yaml_dict_or_path: Union[str, Dict, T], config_class: Type[T]) -> T:
     if isinstance(yaml_dict_or_path, config_class):
@@ -22,6 +32,9 @@ def load_config(yaml_dict_or_path: Union[str, Dict, T], config_class: Type[T]) -
             data = yaml.safe_load(file)
     else:
         data = yaml_dict_or_path
+
+    # we want to support $ROOT_IN_DIR, $ROOT_OUT_DIR
+    data = expand_env_vars(data)
 
     return from_dict(config_class, cast(Dict, data))
 

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -9,7 +9,7 @@ import pytest
 from mmore.index.indexer import Indexer, IndexerConfig
 
 # Import run_index from the correct package path:
-from mmore.run_index import index, load_results
+from mmore.run_index import index
 from mmore.type import MultimodalSample
 
 
@@ -30,21 +30,6 @@ def sample_jsonl(tmp_path):
         for entry in sample_data:
             f.write(json.dumps(entry) + "\n")
     return path
-
-
-def test_load_results(sample_jsonl):
-    """
-    Tests that load_results() properly reads JSONL files and returns a list of MultimodalSample objects
-    """
-    results = load_results(str(sample_jsonl))
-    assert len(results) == 2, "Should load exactly 2 documents"
-    print(type(results[0]), MultimodalSample)
-    assert isinstance(results[0], MultimodalSample), (
-        "Should return MultimodalSample objects"
-    )
-    # If your code overrides the .id, don't check for '1':
-    assert "Document text 1" in results[0].text
-    assert results[1].metadata.get("author") == "Alice"
 
 
 @patch("mmore.run_index.Indexer.from_documents")


### PR DESCRIPTION
- create a CI that builds the image and pushes it to dockerhub androz2091/swiss-ai-mmore (see #126, right now I cannot use RCP because it needs a VPN. I will discuss this with them in the coming days).
- it builds and pushes two images (one with 1000:1000, the standard user, one with light:simon), so I can use it with the RCP development environment. (see #135).
- it now supports `$ROOT_OUT_DIR`, `$ROOT_IN_DIR` environment variables so we can now easily specify a different storage path without having to changes prodution configuration files (added in a new `production-config` folder). Once we deploy to production, I will write down everything (see #136).
- few fixes already pushed on master (retriever --> retrieve), fix steps depending on jsonl files, etc.
- cleaned up dockerfile and added caching