### PR TITLE
GitHub Actions: Test on the latest stable version of Python

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,11 +12,11 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.x"]
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5


### PR DESCRIPTION
Automated testing should tell us if things are broken on the latest stable version of Python before users do.
* https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#using-the-python-version-input
> [x-ranges](https://github.com/npm/node-semver#x-ranges-12x-1x-12-) to specify the latest stable version of Python (for the specified major version)