### PR TITLE
Fix create sample from processor, add page context for pdf

### DIFF
--- a/src/mmore/process/post_processor/chunker/multimodal.py
+++ b/src/mmore/process/post_processor/chunker/multimodal.py
@@ -67,29 +67,57 @@ class MultimodalChunker(BasePostProcessor):
         if not sample.text or not sample.text.strip():
             logger.warning(f"Empty text in sample {sample.id}. Skipping chunking.")
             return []
+        
         try:
             # Chunk using the text chunker
             text_chunks = self.text_chunker.chunk(sample.text)
         except Exception as e:
-            logger.error(
-                f"Chunking error on sample with length: {len(sample.text): {e}} "
-            )
+            logger.error(f"Chunking error on sample with length: {len(sample.text): {e}} ")
             return []
+        
         # Chunk modalities according to the text chunks
         modalities_chunks = MultimodalChunker._chunk_modalities(sample, text_chunks)
+        page_info_chunks = self._assign_page_numbers(sample, text_chunks)
 
         chunks = []
-        for i, (chunk, mods) in enumerate(zip(text_chunks, modalities_chunks)):
+        for i, (chunk, mods, page_info) in enumerate(zip(text_chunks, modalities_chunks, page_info_chunks)):
+            chunk_metadata = sample.metadata.copy()
+            chunk_metadata.update(page_info)
+            chunk_metadata.pop('page_starts', None)
+            
             s = MultimodalSample(
                 text=chunk.text,
                 modalities=mods,
-                metadata=sample.metadata,
+                metadata=chunk_metadata,
                 id=f"{sample.id}+{i}",
             )
             chunks.append(s)
 
         return chunks
 
+    def _assign_page_numbers(self, sample: MultimodalSample, text_chunks: List[Chunk]) -> List[Dict[str, Any]]:
+        """Assign page numbers using page start positions."""
+        page_info_chunks = []
+        page_starts = sample.metadata.get("page_starts", [])
+        
+        if len(page_starts) == 0:
+            for chunk in text_chunks:
+                page_info_chunks.append({})
+            return page_info_chunks
+        
+        for chunk in text_chunks:
+            chunk_page_numbers = set()
+            
+            for i in range(len(page_starts) - 1):
+                page_start, page_num = page_starts[i]
+                next_start, _ = page_starts[i + 1]
+                if (chunk.start_index < next_start and chunk.end_index > page_start):
+                    chunk_page_numbers.add(page_num)
+            
+            sorted_pages = sorted(chunk_page_numbers)
+            page_info_chunks.append({"page_numbers": sorted_pages})
+        
+        return page_info_chunks
 
 def _text_index_to_chunk_index(index: int, chunks: List[Chunk]) -> Optional[int]:
     for i, chunk in enumerate(chunks):

--- a/src/mmore/process/processors/base.py
+++ b/src/mmore/process/processors/base.py
@@ -204,7 +204,7 @@ class Processor(ABC):
         return 1
 
     def create_sample(
-        self, texts: List[str], images: List[Image.Image], file_path
+        self, texts: List[str], images: List[Image.Image], metadata: Optional[Dict[str, Any]] = None
     ) -> MultimodalSample:
         """
         Create a sample dictionary containing text, images, and optional metadata.
@@ -213,7 +213,7 @@ class Processor(ABC):
         Args:
             texts (List[str]): List of text strings.
             images (List[Image.Image]): List of images.
-            path (str, optional): Path for metadata. Defaults to None.
+            metadata (Dict[str, Any], optional): Additional metadata for the sample. Defaults to None.
 
         Returns:
             dict: Sample dictionary with text, image modalities, and metadata.
@@ -261,7 +261,7 @@ class Processor(ABC):
                 for img in images
                 if (tmp_path := _save_temp_image(img, base_path=image_base_path))
             ],
-            {"file_path": file_path} if file_path is not None else dict(),
+            metadata if metadata is not None else {},
         )
         return sample
 

--- a/src/mmore/process/processors/docx_processor.py
+++ b/src/mmore/process/processors/docx_processor.py
@@ -115,7 +115,7 @@ class DOCXProcessor(Processor):
 
         except Exception as e:
             logger.warning(f"Failed to convert {file_path}: {e}")
-            return self.create_sample([], [], file_path)
+            return self.create_sample([], [], {"file_path" : file_path})
 
         markdown = markdownify(result.value)
 

--- a/src/mmore/process/processors/eml_processor.py
+++ b/src/mmore/process/processors/eml_processor.py
@@ -60,7 +60,7 @@ class EMLProcessor(Processor):
                 msg = email.message_from_bytes(f.read(), policy=policy.default)
         except Exception as e:
             logger.error(f"Failed to open EML file {file_path}: {e}")
-            return self.create_sample([], [], file_path)
+            return self.create_sample([], [], {"file_path" : file_path})
 
         all_text = []
         embedded_images = []
@@ -105,4 +105,4 @@ class EMLProcessor(Processor):
                 else:
                     embedded_images = []
 
-        return self.create_sample(all_text, embedded_images, file_path)
+        return self.create_sample(all_text, embedded_images, {"file_path" : file_path})

--- a/src/mmore/process/processors/html_processor.py
+++ b/src/mmore/process/processors/html_processor.py
@@ -94,7 +94,7 @@ class HTMLProcessor(Processor):
                 html = f.read()
         except Exception as e:
             logger.error(f"Failed to open HTML file {file_path}: {e}")
-            return self.create_sample([], [], file_path)
+            return self.create_sample([], [], {"file_path" : file_path})
 
         markdown = md(html, heading_style="ATX")
 
@@ -113,4 +113,4 @@ class HTMLProcessor(Processor):
         cleaned_markdown = clean_text(markdown).strip()
         all_text = [cleaned_markdown] if cleaned_markdown else []
 
-        return self.create_sample(all_text, embedded_images, file_path)
+        return self.create_sample(all_text, embedded_images, {"file_path" : file_path})

--- a/src/mmore/process/processors/md_processor.py
+++ b/src/mmore/process/processors/md_processor.py
@@ -65,10 +65,10 @@ class MarkdownProcessor(Processor):
                 content = f.read()
         except UnicodeDecodeError as e:
             logger.error(f"Encoding error reading file {file_path}: {e}")
-            return self.create_sample([], [], file_path)
+            return self.create_sample([], [], {"file_path" : file_path})
         except IOError as e:
             logger.error(f"IO error reading file {file_path}: {e}")
-            return self.create_sample([], [], file_path)
+            return self.create_sample([], [], {"file_path" : file_path})
 
         try:
             all_text, embedded_images = MarkdownProcessor._process_md(
@@ -77,10 +77,10 @@ class MarkdownProcessor(Processor):
                 self.config.attachment_tag,
                 self.config.custom_config.get("extract_images", True),
             )
-            return self.create_sample([all_text], embedded_images, file_path)
+            return self.create_sample([all_text], embedded_images, {"file_path" : file_path})
         except Exception as e:
             logger.error(f"[MD Processor] Error processing markdown content: {e}")
-            return self.create_sample([], [], file_path)
+            return self.create_sample([], [], {"file_path" : file_path})
 
     @staticmethod
     def _process_md(

--- a/src/mmore/process/processors/media_processor.py
+++ b/src/mmore/process/processors/media_processor.py
@@ -97,7 +97,7 @@ class MediaProcessor(Processor):
         else:
             images = []
 
-        return self.create_sample([all_text], images, file_path)
+        return self.create_sample([all_text], images, {"file_path" : file_path})
 
     def process(self, file_path: str, fast: bool = False) -> MultimodalSample:
         if not self.pipelines:
@@ -112,7 +112,7 @@ class MediaProcessor(Processor):
             if self.config.custom_config.get("extract_images", True)
             else []
         )
-        return self.create_sample([all_text], images, file_path)
+        return self.create_sample([all_text], images, {"file_path" : file_path})
 
     def _extract_text(self, file_path: str, pipeline, fast_mode=False) -> str:
         def _prepare_audio_file(file_path: str, ext: str, temp_audio):

--- a/src/mmore/process/processors/pdf_processor.py
+++ b/src/mmore/process/processors/pdf_processor.py
@@ -141,12 +141,14 @@ class PDFProcessor(Processor):
         text, _, images = text_from_rendered(rendered)
         text = re.sub(IMG_REGEX, "<attachment>", text)
         images = list(images.values())
-        return self.create_sample([text], images, file_path)
+        return self.create_sample([text], images, {"file_path" : file_path})
 
     def process_fast(self, file_path: str) -> MultimodalSample:
         pdf_doc = fitz.open(file_path)
-        all_text = []
+        all_text_parts = []
         embedded_images = []
+        page_starts = []
+        current_position = 0
 
         def _extract_images(pdf_doc, xref) -> Optional[Image.Image]:
             try:
@@ -174,10 +176,14 @@ class PDFProcessor(Processor):
                 )
                 return None
 
-        for page in pdf_doc:
+        for page_num, page in enumerate(pdf_doc):
+            
+            page_starts.append((current_position, page_num))
             text = clean_text(page.get_text())  # type: ignore[attr-defined]
+            
             if text.strip():
-                all_text.append(text)
+                all_text_parts.append(text)
+                current_position += len(text)
 
             if self.config.custom_config.get("extract_images", True):
                 for img_info in page.get_images(full=False):
@@ -185,11 +191,21 @@ class PDFProcessor(Processor):
                     if image and clean_image(image):
                         # clean image filters images below size 512x512 and variance below 100, these are defaults and can be changed
                         embedded_images.append(image)
-                        all_text.append(self.config.attachment_tag)
+                        attachment_text = self.config.attachment_tag
+                        all_text_parts.append(attachment_text)
+                        current_position += len(attachment_text)
             else:
                 embedded_images = []
 
-        return self.create_sample(all_text, embedded_images, file_path)
+        page_starts.append((current_position, len(pdf_doc)))
+        metadata = {
+            "file_path": file_path,
+            "page_starts": page_starts,
+            "document_type": "pdf"
+        }
+        
+        full_text = "".join(all_text_parts)
+        return self.create_sample([full_text], embedded_images, metadata)
 
     # Functions for parallelizing across GPUs
     def _split_files(self, files_paths, num_batches):

--- a/src/mmore/process/processors/pptx_processor.py
+++ b/src/mmore/process/processors/pptx_processor.py
@@ -62,7 +62,7 @@ class PPTXProcessor(Processor):
             prs = Presentation(file_path)
         except Exception as e:
             logger.error(f"Failed to open PowerPoint file {file_path}: {e}")
-            return self.create_sample([], [], file_path)
+            return self.create_sample([], [], {"file_path" : file_path})
 
         all_text: list[str] = []
         embedded_images: list[Image.Image] = []
@@ -111,4 +111,4 @@ class PPTXProcessor(Processor):
         except Exception as e:
             logger.error(f"[PPTX] Error processing slides in {file_path}: {e}")
 
-        return self.create_sample(all_text, embedded_images, file_path)
+        return self.create_sample(all_text, embedded_images, {"file_path" : file_path})

--- a/src/mmore/process/processors/spreadsheet_processor.py
+++ b/src/mmore/process/processors/spreadsheet_processor.py
@@ -165,4 +165,4 @@ class SpreadsheetProcessor(Processor):
         else:
             embedded_images = []
 
-        return self.create_sample([all_text], embedded_images, file_path)
+        return self.create_sample([all_text], embedded_images, {"file_path" : file_path})

--- a/src/mmore/process/processors/txt_processor.py
+++ b/src/mmore/process/processors/txt_processor.py
@@ -50,10 +50,10 @@ class TextProcessor(Processor):
                 all_text = f.read()
         except (FileNotFoundError, PermissionError) as e:
             logger.error(f"Failed to read file {file_path}: {e}")
-            return self.create_sample([], [], file_path)
+            return self.create_sample([], [], {"file_path" : file_path})
         except UnicodeDecodeError as e:
             logger.error(f"Encoding error in file {file_path}: {e}")
-            return self.create_sample([], [], file_path)
+            return self.create_sample([], [], {"file_path" : file_path})
 
         all_text = clean_text(all_text)
-        return self.create_sample([all_text], [], file_path)
+        return self.create_sample([all_text], [], {"file_path" : file_path})

--- a/src/mmore/process/processors/url_processor.py
+++ b/src/mmore/process/processors/url_processor.py
@@ -65,10 +65,10 @@ class URLProcessor(Processor):
                     logger.error(f"Failed to process image {image}: {e}")
 
             all_text = [clean_text(all_text)]
-            return self.create_sample(all_text, embedded_images, file_path)
+            return self.create_sample(all_text, embedded_images, {"file_path" : file_path})
         except Exception as e:
             logger.error(f"Failed to process URL {file_path}: {e}")
-            return self.create_sample([], [], file_path)
+            return self.create_sample([], [], {"file_path" : file_path})
 
     def process(self, file_path: str, fast: bool = False) -> MultimodalSample:
         return self.process_fast(file_path)


### PR DESCRIPTION
This pull request refactors how metadata is handled when creating `MultimodalSample` objects across multiple file processors and introduces improved page number tracking for chunked PDF samples. The main changes standardize metadata passing, ensuring all processors use a dictionary for metadata (not just a file path string), and enhance chunking logic to include page information for downstream tasks.

**Metadata handling standardization:**

* The `create_sample` method in `base.py` now accepts a `metadata` dictionary instead of a file path string, and all processors (`docx`, `eml`, `html`, `md`, `media`, `pdf`, `pptx`, `spreadsheet`, `txt`, `url`) are updated to pass metadata as a dictionary, typically with the file path included. [[1]](diffhunk://#diff-c3b9d1c1992df3c7a2a8c72db3a7c3729b804905df745d48ebf372d114be39d8L207-R207) [[2]](diffhunk://#diff-c3b9d1c1992df3c7a2a8c72db3a7c3729b804905df745d48ebf372d114be39d8L264-R264) [[3]](diffhunk://#diff-9672d6121d7d36fa7ce04faf49da194e1dd2354ba55a47402bfb2199b7b59659L118-R118) [[4]](diffhunk://#diff-5e6eeb7591885e754797d57db26e8b43764ac15f713b363c1017d573dafc4b36L63-R63) [[5]](diffhunk://#diff-5e6eeb7591885e754797d57db26e8b43764ac15f713b363c1017d573dafc4b36L108-R108) [[6]](diffhunk://#diff-9b4974eb46551853bd241e71cc243ae43139058c9214d2330facc17c85a4a7a6L97-R97) [[7]](diffhunk://#diff-9b4974eb46551853bd241e71cc243ae43139058c9214d2330facc17c85a4a7a6L116-R116) [[8]](diffhunk://#diff-1f0f4db70706f33af27415e67d3778f47fbd0c577062db4a9b0db95fd9ccce32L68-R71) [[9]](diffhunk://#diff-1f0f4db70706f33af27415e67d3778f47fbd0c577062db4a9b0db95fd9ccce32L80-R83) [[10]](diffhunk://#diff-423df865bc4b9243e10eced5193a8ff66fc9ef24fe50003f71fd40f1e2df62aaL100-R100) [[11]](diffhunk://#diff-423df865bc4b9243e10eced5193a8ff66fc9ef24fe50003f71fd40f1e2df62aaL115-R115) [[12]](diffhunk://#diff-a8e619aba0082e5343aac3bcfaeb83c09969ef56c90a3488b9050bdf1ea19f7fL144-R151) [[13]](diffhunk://#diff-1794de501313e9ba30028bf4d5d1845323c1e2b1d1692c921e544bc5e6decc15L65-R65) [[14]](diffhunk://#diff-1794de501313e9ba30028bf4d5d1845323c1e2b1d1692c921e544bc5e6decc15L114-R114) [[15]](diffhunk://#diff-1b35565fe24c9d56ae8e87ff4c580bb30194b786377562881cbbd8458468a67dL168-R168) [[16]](diffhunk://#diff-62f32c1466bf84fedfb7aa313ad2e41638c89aba398aaf94ba489af931e30256L53-R59) [[17]](diffhunk://#diff-726cd7b222d7ae3d5d3ff02de564dca2bf8acd1c77c805cdca896d06445751f1L68-R71)

**PDF processing and chunking improvements:**

* The PDF processor's `process_fast` method now tracks page start positions and includes them in the sample's metadata, along with the document type, to support more granular chunking and downstream page-aware processing.
* The multimodal chunker (`multimodal.py`) introduces a `_assign_page_numbers` method to assign page numbers to each chunk based on the new `page_starts` metadata, and updates chunk metadata accordingly during chunking.

**Documentation and argument updates:**

* The docstrings and argument names for `create_sample` are updated to reflect the new metadata dictionary usage, improving clarity for future development.

These changes collectively improve consistency in metadata handling and enable richer, page-aware chunking for multimodal document processing.