### PR TITLE
pre-commit autoupdate 2025-09-04

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,9 +4,9 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.13
+    rev: v0.12.11
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [
           --fix,                # auto-fix lint + style issues
           --unsafe-fixes,       # allows formatting & import sorting


### PR DESCRIPTION
% `pre-commit autoupdate`
```
[https://github.com/PyCQA/isort] already up to date!
[https://github.com/astral-sh/ruff-pre-commit] updating v0.11.13 -> v0.12.11
```
% `pre-commit run --all-files`
```
isort....................................................................Passed
ruff check...............................................................Passed
```
* https://github.com/astral-sh/ruff/releases