### PR TITLE
More convenient set of github actions for new releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,41 +1,40 @@
 name: 📦 Publish Python Package
+
 on:
   release:
     types: [published]
+
 permissions:
   contents: read
+  id-token: write
+
 jobs:
-  release-build:
+  build-and-publish:
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.x"
-      - name: Build release distributions
-        run: |
-          python -m pip install build
-          python -m build
-      - name: Upload distributions
-        uses: actions/upload-artifact@v6
-        with:
-          name: release-dists
-          path: dist/
-  pypi-publish:
-    runs-on: ubuntu-latest
-    needs:
-      - release-build
-    permissions:
-      id-token: write
-    # Dedicated environments with protections for publishing are strongly recommended.
+
     environment:
       name: pypi
       url: https://pypi.org/p/mmore
+
     steps:
-      - name: Retrieve release distributions
-        uses: actions/download-artifact@v7
+      - name: Checkout repository
+        uses: actions/checkout@v6
         with:
-          name: release-dists
-          path: dist/
-      - name: Publish release distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install build dependencies
+        run: |
+          uv pip install build setuptools-scm
+
+      - name: Build package
+        run: |
+          uv build
+
+      - name: Publish to PyPI
+        run: |
+          uv publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mmore"
-version = "1.1.1"
+dynamic = ["version"]
 description = "mmore: Scalable multimodal document extraction pipeline for custom RAG integration."
 readme = "README.md"
 authors = [
@@ -193,3 +193,12 @@ ignore = ["E501", "E402"]   # Avoid enforcing line-length violations (`E501`) an
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
 "run_index_api.py" = ["N803", "N806"]
+
+[tool.setuptools_scm]
+version_scheme = "guess-next-dev"
+local_scheme = "no-local-version"
+
+[dependency-groups]
+dev = [
+    "setuptools-scm>=9.2.2",
+]


### PR DESCRIPTION
This pull request updates the Python package publishing workflow and project configuration to streamline the release process and improve version management. The main changes consolidate the build and publish steps into a single GitHub Actions job, switch to using `uv` for building and publishing, and migrate to dynamic versioning with `setuptools-scm`.

**CI/CD workflow improvements:**

* Replaces the two-step build and publish jobs in `.github/workflows/publish.yml` with a single `build-and-publish` job, simplifying the workflow. The new job uses `uv` for dependency installation, building, and publishing, and sets up appropriate permissions for publishing to PyPI.

**Packaging and versioning updates:**

* Switches from a static version in `pyproject.toml` to dynamic versioning using `setuptools-scm`, enabling automatic version management based on Git tags.
* Adds a `[tool.setuptools_scm]` section to configure versioning schemes, and includes `setuptools-scm` in a new `dev` dependency group for development environments.