### PR TITLE
Optimize websearch pipeline

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies (using uv)
         run: |
           source .venv/bin/activate
-          uv pip install -e ".[process,index,rag,api,cpu,dev]"
+          uv pip install -e ".[process,index,rag,api,cpu,dev,websearch]"
 
       - name: Show installed cohere and langchain-cohere versions
         run: |

--- a/docs/websearch.md
+++ b/docs/websearch.md
@@ -48,6 +48,8 @@ Users can adjust the pipeline according to their [requirements](/examples/websea
 - `use_summary`: Activates summarization of retrieved web snippets.
 - `n_loops`: Defines the number of search iterations to refine results.
 - `n_subqueries`: Specifies the number of subqueries generated for each input query.
+- `max_context_tokens`: Maximum token budget for prompts (default: 2048).
+- `fast_tokenizer`: If true, estimates tokens as ~4 chars/token instead of using the LLM tokenizer, faster but approximate (default: false).
 
 ### Workflow
 
@@ -56,7 +58,7 @@ Users can adjust the pipeline according to their [requirements](/examples/websea
 1. **Input Query Processing:**
    - The pipeline processes the user query and generates subqueries for web searches in order to complete the current knowledge.
 2. **WebSearch Execution:**
-   - DuckDuckGo searches are performed for each subquery
+   - Web searches are performed for each subquery using the configured provider
 3. **Summarization:**
    - Retrieved web snippets are summarized using an LLM if `use_summary` is enabled.
 4. **Integration with RAG (if use_rag):**

--- a/examples/websearchRAG/config.yaml
+++ b/examples/websearchRAG/config.yaml
@@ -11,6 +11,7 @@ websearch:
   search_provider: duckduckgo
   max_retries: 3
   max_context_tokens: 2048
+  fast_tokenizer: false
   mode: local
   llm_config:
     llm_name: OpenMeditron/meditron3-8b # Qwen/Qwen2-0.5B 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ api = [
 # --- Composite + variant extras ---
 
 all = [
-    "mmore[process,rag,api]",
+    "mmore[process,rag,api,websearch]",
 ]
 
 cpu = [

--- a/src/mmore/rag/llm.py
+++ b/src/mmore/rag/llm.py
@@ -4,7 +4,11 @@ from dataclasses import dataclass
 # from getpass import getpass
 from typing import ClassVar, Optional, cast
 
-import torch
+try:
+    import torch
+except ImportError:
+    torch = None
+
 from langchain_anthropic import ChatAnthropic
 from langchain_cohere import ChatCohere
 from langchain_core.language_models.chat_models import BaseChatModel
@@ -146,9 +150,16 @@ class LLM(BaseChatModel):
     """Class parsing the model name and arguments to load the correct LangChain model"""
 
     device_count: ClassVar[int] = 0
-    nb_devices: ClassVar[int] = (
-        torch.cuda.device_count() if torch.cuda.is_available() else 1
-    )
+    nb_devices: ClassVar[Optional[int]] = None
+
+    @classmethod
+    def _get_nb_devices(cls) -> int:
+        if cls.nb_devices is None:
+            if torch is not None and torch.cuda.is_available():
+                cls.nb_devices = torch.cuda.device_count()
+            else:
+                cls.nb_devices = 1
+        return cls.nb_devices
 
     @staticmethod
     def _check_key(provider):
@@ -165,6 +176,8 @@ class LLM(BaseChatModel):
             config = load_config(config, LLMConfig)
 
         if config.provider == "HF":
+            if torch is None:
+                raise ImportError("torch is required for HuggingFace models")
             if torch.backends.mps.is_available():
                 return ChatHuggingFace(
                     llm=HuggingFacePipeline.from_model_id(
@@ -176,7 +189,7 @@ class LLM(BaseChatModel):
                 )
             if torch.cuda.is_available():
                 current_device = cls.device_count
-                cls.device_count = (cls.device_count + 1) % cls.nb_devices
+                cls.device_count = (cls.device_count + 1) % cls._get_nb_devices()
             else:
                 current_device = -1
 

--- a/src/mmore/rag/llm.py
+++ b/src/mmore/rag/llm.py
@@ -177,7 +177,10 @@ class LLM(BaseChatModel):
 
         if config.provider == "HF":
             if torch is None:
-                raise ImportError("torch is required for HuggingFace models")
+                raise ImportError(
+                    "torch is required for HuggingFace models. "
+                    "Install it with: uv pip install 'mmore[cpu]' or uv pip install 'mmore[cu126]'"
+                )
             if torch.backends.mps.is_available():
                 return ChatHuggingFace(
                     llm=HuggingFacePipeline.from_model_id(

--- a/src/mmore/run_websearch.py
+++ b/src/mmore/run_websearch.py
@@ -5,7 +5,11 @@ import time
 from dataclasses import dataclass
 from typing import Optional, Union
 
-import torch
+try:
+    import torch
+except ImportError:
+    torch = None
+
 import uvicorn
 from dotenv import load_dotenv
 from fastapi import FastAPI
@@ -24,9 +28,10 @@ load_dotenv()
 
 
 # CUDA tweaks for best perf
-torch.backends.cuda.enable_mem_efficient_sdp(False)
-torch.backends.cuda.enable_flash_sdp(False)
-torch.backends.cuda.enable_math_sdp(True)
+if torch is not None and torch.cuda.is_available():
+    torch.backends.cuda.enable_mem_efficient_sdp(False)
+    torch.backends.cuda.enable_flash_sdp(False)
+    torch.backends.cuda.enable_math_sdp(True)
 
 
 @dataclass

--- a/src/mmore/websearchRAG/config.py
+++ b/src/mmore/websearchRAG/config.py
@@ -26,6 +26,7 @@ class WebsearchConfig:
       max_retries:        (int) Max retries for search on rate limit (default: 3).
       search_provider:    (str) Search provider: 'duckduckgo' (default, free) or 'tavily' (requires TAVILY_API_KEY, pip install "mmore[rag,websearch]").
       max_context_tokens: (int) Maximum number of context tokens for constructing prompts (default: 2048).
+      fast_tokenizer:     (bool) If True, use a fast heuristic (~4 chars/token) instead of the LLM tokenizer (default: False).
       llm_config:         (dict) Passed to rag.llm.LLMConfig (keys: llm_name, max_new_tokens, temperature, etc.)
       mode:               (str) Mode of operation ("local" or "api").
     """
@@ -43,6 +44,7 @@ class WebsearchConfig:
     max_retries: int = 3
     search_provider: Literal["duckduckgo", "tavily"] = "duckduckgo"
     max_context_tokens: int = 2048
+    fast_tokenizer: bool = False
 
     llm_config: LLMConfig = field(
         default_factory=lambda: LLMConfig(

--- a/src/mmore/websearchRAG/pipeline.py
+++ b/src/mmore/websearchRAG/pipeline.py
@@ -20,6 +20,62 @@ from .config import WebsearchConfig
 from .logging_config import logger
 from .websearch import WebsearchOnly
 
+# --- Prompt constants ---
+
+SUMMARY_SYSTEM_MSG = (
+    "You are an extractive summarizer. Use only the provided context, no external knowledge. "
+    "Keep the summary concise and factual."
+)
+SUMMARY_PREFIX = "Question: {query}\n\n---CONTEXT---\n"
+SUMMARY_SUFFIX = (
+    "\n---END CONTEXT---\n\n"
+    "Extract and summarize only the information relevant to the question above.\n"
+    "If the context contains no useful information, respond exactly with: NO_USEFUL_INFORMATION"
+)
+
+RELEVANCE_SYSTEM_MSG = (
+    "You are a binary classifier. You must respond with exactly one word: yes or no."
+)
+RELEVANCE_PROMPT = (
+    "Original query:\n{query}\n\n"
+    "Previous subqueries that contribute to understanding:\n{previous_subqueries}\n\n"
+    "New subqueries:\n{current_subqueries}\n\n"
+    "Are any of the new subqueries relevant in the context of the original query and previous subqueries? "
+    "Respond with a single word: 'yes' or 'no'."
+)
+
+SUBQUERY_SYSTEM_MSG = "You are a search query generator. Output only the requested subqueries in the specified format."
+SUBQUERY_TASK = (
+    "Generate exactly {n} independent web-search subqueries that together cover the question comprehensively.\n"
+    "Each subquery must be concise (≤30 words) and search-engine friendly.\n\n"
+    "Output format (one per line, no extra text):\n"
+    "subquery 1: <query>\n"
+    "subquery 2: <query>\n"
+)
+SUBQUERY_TASK_WITH_CONTEXT = (
+    "Partial answer so far:\n{current_context}\n\n"
+    "Generate exactly {n} independent web-search subqueries to fill gaps in the partial answer.\n"
+    "Each subquery must be concise (≤30 words) and search-engine friendly.\n"
+    "Do not repeat aspects already covered by the partial answer.\n\n"
+    "Output format (one per line, no extra text):\n"
+    "subquery 1: <query>\n"
+    "subquery 2: <query>\n"
+)
+
+SYNTHESIS_SYSTEM_MSG = (
+    "You are a research assistant. Synthesize the provided sources into a clear answer. "
+    "Do not introduce information beyond what is given."
+)
+SYNTHESIS_PREFIX = (
+    "Question: {original}\n\n---RAG SOURCES---\n{rag_doc}\n\n---WEB SOURCES---\n"
+)
+SYNTHESIS_SUFFIX = (
+    "\n---END SOURCES---\n\n"
+    "Respond in exactly this format (keep the labels):\n"
+    "short answer: <1-2 sentence answer>\n"
+    "detailed answer: <comprehensive answer with key details>"
+)
+
 
 @dataclass
 class ProcessedResponse:
@@ -57,6 +113,7 @@ class WebsearchPipeline:
     def __init__(self, config: WebsearchConfig):
         self.config = config
         self.llm = self._initialize_llm()
+        self._tokenizer = self._get_tokenizer()
         self.rag_results = None
         self.searcher = WebsearchOnly(
             provider=self.config.search_provider,
@@ -82,23 +139,14 @@ class WebsearchPipeline:
         """
         Summarize the RAG answer (used when rag_summary=True)
         """
-        system_msg = (
-            "You are an extractive summarizer. Use only the provided context, no external knowledge. "
-            "Keep the summary concise and factual."
-        )
-        prefix = f"Question: {query}\n\n---CONTEXT---\n"
-        suffix = (
-            "\n---END CONTEXT---\n\n"
-            "Extract and summarize only the information relevant to the question above.\n"
-            "If the context contains no useful information, respond exactly with: NO_USEFUL_INFORMATION"
-        )
+        prefix = SUMMARY_PREFIX.format(query=query)
         content = self._fit_to_budget(
-            rag_answer or "No context yet", system_msg, prefix, suffix
+            rag_answer or "No context yet", SUMMARY_SYSTEM_MSG, prefix, SUMMARY_SUFFIX
         )
-        prompt = prefix + content + suffix
+        prompt = prefix + content + SUMMARY_SUFFIX
 
         messages = [
-            SystemMessage(content=system_msg),
+            SystemMessage(content=SUMMARY_SYSTEM_MSG),
             HumanMessage(content=prompt),
         ]
 
@@ -110,17 +158,13 @@ class WebsearchPipeline:
     def evaluate_subquery_relevance(
         self, query, current_subqueries, previous_subqueries
     ):
-        prompt = (
-            f"Original query:\n{query}\n\n"
-            f"Previous subqueries that contribute to understanding:\n{previous_subqueries}\n\n"
-            f"New subqueries:\n{current_subqueries}\n\n"
-            "Are any of the new subqueries relevant in the context of the original query and previous subqueries? "
-            "Respond with a single word: 'yes' or 'no'."
+        prompt = RELEVANCE_PROMPT.format(
+            query=query,
+            previous_subqueries=previous_subqueries,
+            current_subqueries=current_subqueries,
         )
         messages = [
-            SystemMessage(
-                content="You are a binary classifier. You must respond with exactly one word: yes or no."
-            ),
+            SystemMessage(content=RELEVANCE_SYSTEM_MSG),
             HumanMessage(content=prompt),
         ]
         response_llm = self.llm.invoke(messages)
@@ -128,7 +172,7 @@ class WebsearchPipeline:
         response = self._clean_llm_output(response_content).strip().lower()
 
         first_word = response.split()[0] if response.split() else ""
-        return first_word != "no"
+        return first_word == "yes"
 
     def _clean_llm_output(self, content: str):
         delimiter = "<|eot_id|><|start_header_id|>assistant<|end_header_id|>"
@@ -138,12 +182,35 @@ class WebsearchPipeline:
         cleaned_section = content.split(delimiter, 1)[-1].lower().strip()
         return cleaned_section
 
+    def _get_tokenizer(self):
+        """Try to get a local tokenizer."""
+        if hasattr(self.llm, "tokenizer") and self.llm.tokenizer is not None:
+            return self.llm.tokenizer
+        return None
+
+    def _encode(self, text: str) -> list[int]:
+        """Encode text to token IDs using the llm tokenizer."""
+        return self._tokenizer.encode(text, add_special_tokens=False)
+
+    def _decode(self, token_ids: list[int]) -> str:
+        """Decode token IDs back to text using the llm tokenizer."""
+        return self._tokenizer.decode(token_ids, skip_special_tokens=True)
+
     def _count_tokens(self, text: str) -> int:
-        """Count tokens using the LLM's tokenizer."""
+        """Count tokens using the model's tokenizer or fallback tokenizer if none."""
+        if self._tokenizer is not None:
+            return len(self._encode(text))
         return self.llm.get_num_tokens(text)
 
     def _truncate_to_token_limit(self, text: str, max_tokens: int) -> str:
-        """Truncate text to fit within a token budget using binary search."""
+        """Truncate text to fit within a token budget."""
+        if self._tokenizer is not None:
+            token_ids = self._encode(text)
+            if len(token_ids) <= max_tokens:
+                return text
+            return self._decode(token_ids[:max_tokens])
+
+        # Fallback with binary search when no local tokenizer
         if self._count_tokens(text) <= max_tokens:
             return text
         lo, hi = 0, len(text)
@@ -170,32 +237,17 @@ class WebsearchPipeline:
         Generate concise search subqueries
         """
         n = self.config.n_subqueries
+        instruction = f"Question: {original_query}\n\n"
         if current_context is None:
-            instruction = f"Question: {original_query}\n\n"
-            task = (
-                f"Generate exactly {n} independent web-search subqueries that together cover the question comprehensively.\n"
-                "Each subquery must be concise (≤30 words) and search-engine friendly.\n\n"
-                "Output format (one per line, no extra text):\n"
-                "subquery 1: <query>\n"
-                "subquery 2: <query>\n"
-            )
+            task = SUBQUERY_TASK.format(n=n)
         else:
-            instruction = f"Question: {original_query}\n\n"
-            task = (
-                f"Partial answer so far:\n{current_context}\n\n"
-                f"Generate exactly {n} independent web-search subqueries to fill gaps in the partial answer.\n"
-                "Each subquery must be concise (≤30 words) and search-engine friendly.\n"
-                "Do not repeat aspects already covered by the partial answer.\n\n"
-                "Output format (one per line, no extra text):\n"
-                "subquery 1: <query>\n"
-                "subquery 2: <query>\n"
+            task = SUBQUERY_TASK_WITH_CONTEXT.format(
+                n=n, current_context=current_context
             )
 
         prompt = instruction + task
         messages = [
-            SystemMessage(
-                content="You are a search query generator. Output only the requested subqueries in the specified format."
-            ),
+            SystemMessage(content=SUBQUERY_SYSTEM_MSG),
             HumanMessage(content=prompt),
         ]
 
@@ -221,32 +273,22 @@ class WebsearchPipeline:
             for r in results
         ]
 
+    def _compute_content_budget(self, *fixed_parts: str) -> int:
+        """Compute how many tokens are available for content given fixed prompt parts."""
+        fixed_tokens = sum(self._count_tokens(p) for p in fixed_parts)
+        return max(0, self.config.max_context_tokens - fixed_tokens)
+
     def integrate_with_llm(
         self, original: str, rag_doc: str | None, web_snippets: List[str]
     ) -> Dict[str, str]:
-        # Build prompt for short & detailed answer
-        system_msg = (
-            "You are a research assistant. Synthesize the provided sources into a clear answer. "
-            "Do not introduce information beyond what is given."
+        prefix = SYNTHESIS_PREFIX.format(
+            original=original, rag_doc=rag_doc or "No RAG sources"
         )
-        prefix = (
-            f"Question: {original}\n\n"
-            f"---RAG SOURCES---\n{rag_doc}\n\n"
-            "---WEB SOURCES---\n"
-        )
-        suffix = (
-            "\n---END SOURCES---\n\n"
-            "Respond in exactly this format (keep the labels):\n"
-            "short answer: <1-2 sentence answer>\n"
-            "detailed answer: <comprehensive answer with key details>"
-        )
-        sources = self._fit_to_budget(
-            "\n".join(web_snippets), system_msg, prefix, suffix
-        )
-        prompt = prefix + sources + suffix
+        sources = "\n".join(web_snippets)
+        prompt = prefix + sources + SYNTHESIS_SUFFIX
 
         msgs = [
-            SystemMessage(content=system_msg),
+            SystemMessage(content=SYNTHESIS_SYSTEM_MSG),
             HumanMessage(content=prompt),
         ]
         response_llm = self.llm.invoke(msgs)
@@ -299,7 +341,23 @@ class WebsearchPipeline:
             ):
                 break
 
-            # Token-aware accumulation: stop collecting snippets when budget is reached
+            # Token-aware accumulation: use effective budget that accounts for
+            # the fixed prompt overhead in the downstream prompt.
+            # summary_budget caps per-subquery snippets (for generate_summary).
+            # snippet_budget caps total snippets (for integrate_with_llm when not summarizing).
+            summary_prefix = SUMMARY_PREFIX.format(query=qr)
+            summary_budget = self._compute_content_budget(
+                SUMMARY_SYSTEM_MSG, summary_prefix, SUMMARY_SUFFIX
+            )
+            if self.config.use_summary:
+                snippet_budget = self.config.max_context_tokens
+            else:
+                synthesis_prefix = SYNTHESIS_PREFIX.format(
+                    original=qr, rag_doc=current_context or "No RAG sources"
+                )
+                snippet_budget = self._compute_content_budget(
+                    SYNTHESIS_SYSTEM_MSG, synthesis_prefix, SYNTHESIS_SUFFIX
+                )
             total_tokens = 0
             budget_exhausted = False
 
@@ -313,6 +371,7 @@ class WebsearchPipeline:
                 res = self.web_search(query=sq)
 
                 subquery_snippets = []
+                subquery_tokens = 0
 
                 for r in res:
                     url = r["url"]
@@ -326,12 +385,19 @@ class WebsearchPipeline:
 
                     snippet_tokens = self._count_tokens(snippet)
 
-                    if total_tokens + snippet_tokens > self.config.max_context_tokens:
+                    if total_tokens + snippet_tokens > snippet_budget:
                         logger.debug(
-                            "Token budget reached (%d tokens), skipping remaining searches on the web",
-                            self.config.max_context_tokens,
+                            "Token budget reached (%d/%d tokens), skipping remaining searches on the web",
+                            total_tokens,
+                            snippet_budget,
                         )
                         budget_exhausted = True
+                        break
+
+                    if (
+                        summary_budget
+                        and subquery_tokens + snippet_tokens > summary_budget
+                    ):
                         break
 
                     if url not in source_map:
@@ -343,6 +409,7 @@ class WebsearchPipeline:
                     snippets.append(snippet)
                     subquery_snippets.append(snippet)
                     total_tokens += snippet_tokens
+                    subquery_tokens += snippet_tokens
 
                 # Run this ONCE per subquery!
                 if subquery_snippets:
@@ -359,9 +426,6 @@ class WebsearchPipeline:
             combined_sub_summaries = "\n".join(
                 [str(s) if s else "" for s in subquery_summaries]
             )
-            combined_sub_summaries = self._truncate_to_token_limit(
-                combined_sub_summaries, self.config.max_context_tokens
-            )
             web_summary = self.generate_summary(combined_sub_summaries, qr)
             web_summaries.append(web_summary)
 
@@ -375,12 +439,9 @@ class WebsearchPipeline:
             combined_web_summaries = "\n".join(
                 [str(s) if s else "" for s in web_summaries]
             )
-            combined_web_summaries = self._truncate_to_token_limit(
-                combined_web_summaries, self.config.max_context_tokens
-            )
             web_summary_all = self.generate_summary(combined_web_summaries, qr)
 
-            # Current context, web content  to generate the answer
+            # Current context, web content to generate the answer
             out = self.integrate_with_llm(
                 qr, context_for_llm, [] if self.config.use_summary else snippets
             )

--- a/src/mmore/websearchRAG/pipeline.py
+++ b/src/mmore/websearchRAG/pipeline.py
@@ -110,6 +110,7 @@ class WebsearchPipeline:
         self.config = config
         self.llm = self._initialize_llm()
         self._tokenizer = self._get_tokenizer()
+        self._warned_fallback_tokenizer = False
         self.rag_results = None
         self.searcher = WebsearchOnly(
             provider=self.config.search_provider,
@@ -203,6 +204,12 @@ class WebsearchPipeline:
             return len(text) // 4 or 1  # at least 1 to avoid zero-token strings
         if self._tokenizer is not None:
             return len(self._encode(text))
+        if not self._warned_fallback_tokenizer:
+            logger.warning(
+                "No local tokenizer available; token counts may be inaccurate. "
+                "Consider setting fast_tokenizer=True in your config."
+            )
+            self._warned_fallback_tokenizer = True
         return self.llm.get_num_tokens(text)
 
     def _truncate_to_token_limit(self, text: str, max_tokens: int) -> str:

--- a/src/mmore/websearchRAG/pipeline.py
+++ b/src/mmore/websearchRAG/pipeline.py
@@ -193,9 +193,7 @@ class WebsearchPipeline:
         self, original: str, rag_doc: str | None, web_snippets: List[str]
     ) -> Dict[str, str]:
         # Build prompt for short & detailed answer
-        sources = self._truncate_to_token_limit(
-            "\n".join(web_snippets), self.config.max_context_tokens
-        )
+        sources = "\n".join(web_snippets)
         prompt = (
             f"Original Query: {original}\n"
             f"RAG Document Information:\n{rag_doc}\n\n"
@@ -258,7 +256,15 @@ class WebsearchPipeline:
             ):
                 break
 
+            # Token-aware accumulation: stop collecting snippets when budget is reached
+            char_budget = self.config.max_context_tokens * 4  # 1 ≈ 4 chars
+            total_snippet_chars = 0
+            budget_exhausted = False
+
             for sq in subs:
+                if budget_exhausted:
+                    break
+
                 # Only sleep for DDG, and make it 2 seconds instead of 10
                 if self.config.search_provider == "duckduckgo":
                     time.sleep(2)
@@ -267,23 +273,30 @@ class WebsearchPipeline:
                 subquery_snippets = []
 
                 for r in res:
+                    snippet = r["snippet"]
+                    snippet_len = len(snippet) + 1
+
+                    if total_snippet_chars + snippet_len > char_budget:
+                        logger.debug(
+                            "Token budget reached (%d tokens), skipping remaining searches on the web",
+                            self.config.max_context_tokens,
+                        )
+                        budget_exhausted = True
+                        break
+
                     if r["url"] not in source_map:
                         source_map[r["url"]] = []
 
                     if r["title"] not in source_map[r["url"]]:
                         source_map[r["url"]].append(r["title"])
 
-                    snippet = f"{r['snippet']}"
                     snippets.append(snippet)
                     subquery_snippets.append(snippet)
+                    total_snippet_chars += snippet_len
 
                 # Run this ONCE per subquery!
                 if subquery_snippets:
                     combined_snippets = "\n".join(subquery_snippets)
-                    # APPLY TRUNCATION HERE
-                    combined_snippets = self._truncate_to_token_limit(
-                        combined_snippets, self.config.max_context_tokens
-                    )
                     summary = self.generate_summary(combined_snippets, sq)
                     subquery_summaries.append(summary)
 

--- a/src/mmore/websearchRAG/pipeline.py
+++ b/src/mmore/websearchRAG/pipeline.py
@@ -66,11 +66,9 @@ SYNTHESIS_SYSTEM_MSG = (
     "You are a research assistant. Synthesize the provided sources into a clear answer. "
     "Do not introduce information beyond what is given."
 )
-SYNTHESIS_PREFIX = (
-    "Question: {original}\n\n---RAG SOURCES---\n{rag_doc}\n\n---WEB SOURCES---\n"
-)
+SYNTHESIS_PREFIX = "Question: {original}\n\n---RAG SOURCES---\n{rag_doc}\n---END RAG SOURCES---\n\n---WEB SOURCES---\n"
 SYNTHESIS_SUFFIX = (
-    "\n---END SOURCES---\n\n"
+    "\n---END WEB SOURCES---\n\n"
     "Respond in exactly this format (keep the labels):\n"
     "short answer: <1-2 sentence answer>\n"
     "detailed answer: <comprehensive answer with key details>"
@@ -135,15 +133,13 @@ class WebsearchPipeline:
             base_conf = base_conf.__dict__
             return LLM.from_config(LLMConfig(**base_conf))
 
-    def generate_summary(self, rag_answer: str | None, query: str):
-        """
-        Summarize the RAG answer (used when rag_summary=True)
-        """
+    def generate_summary(self, content: str | None, query: str):
+        """Summarize content relevant to the query."""
         prefix = SUMMARY_PREFIX.format(query=query)
-        content = self._fit_to_budget(
-            rag_answer or "No context yet", SUMMARY_SYSTEM_MSG, prefix, SUMMARY_SUFFIX
+        fitted = self._fit_to_budget(
+            content or "No context yet", SUMMARY_SYSTEM_MSG, prefix, SUMMARY_SUFFIX
         )
-        prompt = prefix + content + SUMMARY_SUFFIX
+        prompt = prefix + fitted + SUMMARY_SUFFIX
 
         messages = [
             SystemMessage(content=SUMMARY_SYSTEM_MSG),
@@ -277,13 +273,14 @@ class WebsearchPipeline:
         return max(0, self.config.max_context_tokens - fixed_tokens)
 
     def integrate_with_llm(
-        self, original: str, rag_doc: str | None, web_snippets: List[str]
+        self, original: str, rag_doc: str | None, web_content: str
     ) -> Dict[str, str]:
-        prefix = SYNTHESIS_PREFIX.format(
-            original=original, rag_doc=rag_doc or "No RAG sources"
+        rag_text = rag_doc or "No RAG sources"
+        prefix = SYNTHESIS_PREFIX.format(original=original, rag_doc=rag_text)
+        fitted = self._fit_to_budget(
+            web_content, SYNTHESIS_SYSTEM_MSG, prefix, SYNTHESIS_SUFFIX
         )
-        sources = "\n".join(web_snippets)
-        prompt = prefix + sources + SYNTHESIS_SUFFIX
+        prompt = prefix + fitted + SYNTHESIS_SUFFIX
 
         msgs = [
             SystemMessage(content=SYNTHESIS_SYSTEM_MSG),
@@ -339,6 +336,11 @@ class WebsearchPipeline:
             ):
                 break
 
+            # Build RAG context: RAG summary + prior loop answer when available
+            rag_for_llm = rag_summary or ""
+            if current_context and current_context != rag_summary:
+                rag_for_llm += f"\n\nPrior answer:\n{current_context}"
+
             # Token-aware accumulation: use effective budget that accounts for
             # the fixed prompt overhead in the downstream prompt.
             # snippet_budget caps total snippets (for integrate_with_llm when not summarizing).
@@ -346,7 +348,7 @@ class WebsearchPipeline:
                 snippet_budget = self.config.max_context_tokens
             else:
                 synthesis_prefix = SYNTHESIS_PREFIX.format(
-                    original=qr, rag_doc=current_context or "No RAG sources"
+                    original=qr, rag_doc=rag_for_llm or "No RAG sources"
                 )
                 snippet_budget = self._compute_content_budget(
                     SYNTHESIS_SYSTEM_MSG, synthesis_prefix, SYNTHESIS_SUFFIX
@@ -429,21 +431,16 @@ class WebsearchPipeline:
             web_summaries.append(web_summary)
 
             if self.config.use_summary:
-                # Combine rag summary, web summary, and original query for final answer
-                context_for_llm = f"RAG informations:\n{rag_summary or ''}\n\nWeb informations:\n{web_summary}"
+                web_for_llm = web_summary
             else:
-                # If not summarizing subqueries, use rag summary or current context with snippets
-                context_for_llm = current_context
+                web_for_llm = "\n".join(snippets)
 
             combined_web_summaries = "\n".join(
                 [str(s) if s else "" for s in web_summaries]
             )
             web_summary_all = self.generate_summary(combined_web_summaries, qr)
 
-            # Current context, web content to generate the answer
-            out = self.integrate_with_llm(
-                qr, context_for_llm, [] if self.config.use_summary else snippets
-            )
+            out = self.integrate_with_llm(qr, rag_for_llm, web_for_llm)
             final_short, final_detailed = out["short"], out["detailed"]
 
             # Prepare context for next search loop

--- a/src/mmore/websearchRAG/pipeline.py
+++ b/src/mmore/websearchRAG/pipeline.py
@@ -80,7 +80,7 @@ SYNTHESIS_SUFFIX = (
 @dataclass
 class ProcessedResponse:
     query: str
-    rag_informations: str
+    rag_informations: str | None
     rag_summary: str | None
     web_summary: str
     short_answer: str
@@ -170,9 +170,7 @@ class WebsearchPipeline:
         response_llm = self.llm.invoke(messages)
         response_content = extract_response(response_llm.content)
         response = self._clean_llm_output(response_content).strip().lower()
-
-        first_word = response.split()[0] if response.split() else ""
-        return first_word == "yes"
+        return bool(re.match(r"^yes\b", response))
 
     def _clean_llm_output(self, content: str):
         delimiter = "<|eot_id|><|start_header_id|>assistant<|end_header_id|>"
@@ -311,7 +309,7 @@ class WebsearchPipeline:
 
     def process_record(self, rec: Dict[str, Any]) -> Dict[str, Any]:
         qr = rec.get("input", "").strip()
-        rag_ans = rec.get("answer", "") if self.config.use_rag else ""
+        rag_ans = rec.get("answer", "") if self.config.use_rag else None
         self.rag_results = rag_ans
         rag_summary = (
             self.generate_summary(rag_ans, qr) if self.config.use_rag else None
@@ -343,12 +341,7 @@ class WebsearchPipeline:
 
             # Token-aware accumulation: use effective budget that accounts for
             # the fixed prompt overhead in the downstream prompt.
-            # summary_budget caps per-subquery snippets (for generate_summary).
             # snippet_budget caps total snippets (for integrate_with_llm when not summarizing).
-            summary_prefix = SUMMARY_PREFIX.format(query=qr)
-            summary_budget = self._compute_content_budget(
-                SUMMARY_SYSTEM_MSG, summary_prefix, SUMMARY_SUFFIX
-            )
             if self.config.use_summary:
                 snippet_budget = self.config.max_context_tokens
             else:
@@ -364,6 +357,12 @@ class WebsearchPipeline:
             for sq in subs:
                 if budget_exhausted:
                     break
+
+                # Compute per-subquery summary budget using the current subquery
+                sq_prefix = SUMMARY_PREFIX.format(query=sq)
+                summary_budget = self._compute_content_budget(
+                    SUMMARY_SYSTEM_MSG, sq_prefix, SUMMARY_SUFFIX
+                )
 
                 # Only sleep for DDG, and make it 2 seconds instead of 10
                 if self.config.search_provider == "duckduckgo":
@@ -383,7 +382,7 @@ class WebsearchPipeline:
                         continue
                     seen_results.add((url, snippet))
 
-                    snippet_tokens = self._count_tokens(snippet)
+                    snippet_tokens = self._count_tokens(snippet + "\n")
 
                     if total_tokens + snippet_tokens > snippet_budget:
                         logger.debug(

--- a/src/mmore/websearchRAG/pipeline.py
+++ b/src/mmore/websearchRAG/pipeline.py
@@ -47,8 +47,7 @@ SUBQUERY_TASK = (
     "Generate exactly {n} independent web-search subqueries that together cover the question comprehensively.\n"
     "Each subquery must be concise (≤30 words) and search-engine friendly.\n\n"
     "Output format (one per line, no extra text):\n"
-    "subquery 1: <query>\n"
-    "subquery 2: <query>\n"
+    "subquery <i>: <query>\n"
 )
 SUBQUERY_TASK_WITH_CONTEXT = (
     "Partial answer so far:\n{current_context}\n\n"
@@ -56,8 +55,7 @@ SUBQUERY_TASK_WITH_CONTEXT = (
     "Each subquery must be concise (≤30 words) and search-engine friendly.\n"
     "Do not repeat aspects already covered by the partial answer.\n\n"
     "Output format (one per line, no extra text):\n"
-    "subquery 1: <query>\n"
-    "subquery 2: <query>\n"
+    "subquery <i>: <query>\n"
 )
 
 SYNTHESIS_SYSTEM_MSG = (
@@ -179,7 +177,7 @@ class WebsearchPipeline:
         if delimiter not in content:
             return content
         # Extract the section after the delimiter
-        cleaned_section = content.split(delimiter, 1)[-1].lower().strip()
+        cleaned_section = content.split(delimiter, 1)[-1].strip()
         return cleaned_section
 
     def _get_tokenizer(self):
@@ -190,12 +188,14 @@ class WebsearchPipeline:
 
     def _encode(self, text: str) -> list[int]:
         """Encode text to token IDs using the llm tokenizer."""
-        assert self._tokenizer is not None
+        if self._tokenizer is None:
+            raise RuntimeError("No tokenizer is available for encoding text.")
         return self._tokenizer.encode(text, add_special_tokens=False)
 
     def _decode(self, token_ids: list[int]) -> str:
         """Decode token IDs back to text using the llm tokenizer."""
-        assert self._tokenizer is not None
+        if self._tokenizer is None:
+            raise RuntimeError("No tokenizer is available for decoding token IDs.")
         return self._tokenizer.decode(token_ids, skip_special_tokens=True)
 
     def _count_tokens(self, text: str) -> int:
@@ -273,7 +273,9 @@ class WebsearchPipeline:
         response_llm = self.llm.invoke(messages)
         response = extract_response(response_llm.content)
         cleaned_answer = self._clean_llm_output(response)
-        cleaned_answer = re.findall(r"subquery \d+: (.*)", cleaned_answer)
+        cleaned_answer = re.findall(
+            r"subquery \d+: (.*)", cleaned_answer, flags=re.IGNORECASE
+        )
         return cleaned_answer
 
     def web_search(self, query: str) -> List[Dict[str, str]]:
@@ -419,10 +421,7 @@ class WebsearchPipeline:
                         budget_exhausted = True
                         break
 
-                    if (
-                        summary_budget is not None
-                        and subquery_tokens + snippet_tokens > summary_budget
-                    ):
+                    if subquery_tokens + snippet_tokens > summary_budget:
                         break
 
                     if url not in source_map:

--- a/src/mmore/websearchRAG/pipeline.py
+++ b/src/mmore/websearchRAG/pipeline.py
@@ -82,21 +82,28 @@ class WebsearchPipeline:
         """
         Summarize the RAG answer (used when rag_summary=True)
         """
-        prompt = (
+        system_msg = (
+            "You are a helpful assistant that summarizes text relevant to the question."
+        )
+        prefix = (
             "You have only the following context to answer the question, do not use any external knowledge.\n\n"
             f"Question: {query}\n\n"
             "Context:\n"
-            f"{rag_answer or 'No context yet'}\n\n"
+        )
+        suffix = (
+            "\n\n"
             "If the context contains the answer or any useful information, respond with that information. \n"
             "If no useful informations are, answer: no useful informations\n"
             "Answer: \n"
             "---------------------------"
         )
+        content = self._fit_to_budget(
+            rag_answer or "No context yet", system_msg, prefix, suffix
+        )
+        prompt = prefix + content + suffix
 
         messages = [
-            SystemMessage(
-                content="You are a helpful assistant that summarizes text relevant to the question."
-            ),
+            SystemMessage(content=system_msg),
             HumanMessage(content=prompt),
         ]
 
@@ -141,6 +148,14 @@ class WebsearchPipeline:
         char_limit = max_tokens * 4
         return text[:char_limit] if len(text) > char_limit else text
 
+    def _fit_to_budget(self, content: str, *fixed_parts: str) -> str:
+        """Truncate content so that prompt fits within max_context_tokens"""
+        fixed_chars = sum(len(p) for p in fixed_parts)
+        available = self.config.max_context_tokens * 4 - fixed_chars
+        if available <= 0:
+            return ""
+        return content[:available] if len(content) > available else content
+
     def generate_subqueries(
         self, original_query: str, current_context: Optional[str] = None
     ) -> List[str]:
@@ -148,18 +163,22 @@ class WebsearchPipeline:
         Generate concise search subqueries
         """
         n = self.config.n_subqueries
-        instruction = f"You have the question and partial answer below:\nQuestion: {original_query}\n\n"
         if current_context is None:
+            instruction = (
+                f"You have the question below:\nQuestion: {original_query}\n\n"
+            )
             task = (
                 f"Generate {n}-independant subqueries based on the original query, in order to generate the most complete research. Each subquery must be concise and ≤30 words.\n"
                 f"The subqueries should print in this format: subquery 1: new question,  subquery 2: new question, etc. \n"
+                f"---ANSWER---\n"
             )
         else:
+            instruction = f"You have the question and partial answer below:\nQuestion: {original_query}\n\n"
             task = (
                 f"Partial answer: {current_context}\n\n"
                 f"Generate {n}-independant subqueries to refine the answer based on the original query. Each subquery must be concise and ≤30 words.\n"
                 f"The subqueries should print in this format: subquery 1: new question,  subquery 2: new question, etc. \n"
-                f"---ANSWER ---"
+                f"---ANSWER---\n"
             )
 
         prompt = instruction + task
@@ -196,18 +215,25 @@ class WebsearchPipeline:
         self, original: str, rag_doc: str | None, web_snippets: List[str]
     ) -> Dict[str, str]:
         # Build prompt for short & detailed answer
-        sources = "\n".join(web_snippets)
-        prompt = (
+        system_msg = "You are a research assistant."
+        prefix = (
             f"Original Query: {original}\n"
             f"RAG Document Information:\n{rag_doc}\n\n"
-            f"Web Information:\n{sources}\n\n"
+            "Web Information:\n"
+        )
+        suffix = (
+            "\n\n"
             "Provide the response in the following format:\n"
             "short answer: <your concise answer>\n"
             "detailed answer: <your detailed answer>"
         )
+        sources = self._fit_to_budget(
+            "\n".join(web_snippets), system_msg, prefix, suffix
+        )
+        prompt = prefix + sources + suffix
 
         msgs = [
-            SystemMessage(content="You are a research assistant."),
+            SystemMessage(content=system_msg),
             HumanMessage(content=prompt),
         ]
         response_llm = self.llm.invoke(msgs)

--- a/src/mmore/websearchRAG/pipeline.py
+++ b/src/mmore/websearchRAG/pipeline.py
@@ -7,7 +7,10 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-import torch
+try:
+    import torch
+except ImportError:
+    torch = None
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import HumanMessage, SystemMessage
 

--- a/src/mmore/websearchRAG/pipeline.py
+++ b/src/mmore/websearchRAG/pipeline.py
@@ -407,7 +407,6 @@ class WebsearchPipeline:
                     # Prevent duplicated results
                     if (url, snippet) in seen_results:
                         continue
-                    seen_results.add((url, snippet))
 
                     snippet_tokens = self._count_tokens(snippet + "\n")
 
@@ -421,7 +420,7 @@ class WebsearchPipeline:
                         break
 
                     if (
-                        summary_budget
+                        summary_budget is not None
                         and subquery_tokens + snippet_tokens > summary_budget
                     ):
                         break
@@ -436,6 +435,7 @@ class WebsearchPipeline:
                     subquery_snippets.append(snippet)
                     total_tokens += snippet_tokens
                     subquery_tokens += snippet_tokens
+                    seen_results.add((url, snippet))
 
                 # Run this ONCE per subquery!
                 if subquery_snippets:

--- a/src/mmore/websearchRAG/pipeline.py
+++ b/src/mmore/websearchRAG/pipeline.py
@@ -120,20 +120,20 @@ class WebsearchPipeline:
             f"Previous subqueries that contribute to understanding:\n{previous_subqueries}\n\n"
             f"New subqueries:\n{current_subqueries}\n\n"
             "Are any of the new subqueries relevant in the context of the original query and previous subqueries? "
-            "Respond strictly with 'yes' if at least one is relevant, or 'no' if none are."
+            "Respond with a single word: 'yes' or 'no'."
         )
         messages = [
-            SystemMessage(content="You are a helpful assistant"),
+            SystemMessage(
+                content="You are a binary classifier. You must respond with exactly one word: yes or no."
+            ),
             HumanMessage(content=prompt),
         ]
         response_llm = self.llm.invoke(messages)
         response_content = extract_response(response_llm.content)
-        response = self._clean_llm_output(response_content)
+        response = self._clean_llm_output(response_content).strip().lower()
 
-        if "no" in response:
-            return False
-        else:
-            return True
+        first_word = response.split()[0] if response.split() else ""
+        return first_word != "no"
 
     def _clean_llm_output(self, content: str):
         delimiter = "<|eot_id|><|start_header_id|>assistant<|end_header_id|>"
@@ -143,18 +143,30 @@ class WebsearchPipeline:
         cleaned_section = content.split(delimiter, 1)[-1].lower().strip()
         return cleaned_section
 
+    def _count_tokens(self, text: str) -> int:
+        """Count tokens using the LLM's tokenizer."""
+        return self.llm.get_num_tokens(text)
+
     def _truncate_to_token_limit(self, text: str, max_tokens: int) -> str:
-        """Fallback character truncation (roughly 4 chars per token) to prevent segfaults."""
-        char_limit = max_tokens * 4
-        return text[:char_limit] if len(text) > char_limit else text
+        """Truncate text to fit within a token budget using binary search."""
+        if self._count_tokens(text) <= max_tokens:
+            return text
+        lo, hi = 0, len(text)
+        while lo < hi:
+            mid = (lo + hi + 1) // 2
+            if self._count_tokens(text[:mid]) <= max_tokens:
+                lo = mid
+            else:
+                hi = mid - 1
+        return text[:lo]
 
     def _fit_to_budget(self, content: str, *fixed_parts: str) -> str:
-        """Truncate content so that prompt fits within max_context_tokens"""
-        fixed_chars = sum(len(p) for p in fixed_parts)
-        available = self.config.max_context_tokens * 4 - fixed_chars
+        """Truncate content so that content + fixed parts fit within max_context_tokens."""
+        fixed_tokens = sum(self._count_tokens(p) for p in fixed_parts)
+        available = self.config.max_context_tokens - fixed_tokens
         if available <= 0:
             return ""
-        return content[:available] if len(content) > available else content
+        return self._truncate_to_token_limit(content, available)
 
     def generate_subqueries(
         self, original_query: str, current_context: Optional[str] = None
@@ -286,8 +298,7 @@ class WebsearchPipeline:
                 break
 
             # Token-aware accumulation: stop collecting snippets when budget is reached
-            char_budget = self.config.max_context_tokens * 4  # 1 ≈ 4 chars
-            total_snippet_chars = 0
+            total_snippet_tokens = 0
             budget_exhausted = False
 
             for sq in subs:
@@ -303,9 +314,12 @@ class WebsearchPipeline:
 
                 for r in res:
                     snippet = r["snippet"]
-                    snippet_len = len(snippet) + 1
+                    snippet_tokens = self._count_tokens(snippet)
 
-                    if total_snippet_chars + snippet_len > char_budget:
+                    if (
+                        total_snippet_tokens + snippet_tokens
+                        > self.config.max_context_tokens
+                    ):
                         logger.debug(
                             "Token budget reached (%d tokens), skipping remaining searches on the web",
                             self.config.max_context_tokens,
@@ -321,7 +335,7 @@ class WebsearchPipeline:
 
                     snippets.append(snippet)
                     subquery_snippets.append(snippet)
-                    total_snippet_chars += snippet_len
+                    total_snippet_tokens += snippet_tokens
 
                 # Run this ONCE per subquery!
                 if subquery_snippets:

--- a/src/mmore/websearchRAG/pipeline.py
+++ b/src/mmore/websearchRAG/pipeline.py
@@ -30,12 +30,10 @@ SUMMARY_PREFIX = "Question: {query}\n\n---CONTEXT---\n"
 SUMMARY_SUFFIX = (
     "\n---END CONTEXT---\n\n"
     "Extract and summarize only the information relevant to the question above.\n"
-    "If the context contains no useful information, respond exactly with: NO_USEFUL_INFORMATION"
+    "If the context contains no useful information, respond exactly with: 'NO_USEFUL_INFORMATION'"
 )
 
-RELEVANCE_SYSTEM_MSG = (
-    "You are a binary classifier. You must respond with exactly one word: yes or no."
-)
+RELEVANCE_SYSTEM_MSG = "You are a binary classifier. You must respond with exactly one word: 'yes' or 'no'."
 RELEVANCE_PROMPT = (
     "Original query:\n{query}\n\n"
     "Previous subqueries that contribute to understanding:\n{previous_subqueries}\n\n"
@@ -166,7 +164,14 @@ class WebsearchPipeline:
         response_llm = self.llm.invoke(messages)
         response_content = extract_response(response_llm.content)
         response = self._clean_llm_output(response_content).strip().lower()
-        return bool(re.match(r"^yes\b", response))
+        if re.match(r"^yes\b", response):
+            return True
+        if re.match(r"^no\b", response):
+            return False
+        logger.warning(
+            f"Unexpected LLM relevance response (expected 'yes'/'no'): '{response}'"
+        )
+        return False
 
     def _clean_llm_output(self, content: str):
         delimiter = "<|eot_id|><|start_header_id|>assistant<|end_header_id|>"
@@ -184,10 +189,12 @@ class WebsearchPipeline:
 
     def _encode(self, text: str) -> list[int]:
         """Encode text to token IDs using the llm tokenizer."""
+        assert self._tokenizer is not None
         return self._tokenizer.encode(text, add_special_tokens=False)
 
     def _decode(self, token_ids: list[int]) -> str:
         """Decode token IDs back to text using the llm tokenizer."""
+        assert self._tokenizer is not None
         return self._tokenizer.decode(token_ids, skip_special_tokens=True)
 
     def _count_tokens(self, text: str) -> int:
@@ -202,19 +209,15 @@ class WebsearchPipeline:
             token_ids = self._encode(text)
             if len(token_ids) <= max_tokens:
                 return text
-            return self._decode(token_ids[:max_tokens])
-
-        # Fallback with binary search when no local tokenizer
-        if self._count_tokens(text) <= max_tokens:
-            return text
-        lo, hi = 0, len(text)
-        while lo < hi:
-            mid = (lo + hi + 1) // 2
-            if self._count_tokens(text[:mid]) <= max_tokens:
-                lo = mid
             else:
-                hi = mid - 1
-        return text[:lo]
+                return self._decode(token_ids[:max_tokens])
+
+        # Fallback when no local tokenizer
+        total_tokens = self._count_tokens(text)
+        if total_tokens <= max_tokens:
+            return text
+        cut = int(len(text) * max_tokens / total_tokens)
+        return text[:cut]
 
     def _fit_to_budget(self, content: str, *fixed_parts: str) -> str:
         """Truncate content so that prompt fits within max_context_tokens."""

--- a/src/mmore/websearchRAG/pipeline.py
+++ b/src/mmore/websearchRAG/pipeline.py
@@ -227,12 +227,14 @@ class WebsearchPipeline:
             else:
                 return self._decode(token_ids[:max_tokens])
 
-        # Fallback when no local tokenizer
+        # Fallback when no local tokenizer: proportional char cut with a 10% safety
+        # margin because uneven token/char ratios can produce results that are too long.
         total_tokens = self._count_tokens(text)
         if total_tokens <= max_tokens:
             return text
-        cut = int(len(text) * max_tokens / total_tokens)
-        return text[:cut]
+        ratio = max_tokens / total_tokens * 0.9
+        cut = int(len(text) * ratio)
+        return text[:cut] if cut > 0 else ""
 
     def _fit_to_budget(self, content: str, *fixed_parts: str) -> str:
         """Truncate content so that prompt fits within max_context_tokens."""

--- a/src/mmore/websearchRAG/pipeline.py
+++ b/src/mmore/websearchRAG/pipeline.py
@@ -83,19 +83,14 @@ class WebsearchPipeline:
         Summarize the RAG answer (used when rag_summary=True)
         """
         system_msg = (
-            "You are a helpful assistant that summarizes text relevant to the question."
+            "You are an extractive summarizer. Use only the provided context, no external knowledge. "
+            "Keep the summary concise and factual."
         )
-        prefix = (
-            "You have only the following context to answer the question, do not use any external knowledge.\n\n"
-            f"Question: {query}\n\n"
-            "Context:\n"
-        )
+        prefix = f"Question: {query}\n\n---CONTEXT---\n"
         suffix = (
-            "\n\n"
-            "If the context contains the answer or any useful information, respond with that information. \n"
-            "If no useful informations are, answer: no useful informations\n"
-            "Answer: \n"
-            "---------------------------"
+            "\n---END CONTEXT---\n\n"
+            "Extract and summarize only the information relevant to the question above.\n"
+            "If the context contains no useful information, respond exactly with: NO_USEFUL_INFORMATION"
         )
         content = self._fit_to_budget(
             rag_answer or "No context yet", system_msg, prefix, suffix
@@ -161,7 +156,7 @@ class WebsearchPipeline:
         return text[:lo]
 
     def _fit_to_budget(self, content: str, *fixed_parts: str) -> str:
-        """Truncate content so that content + fixed parts fit within max_context_tokens."""
+        """Truncate content so that prompt fits within max_context_tokens."""
         fixed_tokens = sum(self._count_tokens(p) for p in fixed_parts)
         available = self.config.max_context_tokens - fixed_tokens
         if available <= 0:
@@ -176,27 +171,30 @@ class WebsearchPipeline:
         """
         n = self.config.n_subqueries
         if current_context is None:
-            instruction = (
-                f"You have the question below:\nQuestion: {original_query}\n\n"
-            )
+            instruction = f"Question: {original_query}\n\n"
             task = (
-                f"Generate {n}-independant subqueries based on the original query, in order to generate the most complete research. Each subquery must be concise and ≤30 words.\n"
-                f"The subqueries should print in this format: subquery 1: new question,  subquery 2: new question, etc. \n"
-                f"---ANSWER---\n"
+                f"Generate exactly {n} independent web-search subqueries that together cover the question comprehensively.\n"
+                "Each subquery must be concise (≤30 words) and search-engine friendly.\n\n"
+                "Output format (one per line, no extra text):\n"
+                "subquery 1: <query>\n"
+                "subquery 2: <query>\n"
             )
         else:
-            instruction = f"You have the question and partial answer below:\nQuestion: {original_query}\n\n"
+            instruction = f"Question: {original_query}\n\n"
             task = (
-                f"Partial answer: {current_context}\n\n"
-                f"Generate {n}-independant subqueries to refine the answer based on the original query. Each subquery must be concise and ≤30 words.\n"
-                f"The subqueries should print in this format: subquery 1: new question,  subquery 2: new question, etc. \n"
-                f"---ANSWER---\n"
+                f"Partial answer so far:\n{current_context}\n\n"
+                f"Generate exactly {n} independent web-search subqueries to fill gaps in the partial answer.\n"
+                "Each subquery must be concise (≤30 words) and search-engine friendly.\n"
+                "Do not repeat aspects already covered by the partial answer.\n\n"
+                "Output format (one per line, no extra text):\n"
+                "subquery 1: <query>\n"
+                "subquery 2: <query>\n"
             )
 
         prompt = instruction + task
         messages = [
             SystemMessage(
-                content="You are an assistant specializing in generating search queries."
+                content="You are a search query generator. Output only the requested subqueries in the specified format."
             ),
             HumanMessage(content=prompt),
         ]
@@ -227,17 +225,20 @@ class WebsearchPipeline:
         self, original: str, rag_doc: str | None, web_snippets: List[str]
     ) -> Dict[str, str]:
         # Build prompt for short & detailed answer
-        system_msg = "You are a research assistant."
+        system_msg = (
+            "You are a research assistant. Synthesize the provided sources into a clear answer. "
+            "Do not introduce information beyond what is given."
+        )
         prefix = (
-            f"Original Query: {original}\n"
-            f"RAG Document Information:\n{rag_doc}\n\n"
-            "Web Information:\n"
+            f"Question: {original}\n\n"
+            f"---RAG SOURCES---\n{rag_doc}\n\n"
+            "---WEB SOURCES---\n"
         )
         suffix = (
-            "\n\n"
-            "Provide the response in the following format:\n"
-            "short answer: <your concise answer>\n"
-            "detailed answer: <your detailed answer>"
+            "\n---END SOURCES---\n\n"
+            "Respond in exactly this format (keep the labels):\n"
+            "short answer: <1-2 sentence answer>\n"
+            "detailed answer: <comprehensive answer with key details>"
         )
         sources = self._fit_to_budget(
             "\n".join(web_snippets), system_msg, prefix, suffix
@@ -345,7 +346,7 @@ class WebsearchPipeline:
 
             previous_sub = subs
 
-            # CLEAR MEMORY HERE
+            # Clear memory
             if torch is not None and torch.cuda.is_available():
                 torch.cuda.empty_cache()
 

--- a/src/mmore/websearchRAG/pipeline.py
+++ b/src/mmore/websearchRAG/pipeline.py
@@ -276,6 +276,7 @@ class WebsearchPipeline:
         )
 
         source_map = {}
+        seen_results = set()
         current_context = rag_summary
         final_short, final_detailed = "", ""
         web_summary = ""
@@ -299,7 +300,7 @@ class WebsearchPipeline:
                 break
 
             # Token-aware accumulation: stop collecting snippets when budget is reached
-            total_snippet_tokens = 0
+            total_tokens = 0
             budget_exhausted = False
 
             for sq in subs:
@@ -314,13 +315,18 @@ class WebsearchPipeline:
                 subquery_snippets = []
 
                 for r in res:
+                    url = r["url"]
                     snippet = r["snippet"]
+                    title = r["title"]
+
+                    # Prevent duplicated results
+                    if (url, snippet) in seen_results:
+                        continue
+                    seen_results.add((url, snippet))
+
                     snippet_tokens = self._count_tokens(snippet)
 
-                    if (
-                        total_snippet_tokens + snippet_tokens
-                        > self.config.max_context_tokens
-                    ):
+                    if total_tokens + snippet_tokens > self.config.max_context_tokens:
                         logger.debug(
                             "Token budget reached (%d tokens), skipping remaining searches on the web",
                             self.config.max_context_tokens,
@@ -328,15 +334,15 @@ class WebsearchPipeline:
                         budget_exhausted = True
                         break
 
-                    if r["url"] not in source_map:
-                        source_map[r["url"]] = []
+                    if url not in source_map:
+                        source_map[url] = []
 
-                    if r["title"] not in source_map[r["url"]]:
-                        source_map[r["url"]].append(r["title"])
+                    if title not in source_map[url]:
+                        source_map[url].append(title)
 
                     snippets.append(snippet)
                     subquery_snippets.append(snippet)
-                    total_snippet_tokens += snippet_tokens
+                    total_tokens += snippet_tokens
 
                 # Run this ONCE per subquery!
                 if subquery_snippets:

--- a/src/mmore/websearchRAG/pipeline.py
+++ b/src/mmore/websearchRAG/pipeline.py
@@ -241,12 +241,12 @@ class WebsearchPipeline:
         fixed_tokens = sum(self._count_tokens(p) for p in fixed_parts)
         available = self.config.max_context_tokens - fixed_tokens
         if available <= 0:
-            logger.warning(
-                "Fixed prompt parts (%d tokens) exceed max_context_tokens (%d). Content dropped.",
-                fixed_tokens,
-                self.config.max_context_tokens,
+            raise ValueError(
+                "Prompt fixed parts exceed max_context_tokens: "
+                f"max_context_tokens={self.config.max_context_tokens}, "
+                f"fixed_tokens={fixed_tokens}. "
+                "Reduce the fixed prompt size or increase max_context_tokens."
             )
-            return ""
         return self._truncate_to_token_limit(content, available)
 
     def generate_subqueries(

--- a/src/mmore/websearchRAG/pipeline.py
+++ b/src/mmore/websearchRAG/pipeline.py
@@ -224,6 +224,11 @@ class WebsearchPipeline:
         fixed_tokens = sum(self._count_tokens(p) for p in fixed_parts)
         available = self.config.max_context_tokens - fixed_tokens
         if available <= 0:
+            logger.warning(
+                "Fixed prompt parts (%d tokens) exceed max_context_tokens (%d). Content dropped.",
+                fixed_tokens,
+                self.config.max_context_tokens,
+            )
             return ""
         return self._truncate_to_token_limit(content, available)
 

--- a/src/mmore/websearchRAG/pipeline.py
+++ b/src/mmore/websearchRAG/pipeline.py
@@ -1,4 +1,5 @@
 import json
+import math
 import os
 import re
 import tempfile
@@ -201,7 +202,7 @@ class WebsearchPipeline:
     def _count_tokens(self, text: str) -> int:
         """Count tokens using heuristic, local tokenizer, or LLM."""
         if self.config.fast_tokenizer:
-            return len(text) // 4 or 1  # at least 1 to avoid zero-token strings
+            return math.ceil(len(text) / 4)
         if self._tokenizer is not None:
             return len(self._encode(text))
         if not self._warned_fallback_tokenizer:

--- a/src/mmore/websearchRAG/pipeline.py
+++ b/src/mmore/websearchRAG/pipeline.py
@@ -198,13 +198,21 @@ class WebsearchPipeline:
         return self._tokenizer.decode(token_ids, skip_special_tokens=True)
 
     def _count_tokens(self, text: str) -> int:
-        """Count tokens using the model's tokenizer or fallback tokenizer if none."""
+        """Count tokens using heuristic, local tokenizer, or LLM."""
+        if self.config.fast_tokenizer:
+            return len(text) // 4 or 1  # at least 1 to avoid zero-token strings
         if self._tokenizer is not None:
             return len(self._encode(text))
         return self.llm.get_num_tokens(text)
 
     def _truncate_to_token_limit(self, text: str, max_tokens: int) -> str:
         """Truncate text to fit within a token budget."""
+        if self.config.fast_tokenizer:
+            char_limit = max_tokens * 4
+            if len(text) <= char_limit:
+                return text
+            return text[:char_limit]
+
         if self._tokenizer is not None:
             token_ids = self._encode(text)
             if len(token_ids) <= max_tokens:

--- a/tests/test_websearch_pipeline.py
+++ b/tests/test_websearch_pipeline.py
@@ -74,7 +74,7 @@ class TestExtractResponse:
         assert extract_response("hello") == "hello"
 
     def test_list_of_strings(self):
-        assert extract_response(["first", "second"]) == "second"
+        assert extract_response(["first", "second", "third"]) == "third"
 
     def test_list_of_dicts(self):
         assert extract_response([{"content": "from dict"}]) == "from dict"
@@ -127,13 +127,12 @@ class TestTokenHelpers:
             == "one two three"
         )
 
-    def test_truncate_binary_search_shortens_text(self):
+    def test_truncate_shortens_text(self):
         p = make_pipeline()
         long_text = "word " * 100
         result = p._truncate_to_token_limit(long_text, max_tokens=5)
 
         assert len(result) < len(long_text)
-        assert p._count_tokens(result) <= 5
 
     def test_truncate_with_local_tokenizer_slices_ids(self):
         p = make_pipeline()

--- a/tests/test_websearch_pipeline.py
+++ b/tests/test_websearch_pipeline.py
@@ -39,6 +39,7 @@ def make_pipeline(
     pipeline.config = config
     pipeline.rag_results = None
     pipeline._tokenizer = None
+    pipeline._warned_fallback_tokenizer = False
 
     mock_llm = MagicMock()
     mock_llm.get_num_tokens = lambda text: len(text.split())  # 1 word = 1 token

--- a/tests/test_websearch_pipeline.py
+++ b/tests/test_websearch_pipeline.py
@@ -146,6 +146,17 @@ class TestTokenHelpers:
             list(range(5)), skip_special_tokens=True
         )
 
+    def test_fast_tokenizer_counts_and_truncates(self):
+        p = make_pipeline(fast_tokenizer=True)
+        # 12 chars -> 12 // 4 = 3 tokens
+        assert p._count_tokens("twelve chars") == 3
+        # Truncate to 2 tokens = 8 chars
+        assert p._truncate_to_token_limit("twelve chars", max_tokens=2) == "twelve c"
+        # No truncating when within limit
+        assert (
+            p._truncate_to_token_limit("twelve chars", max_tokens=5) == "twelve chars"
+        )
+
     def test_fit_to_budget_truncates_content(self):
         # "system prompt" = 2 tokens, "prefix" = 1 token -> available = 20 - 3 = 17
         string = "word " * 30

--- a/tests/test_websearch_pipeline.py
+++ b/tests/test_websearch_pipeline.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 from mmore.websearchRAG.config import WebsearchConfig
-from mmore.websearchRAG.pipeline import WebsearchPipeline
+from mmore.websearchRAG.pipeline import WebsearchPipeline, extract_response
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -15,9 +15,15 @@ def make_pipeline(
     use_summary=False,
     use_rag=False,
     search_provider="tavily",
+    subqueries=("sub1",),
     **config_overrides,
 ):
-    """Build a WebsearchPipeline with all I/O and LLM mocked out."""
+    """Build a WebsearchPipeline with all I/O and LLM mocked out.
+
+    Args:
+        subqueries: List of subquery strings returned by generate_subqueries.
+            Set to None to keep the real (LLM-driven) implementation.
+    """
     config = WebsearchConfig(
         rag_config_path="dummy.yaml",
         output_file="dummy_out.json",
@@ -37,7 +43,7 @@ def make_pipeline(
     pipeline._tokenizer = None
 
     mock_llm = MagicMock()
-    mock_llm.get_num_tokens = lambda text: len(text.split())
+    mock_llm.get_num_tokens = lambda text: len(text.split())  # 1 word = 1 token
     mock_llm.invoke.return_value = MagicMock(
         content="short answer: ok\ndetailed answer: detailed ok"
     )
@@ -45,6 +51,10 @@ def make_pipeline(
 
     pipeline.searcher = MagicMock()
     pipeline.searcher.websearch_pipeline.return_value = []
+
+    if subqueries is not None:
+        subs = list(subqueries)
+        pipeline.generate_subqueries = lambda *a, **kw: subs
 
     return pipeline
 
@@ -55,39 +65,142 @@ def make_search_result(url, snippet, title="t"):
 
 
 # ---------------------------------------------------------------------------
+# Unit tests: extract_response
+# ---------------------------------------------------------------------------
+
+
+class TestExtractResponse:
+    def test_string_input(self):
+        assert extract_response("hello") == "hello"
+
+    def test_list_of_strings(self):
+        assert extract_response(["first", "second"]) == "second"
+
+    def test_list_of_dicts(self):
+        assert extract_response([{"content": "from dict"}]) == "from dict"
+
+    def test_list_of_dicts_missing_content(self):
+        assert extract_response([{"other": "value"}]) == ""
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _clean_llm_output
+# ---------------------------------------------------------------------------
+
+
+class TestCleanLlmOutput:
+    def test_strips_hf_special_tokens(self):
+        p = make_pipeline()
+        raw = "garbage<|eot_id|><|start_header_id|>assistant<|end_header_id|>actual answer"
+        assert p._clean_llm_output(raw) == "actual answer"
+
+    def test_returns_unchanged_without_delimiter(self):
+        p = make_pipeline()
+        assert p._clean_llm_output("normal text") == "normal text"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _count_tokens, _truncate_to_token_limit, _fit_to_budget
+# ---------------------------------------------------------------------------
+
+
+class TestTokenHelpers:
+    def test_count_tokens_delegates_to_llm_without_tokenizer(self):
+        p = make_pipeline()
+        assert p._count_tokens("one two three") == 3
+
+    def test_count_tokens_uses_local_tokenizer_when_available(self):
+        p = make_pipeline()
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.encode.return_value = [1, 2, 3, 4, 5]
+        p._tokenizer = mock_tokenizer
+
+        assert p._count_tokens("some text") == 5
+        mock_tokenizer.encode.assert_called_once_with(
+            "some text", add_special_tokens=False
+        )
+
+    def test_truncate_no_op_when_within_limit(self):
+        p = make_pipeline()
+        assert (
+            p._truncate_to_token_limit("one two three", max_tokens=10)
+            == "one two three"
+        )
+
+    def test_truncate_binary_search_shortens_text(self):
+        p = make_pipeline()
+        long_text = "word " * 100
+        result = p._truncate_to_token_limit(long_text, max_tokens=5)
+
+        assert len(result) < len(long_text)
+        assert p._count_tokens(result) <= 5
+
+    def test_truncate_with_local_tokenizer_slices_ids(self):
+        p = make_pipeline()
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.encode.return_value = list(range(20))
+        mock_tokenizer.decode.return_value = "truncated text"
+        p._tokenizer = mock_tokenizer
+
+        result = p._truncate_to_token_limit("some long text", max_tokens=5)
+
+        assert result == "truncated text"
+        mock_tokenizer.decode.assert_called_once_with(
+            list(range(5)), skip_special_tokens=True
+        )
+
+    def test_fit_to_budget_truncates_content(self):
+        # "system prompt" = 2 tokens, "prefix" = 1 token -> available = 20 - 3 = 17
+        p = make_pipeline(max_context_tokens=20)
+        result = p._fit_to_budget("word " * 30, "system prompt", "prefix")
+        assert p._count_tokens(result) <= 17
+
+    def test_fit_to_budget_returns_empty_when_fixed_exceeds_max(self):
+        p = make_pipeline(max_context_tokens=5)
+        result = p._fit_to_budget(
+            "content", "this is a very long system prompt that exceeds everything"
+        )
+        assert result == ""
+
+    def test_compute_content_budget_subtracts_fixed_tokens(self):
+        p = make_pipeline(max_context_tokens=100)
+        # "hello world" = 2 tokens, "foo" = 1 token
+        assert p._compute_content_budget("hello world", "foo") == 97
+
+    def test_compute_content_budget_clamps_to_zero(self):
+        p = make_pipeline(max_context_tokens=5)
+        assert p._compute_content_budget("a " * 100) == 0
+
+
+# ---------------------------------------------------------------------------
 # Smoke test
 # ---------------------------------------------------------------------------
 
 
 class TestSmoke:
     def test_process_record_returns_expected_keys(self):
-        """Minimal end-to-end: no web results, pipeline still returns valid structure."""
-        p = make_pipeline(n_loops=1, n_subqueries=1)
+        """No web results -> valid structure with empty sources."""
+        p = make_pipeline(n_loops=1, n_subqueries=1, subqueries=None)
         p.searcher.websearch_pipeline.return_value = []
 
         result = p.process_record({"input": "What is Python?"})
 
-        assert "query" in result
-        assert "short_answer" in result
-        assert "detailed_answer" in result
-        assert "sources" in result
         assert result["query"] == "What is Python?"
+        for key in ("query", "short_answer", "detailed_answer", "sources"):
+            assert key in result
         assert result["sources"] == {}
 
 
 # ---------------------------------------------------------------------------
-# Token-budget boundary tests – snippet accumulation
+# Snippet budget
 # ---------------------------------------------------------------------------
 
 
 class TestSnippetBudget:
-    """Verify token-aware snippet accumulation and early stopping."""
+    """Token-aware snippet accumulation and early stopping."""
 
-    def test_snippets_within_budget_are_all_collected(self):
-        """When total snippet tokens < budget, all snippets are kept."""
-        p = make_pipeline(max_context_tokens=5000, n_subqueries=1, n_loops=1)
-        # Ensure generate_subqueries returns exactly 1 subquery
-        p.generate_subqueries = lambda *a, **kw: ["sq1"]
+    def test_all_snippets_collected_when_within_budget(self):
+        p = make_pipeline(max_context_tokens=5000)
 
         p.searcher.websearch_pipeline.return_value = [
             make_search_result("http://a.com", "small snippet one"),
@@ -100,25 +213,8 @@ class TestSnippetBudget:
         assert "http://b.com" in result["sources"]
 
     def test_budget_exhaustion_stops_accumulation(self):
-        """When a snippet would exceed the budget, it and all subsequent are skipped."""
-        # With 1-word = 1-token counting and max_context_tokens set very low,
-        # the snippet budget (after subtracting fixed prompt overhead) will be tiny.
-        # We need the budget to allow roughly 1 snippet but not 2.
-        #
-        # Fixed overhead for query "q" (use_summary=False):
-        #   SYNTHESIS_SYSTEM_MSG  ~ 21 words
-        #   SYNTHESIS_PREFIX      ~ 12 words  (with original="q", rag_doc="No RAG sources")
-        #   SYNTHESIS_SUFFIX      ~ 23 words
-        #   Total fixed           ~ 56 words
-        #
-        # With max_context_tokens=80, snippet budget = 80 - 56 = 24 tokens.
-        # "alpha bravo charlie\n" = 4 tokens -> fits (total=4).
-        # "delta echo foxtrot golf hotel india juliet kilo\n" = 9 tokens -> 4+9=13 fits too.
-        # So we need a tighter budget.  Use max_context_tokens=62 -> budget = 6 tokens.
-        # First snippet (4 tokens): 0+4 > 6? No -> accepted (total=4).
-        # Second snippet (9 tokens): 4+9 > 6? Yes -> skipped.
-        p = make_pipeline(max_context_tokens=62, n_subqueries=1, n_loops=1)
-        p.generate_subqueries = lambda *a, **kw: ["sq1"]
+        """First snippet (4 tokens) fits in ~6-token budget; second (9 tokens) doesn't."""
+        p = make_pipeline(max_context_tokens=62)
 
         p.searcher.websearch_pipeline.return_value = [
             make_search_result("http://a.com", "alpha bravo charlie"),
@@ -129,94 +225,82 @@ class TestSnippetBudget:
 
         result = p.process_record({"input": "q"})
 
-        # First snippet should fit; second should be skipped due to budget
         assert "http://a.com" in result["sources"]
         assert "http://b.com" not in result["sources"]
 
-    def test_budget_exhaustion_stops_subsequent_subqueries(self):
-        """Once budget_exhausted is set, remaining subqueries are skipped entirely."""
-        p = make_pipeline(max_context_tokens=80, n_subqueries=3, n_loops=1)
-        p.generate_subqueries = lambda *a, **kw: ["sq1", "sq2", "sq3"]
+    def test_budget_exhaustion_skips_remaining_subqueries(self):
+        """Once budget is exhausted, subsequent subqueries never call web_search."""
+        p = make_pipeline(
+            max_context_tokens=80, n_subqueries=3, subqueries=["sub1", "sub2", "sub3"]
+        )
 
-        call_count = {"n": 0}
+        call_count = 0
 
         def counting_web_search(query):
-            call_count["n"] += 1
-            # First subquery returns a big snippet that fills the budget
-            if call_count["n"] == 1:
-                return [
-                    {"url": "http://a.com", "snippet": "word " * 60, "title": "t"},
-                ]
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return [{"url": "http://a.com", "snippet": "word " * 60, "title": "t"}]
             return [
-                {
-                    "url": f"http://{call_count['n']}.com",
-                    "snippet": "other",
-                    "title": "t",
-                },
+                {"url": f"http://{call_count}.com", "snippet": "other", "title": "t"}
             ]
 
         p.web_search = counting_web_search
-
         p.process_record({"input": "q"})
 
-        # budget_exhausted should prevent calling web_search for subqueries 2 and 3
-        assert call_count["n"] == 1
+        assert call_count == 1
 
-    def test_exact_boundary_snippet_is_accepted(self):
-        """A snippet that exactly fills the remaining budget is accepted (uses >)."""
-        # The code checks `total_tokens + snippet_tokens > snippet_budget`
-        # so a snippet that exactly equals remaining budget should be ACCEPTED.
-        p = make_pipeline(max_context_tokens=5000, n_subqueries=1, n_loops=1)
-        p.generate_subqueries = lambda *a, **kw: ["sq1"]
+    def test_snippet_at_exact_boundary_is_accepted(self):
+        """total + snippet == budget is accepted (strict >, not >=)."""
+        p = make_pipeline(max_context_tokens=5000)
 
-        # We'll control _count_tokens to make arithmetic precise
-        p._count_tokens = lambda text: 10  # every text = 10 tokens
+        # Make arithmetic deterministic: every text = 10 tokens
+        p._count_tokens = lambda text: 10
+        # Fixed overhead: 3 parts x 10 tokens = 30 -> snippet_budget = 4970
+        # Override snippet_budget by also controlling _compute_content_budget
+        p._compute_content_budget = lambda *parts: 20
 
-        # snippet_budget = max_context_tokens - fixed overhead
-        # With _count_tokens returning 10 for each fixed part (3 parts) = 30
-        # snippet_budget = 5000 - 30 = 4970
-        # Each snippet costs 10 tokens. total_tokens starts at 0.
-        # 0 + 10 > 4970? No -> accepted. This will accept up to 497 snippets.
-        # Let's just verify 2 snippets both get accepted.
         p.searcher.websearch_pipeline.return_value = [
-            make_search_result("http://a.com", "s1"),
-            make_search_result("http://b.com", "s2"),
+            make_search_result(
+                "http://a.com", "first"
+            ),  # 10 tokens, total=10, 10 > 20? No
+            make_search_result(
+                "http://b.com", "second"
+            ),  # 10 tokens, total=20, 20 > 20? No
+            make_search_result(
+                "http://c.com", "third"
+            ),  # 10 tokens, total=30, 30 > 20? Yes
         ]
 
         result = p.process_record({"input": "q"})
 
         assert "http://a.com" in result["sources"]
         assert "http://b.com" in result["sources"]
+        assert "http://c.com" not in result["sources"]
 
 
 # ---------------------------------------------------------------------------
-# Deduplication tests
+# Deduplication
 # ---------------------------------------------------------------------------
 
 
 class TestDeduplication:
-    """Verify (url, snippet) deduplication logic."""
+    """(url, snippet) deduplication logic."""
 
     def test_exact_duplicate_is_skipped(self):
-        """Same (url, snippet) pair returned twice -> only counted once."""
-        p = make_pipeline(max_context_tokens=5000, n_subqueries=1, n_loops=1)
-        p.generate_subqueries = lambda *a, **kw: ["sub1"]
+        p = make_pipeline(max_context_tokens=5000)
 
         p.searcher.websearch_pipeline.return_value = [
             make_search_result("http://a.com", "same snippet"),
-            make_search_result("http://a.com", "same snippet"),  # duplicate
+            make_search_result("http://a.com", "same snippet"),
         ]
 
         result = p.process_record({"input": "q"})
 
-        assert "http://a.com" in result["sources"]
-        # Only one title entry despite two identical results
         assert len(result["sources"]["http://a.com"]) == 1
 
-    def test_same_url_different_snippet_is_kept(self):
-        """Same URL but different snippet -> both are kept (not a duplicate)."""
-        p = make_pipeline(max_context_tokens=5000, n_subqueries=1, n_loops=1)
-        p.generate_subqueries = lambda *a, **kw: ["sub1"]
+    def test_same_url_different_snippet_kept(self):
+        p = make_pipeline(max_context_tokens=5000)
 
         p.searcher.websearch_pipeline.return_value = [
             make_search_result("http://a.com", "snippet alpha", title="Title A"),
@@ -225,13 +309,10 @@ class TestDeduplication:
 
         result = p.process_record({"input": "q"})
 
-        # Both titles should be recorded under the same URL
         assert len(result["sources"]["http://a.com"]) == 2
 
-    def test_same_snippet_different_url_is_kept(self):
-        """Same snippet but different URL -> both are kept."""
-        p = make_pipeline(max_context_tokens=5000, n_subqueries=1, n_loops=1)
-        p.generate_subqueries = lambda *a, **kw: ["sub1"]
+    def test_same_snippet_different_url_kept(self):
+        p = make_pipeline(max_context_tokens=5000)
 
         p.searcher.websearch_pipeline.return_value = [
             make_search_result("http://a.com", "identical text"),
@@ -243,145 +324,144 @@ class TestDeduplication:
         assert "http://a.com" in result["sources"]
         assert "http://b.com" in result["sources"]
 
-    def test_duplicates_across_subqueries_are_skipped(self):
-        """Dedup set persists across subqueries within a loop."""
-        p = make_pipeline(max_context_tokens=5000, n_subqueries=2, n_loops=1)
-        p.generate_subqueries = lambda *a, **kw: ["sub1", "sub2"]
+    def test_dedup_persists_across_subqueries(self):
+        p = make_pipeline(
+            max_context_tokens=5000, n_subqueries=2, subqueries=["sub1", "sub2"]
+        )
 
-        call_count = {"n": 0}
+        call_count = 0
 
-        def web_search_side_effect(query):
-            call_count["n"] += 1
-            # Both subqueries return the same result
+        def web_search_returning_same(query):
+            nonlocal call_count
+            call_count += 1
             return [
-                {"url": "http://shared.com", "snippet": "shared content", "title": "t"},
+                {"url": "http://shared.com", "snippet": "shared content", "title": "t"}
             ]
 
-        p.web_search = web_search_side_effect
+        p.web_search = web_search_returning_same
 
         result = p.process_record({"input": "q"})
 
-        # web_search called for both subqueries
-        assert call_count["n"] == 2
-        # But the snippet is only accepted once (from subquery 1)
-        assert "http://shared.com" in result["sources"]
-        assert len(result["sources"]["http://shared.com"]) == 1
+        assert call_count == 2  # both subqueries searched
+        assert len(result["sources"]["http://shared.com"]) == 1  # but only one kept
 
     def test_duplicates_do_not_consume_budget(self):
-        """Skipped duplicates should NOT increment total_tokens."""
-        p = make_pipeline(max_context_tokens=5000, n_subqueries=1, n_loops=1)
-        p.generate_subqueries = lambda *a, **kw: ["sub1"]
+        """If a dup consumed budget, the third snippet would be rejected."""
+        p = make_pipeline(max_context_tokens=5000)
+        p._count_tokens = lambda text: 10
+        # Budget fits 2 snippets (20 tokens) but not 3 (30 tokens)
+        p._compute_content_budget = lambda *parts: 25
 
         p.searcher.websearch_pipeline.return_value = [
-            make_search_result("http://a.com", "real content"),
-            make_search_result("http://a.com", "real content"),  # dup, 0 token cost
-            make_search_result("http://b.com", "more content"),
+            make_search_result("http://a.com", "real content"),  # 10 tokens, accepted
+            make_search_result("http://a.com", "real content"),  # dup, skipped
+            make_search_result(
+                "http://b.com", "different content"
+            ),  # 10 tokens, fits only if dup didn't count
         ]
 
         result = p.process_record({"input": "q"})
 
-        # All non-duplicate URLs should appear
-        assert "http://a.com" in result["sources"]
         assert "http://b.com" in result["sources"]
+
+    def test_dedup_persists_across_loops(self):
+        """Same (url, snippet) in loop 1 is skipped because seen_results carries over."""
+        p = make_pipeline(max_context_tokens=5000, n_loops=2)
+        p.evaluate_subquery_relevance = MagicMock(return_value=True)
+
+        call_count = 0
+
+        def web_search_per_loop(query):
+            nonlocal call_count
+            call_count += 1
+            # Same url+snippet but different title each loop
+            return [
+                {
+                    "url": "http://a.com",
+                    "snippet": "same snippet",
+                    "title": f"Title Loop {call_count}",
+                }
+            ]
+
+        p.web_search = web_search_per_loop
+
+        result = p.process_record({"input": "q"})
+
+        # Only loop 0's title kept; loop 1's result was deduped before title check
+        assert result["sources"]["http://a.com"] == ["Title Loop 1"]
 
 
 # ---------------------------------------------------------------------------
-# Multi-loop budget behavior and RAG context growth
+# Multi-loop budget and RAG context growth
 # ---------------------------------------------------------------------------
 
 
 class TestMultiLoopBudget:
-    """Verify budget accounting across multiple loops and RAG context growth."""
+    def test_second_loop_runs_when_relevant(self):
+        p = make_pipeline(max_context_tokens=5000, n_loops=2)
 
-    def test_second_loop_runs_when_relevance_is_true(self):
-        """When evaluate_subquery_relevance returns True, loop 2 executes."""
-        p = make_pipeline(max_context_tokens=5000, n_subqueries=1, n_loops=2)
-        p.generate_subqueries = lambda *a, **kw: ["sub1"]
+        call_count = 0
 
-        search_calls = {"n": 0}
-
-        def web_search_side_effect(query):
-            search_calls["n"] += 1
+        def counting_web_search(query):
+            nonlocal call_count
+            call_count += 1
             return [
-                {
-                    "url": f"http://{search_calls['n']}.com",
-                    "snippet": "info",
-                    "title": "t",
-                },
+                {"url": f"http://{call_count}.com", "snippet": "info", "title": "t"}
             ]
 
-        p.web_search = web_search_side_effect
+        p.web_search = counting_web_search
         p.evaluate_subquery_relevance = MagicMock(return_value=True)
 
         p.process_record({"input": "q"})
 
-        # Both loops should have triggered web_search
-        assert search_calls["n"] == 2  # 1 subquery x 2 loops
+        assert call_count == 2
 
-    def test_second_loop_skipped_when_relevance_is_false(self):
-        """When evaluate_subquery_relevance returns False on loop 2, it breaks."""
-        p = make_pipeline(max_context_tokens=5000, n_subqueries=1, n_loops=2)
-        p.generate_subqueries = lambda *a, **kw: ["sub1"]
+    def test_second_loop_skipped_when_irrelevant(self):
+        p = make_pipeline(max_context_tokens=5000, n_loops=2)
 
-        search_calls = {"n": 0}
+        call_count = 0
 
-        def web_search_side_effect(query):
-            search_calls["n"] += 1
+        def counting_web_search(query):
+            nonlocal call_count
+            call_count += 1
             return [
-                {
-                    "url": f"http://{search_calls['n']}.com",
-                    "snippet": "info",
-                    "title": "t",
-                },
+                {"url": f"http://{call_count}.com", "snippet": "info", "title": "t"}
             ]
 
-        p.web_search = web_search_side_effect
+        p.web_search = counting_web_search
         p.evaluate_subquery_relevance = MagicMock(return_value=False)
 
         p.process_record({"input": "q"})
 
-        # Only loop 0 should run (loop 1 breaks before web_search)
-        assert search_calls["n"] == 1
+        assert call_count == 1
 
     def test_rag_context_grows_across_loops(self):
-        """current_context is updated to final_detailed after each loop,
-        causing rag_for_llm to grow and contain Prior answer."""
-        p = make_pipeline(max_context_tokens=5000, n_subqueries=1, n_loops=2)
-        p.generate_subqueries = lambda *a, **kw: ["sub1"]
+        """Loop 1's rag_for_llm should contain loop 0's detailed answer."""
+        p = make_pipeline(max_context_tokens=5000, n_loops=2)
 
-        # Track what integrate_with_llm receives as rag_doc across loops
         rag_docs_seen = []
 
         def tracking_integrate(original, rag_doc, web_content):
             rag_docs_seen.append(rag_doc)
-            return {"short": "s", "detailed": "long detailed answer for context growth"}
+            return {"short": "s", "detailed": "long detailed answer for growth"}
 
         p.integrate_with_llm = tracking_integrate
         p.evaluate_subquery_relevance = MagicMock(return_value=True)
-
-        def web_search_side_effect(query):
-            return [
-                {"url": "http://x.com", "snippet": f"snippet for {query}", "title": "t"}
-            ]
-
-        p.web_search = web_search_side_effect
+        p.web_search = lambda query: [
+            {"url": "http://x.com", "snippet": "data", "title": "t"}
+        ]
 
         p.process_record({"input": "q"})
 
-        # Loop 0: rag_for_llm is "" (no rag, no prior context)
         assert rag_docs_seen[0] == ""
-        # Loop 1: rag_for_llm should contain "Prior answer:" from loop 0
         assert "Prior answer:" in rag_docs_seen[1]
-        assert "long detailed answer for context growth" in rag_docs_seen[1]
+        assert "long detailed answer for growth" in rag_docs_seen[1]
 
     def test_snippet_budget_shrinks_with_growing_context(self):
-        """As rag_for_llm grows across loops, snippet_budget decreases
-        (because the synthesis prefix contains the growing rag_doc)."""
-        p = make_pipeline(max_context_tokens=200, n_subqueries=1, n_loops=2)
-        p.generate_subqueries = lambda *a, **kw: ["sub1"]
+        """Growing rag_for_llm increases synthesis prefix, reducing snippet budget."""
+        p = make_pipeline(max_context_tokens=200, n_loops=2)
 
         budgets_seen = []
-
         original_compute = p._compute_content_budget
 
         def tracking_compute(*fixed_parts):
@@ -391,48 +471,33 @@ class TestMultiLoopBudget:
 
         p._compute_content_budget = tracking_compute
         p.evaluate_subquery_relevance = MagicMock(return_value=True)
+        p.web_search = lambda query: [
+            {"url": "http://x.com", "snippet": "data", "title": "t"}
+        ]
 
-        def web_search_side_effect(query):
-            return [{"url": "http://x.com", "snippet": "data", "title": "t"}]
-
-        p.web_search = web_search_side_effect
-
-        # LLM returns a long detailed answer so context grows significantly
+        # Long detailed answer to grow the context
         p.llm.invoke.return_value = MagicMock(
             content="short answer: s\ndetailed answer: " + "word " * 30
         )
 
         p.process_record({"input": "q"})
 
-        # _compute_content_budget is called for snippet_budget and summary_budget per loop.
-        # With 2 loops we expect at least 4 calls (snippet + summary per loop).
-        assert len(budgets_seen) >= 4
-        # The snippet budget in loop 1 should be smaller than loop 0.
         # budgets_seen[0] = snippet budget loop 0, budgets_seen[2] = snippet budget loop 1
-        # (indices 1, 3 are summary budgets)
-        snippet_budget_loop0 = budgets_seen[0]
-        snippet_budget_loop1 = budgets_seen[2]
-        assert snippet_budget_loop1 < snippet_budget_loop0
+        assert len(budgets_seen) >= 4
+        assert budgets_seen[2] < budgets_seen[0]
 
 
 # ---------------------------------------------------------------------------
-# Summary budget (per-subquery) tests
+# Summary budget (per-subquery)
 # ---------------------------------------------------------------------------
 
 
 class TestSummaryBudget:
-    """Verify per-subquery summary_budget caps snippets for generate_summary."""
+    def test_large_snippet_excluded_by_summary_budget(self):
+        """Per-subquery summary_budget excludes snippets that overflow it,
+        even if the global snippet_budget has room."""
+        p = make_pipeline(max_context_tokens=100)
 
-    def test_summary_budget_limits_snippets_per_subquery(self):
-        """Snippets exceeding the per-subquery summary_budget are excluded
-        from that subquery's batch, even if global snippet_budget has room."""
-        # Set max_context_tokens so that the summary_budget (which subtracts
-        # SUMMARY_SYSTEM_MSG + SUMMARY_PREFIX + SUMMARY_SUFFIX overhead) is small,
-        # but the global snippet_budget is larger.
-        p = make_pipeline(max_context_tokens=100, n_subqueries=1, n_loops=1)
-        p.generate_subqueries = lambda *a, **kw: ["sub1"]
-
-        # Track what generate_summary receives (per-subquery call)
         summary_inputs = []
 
         def tracking_summary(content, query):
@@ -441,162 +506,45 @@ class TestSummaryBudget:
 
         p.generate_summary = tracking_summary
 
-        # Return 3 snippets: the third is large and should exceed summary_budget
+        small = "word " * 3
+        large = "word " * 50
         p.searcher.websearch_pipeline.return_value = [
-            make_search_result("http://a.com", "word " * 3),
-            make_search_result("http://b.com", "word " * 3),
-            make_search_result("http://c.com", "word " * 50),  # large
+            make_search_result("http://a.com", small),
+            make_search_result("http://b.com", small),
+            make_search_result("http://c.com", large),
         ]
 
         p.process_record({"input": "q"})
 
-        # The per-subquery summary call (first call) should have received
-        # fewer snippets than the total 3 returned by web search
+        # First generate_summary call is the per-subquery one
         assert len(summary_inputs) >= 1
+        per_subquery_input = summary_inputs[0]
+        assert small.strip() in per_subquery_input
+        assert large.strip() not in per_subquery_input
 
-    def test_use_summary_mode_sets_snippet_budget_to_max_context(self):
-        """When use_summary=True, snippet_budget = max_context_tokens
-        (no synthesis overhead subtracted), so more snippets fit."""
-        p = make_pipeline(
-            max_context_tokens=200, n_subqueries=1, n_loops=1, use_summary=True
-        )
-        p.generate_subqueries = lambda *a, **kw: ["sub1"]
+    def test_use_summary_bypasses_synthesis_overhead(self):
+        """With a tight budget, use_summary=True accepts what use_summary=False rejects.
 
-        p.searcher.websearch_pipeline.return_value = [
-            make_search_result("http://a.com", "snippet"),
+        Synthesis prompt overhead is ~56 tokens for query "q". At max_context_tokens=60,
+        use_summary=False leaves ~4 tokens for snippets (too few), while
+        use_summary=True gives the full 60 tokens.
+        """
+        snippet = "this snippet has seven words total"
+
+        p_no = make_pipeline(max_context_tokens=60, use_summary=False)
+        p_no.searcher.websearch_pipeline.return_value = [
+            make_search_result("http://a.com", snippet),
         ]
+        result_no = p_no.process_record({"input": "q"})
 
-        result = p.process_record({"input": "q"})
+        p_yes = make_pipeline(max_context_tokens=60, use_summary=True)
+        p_yes.searcher.websearch_pipeline.return_value = [
+            make_search_result("http://a.com", snippet),
+        ]
+        result_yes = p_yes.process_record({"input": "q"})
 
-        assert "http://a.com" in result["sources"]
-
-
-# ---------------------------------------------------------------------------
-# Token helper unit tests
-# ---------------------------------------------------------------------------
-
-
-class TestTokenHelpers:
-    """Unit tests for _count_tokens, _truncate_to_token_limit, _fit_to_budget."""
-
-    def test_count_tokens_uses_llm_when_no_tokenizer(self):
-        """When _tokenizer is None, delegates to llm.get_num_tokens."""
-        p = make_pipeline()
-        p._tokenizer = None
-
-        assert p._count_tokens("one two three") == 3  # 1 word = 1 token
-
-    def test_count_tokens_uses_local_tokenizer_when_available(self):
-        """When _tokenizer is set, uses _encode instead of llm."""
-        p = make_pipeline()
-        mock_tokenizer = MagicMock()
-        mock_tokenizer.encode.return_value = [1, 2, 3, 4, 5]  # 5 tokens
-        p._tokenizer = mock_tokenizer
-
-        assert p._count_tokens("some text") == 5
-        mock_tokenizer.encode.assert_called_once_with(
-            "some text", add_special_tokens=False
-        )
-
-    def test_truncate_no_op_when_within_limit(self):
-        """Text within budget is returned unchanged."""
-        p = make_pipeline()
-        result = p._truncate_to_token_limit("one two three", max_tokens=10)
-        assert result == "one two three"
-
-    def test_truncate_binary_search_shortens_text(self):
-        """Text exceeding budget is shortened (binary search path)."""
-        p = make_pipeline()
-        long_text = "word " * 100  # 100+ tokens with word-splitting
-        result = p._truncate_to_token_limit(long_text, max_tokens=5)
-
-        # Result should be shorter than original
-        assert len(result) < len(long_text)
-        # And within budget
-        assert p._count_tokens(result) <= 5
-
-    def test_truncate_with_local_tokenizer(self):
-        """When tokenizer is available, uses encode/decode path."""
-        p = make_pipeline()
-        mock_tokenizer = MagicMock()
-        mock_tokenizer.encode.return_value = list(range(20))  # 20 tokens
-        mock_tokenizer.decode.return_value = "truncated text"
-        p._tokenizer = mock_tokenizer
-
-        result = p._truncate_to_token_limit("some long text", max_tokens=5)
-
-        assert result == "truncated text"
-        mock_tokenizer.decode.assert_called_once_with(
-            list(range(5)), skip_special_tokens=True
-        )
-
-    def test_fit_to_budget_truncates_content(self):
-        """Content is truncated so total (fixed + content) fits max_context_tokens."""
-        p = make_pipeline(max_context_tokens=20)
-
-        # fixed parts: "system prompt" (2 tokens) + "prefix" (1 token) = 3 tokens
-        # available = 20 - 3 = 17 tokens
-        result = p._fit_to_budget("word " * 30, "system prompt", "prefix")
-
-        assert p._count_tokens(result) <= 17
-
-    def test_fit_to_budget_returns_empty_when_fixed_exceeds_max(self):
-        """When fixed parts alone exceed max_context_tokens, returns empty."""
-        p = make_pipeline(max_context_tokens=5)
-
-        result = p._fit_to_budget(
-            "content", "this is a very long system prompt that exceeds everything"
-        )
-
-        assert result == ""
-
-    def test_compute_content_budget_basic(self):
-        """Returns max_context_tokens minus token count of fixed parts."""
-        p = make_pipeline(max_context_tokens=100)
-
-        # "hello world" = 2 tokens, "foo" = 1 token -> fixed = 3
-        budget = p._compute_content_budget("hello world", "foo")
-
-        assert budget == 100 - 3
-
-    def test_compute_content_budget_clamps_to_zero(self):
-        """Returns 0 (not negative) when fixed parts exceed max."""
-        p = make_pipeline(max_context_tokens=5)
-
-        budget = p._compute_content_budget("a " * 100)
-
-        assert budget == 0
-
-
-# ---------------------------------------------------------------------------
-# extract_response unit tests
-# ---------------------------------------------------------------------------
-
-
-class TestExtractResponse:
-    """Unit tests for the extract_response helper."""
-
-    def test_string_input(self):
-        from mmore.websearchRAG.pipeline import extract_response
-
-        assert extract_response("hello") == "hello"
-
-    def test_list_of_strings(self):
-        from mmore.websearchRAG.pipeline import extract_response
-
-        assert extract_response(["first", "second"]) == "second"
-
-    def test_list_of_dicts(self):
-        from mmore.websearchRAG.pipeline import extract_response
-
-        result = extract_response([{"content": "from dict"}])
-        assert result == "from dict"
-
-    def test_list_of_dicts_missing_content(self):
-        from mmore.websearchRAG.pipeline import extract_response
-
-        result = extract_response([{"other": "value"}])
-        assert result == ""
+        assert "http://a.com" not in result_no["sources"]
+        assert "http://a.com" in result_yes["sources"]
 
 
 # ---------------------------------------------------------------------------
@@ -605,31 +553,16 @@ class TestExtractResponse:
 
 
 class TestEdgeCases:
-    """Edge cases for process_record."""
-
     def test_empty_query(self):
-        """Empty input string should not crash."""
-        p = make_pipeline(n_subqueries=1, n_loops=1)
+        p = make_pipeline(n_loops=1, subqueries=None)
         p.searcher.websearch_pipeline.return_value = []
 
         result = p.process_record({"input": ""})
 
         assert result["query"] == ""
 
-    def test_web_search_returns_empty(self):
-        """When web search returns no results, pipeline completes with empty sources."""
-        p = make_pipeline(n_subqueries=2, n_loops=1)
-        p.generate_subqueries = lambda *a, **kw: ["sub1", "sub2"]
-        p.searcher.websearch_pipeline.return_value = []
-
-        result = p.process_record({"input": "obscure query"})
-
-        assert result["sources"] == {}
-
-    def test_zero_max_context_tokens(self):
-        """With very small max_context_tokens, no snippets are collected."""
-        p = make_pipeline(max_context_tokens=1, n_subqueries=1, n_loops=1)
-        p.generate_subqueries = lambda *a, **kw: ["sub1"]
+    def test_tiny_budget_rejects_all_snippets(self):
+        p = make_pipeline(max_context_tokens=1)
 
         p.searcher.websearch_pipeline.return_value = [
             make_search_result("http://a.com", "data"),
@@ -637,33 +570,4 @@ class TestEdgeCases:
 
         result = p.process_record({"input": "q"})
 
-        # With such a tiny budget, no snippets should make it through
         assert result["sources"] == {}
-
-    def test_clean_llm_output_with_delimiter(self):
-        """_clean_llm_output strips HF special tokens."""
-        p = make_pipeline()
-        raw = "garbage<|eot_id|><|start_header_id|>assistant<|end_header_id|>actual answer"
-        result = p._clean_llm_output(raw)
-        assert result == "actual answer"
-
-    def test_clean_llm_output_without_delimiter(self):
-        """_clean_llm_output returns input unchanged when no delimiter."""
-        p = make_pipeline()
-        assert p._clean_llm_output("normal text") == "normal text"
-
-    def test_dedup_across_loops(self):
-        """seen_results set persists across loops, deduplicating across iterations."""
-        p = make_pipeline(max_context_tokens=5000, n_subqueries=1, n_loops=2)
-        p.generate_subqueries = lambda *a, **kw: ["sub1"]
-        p.evaluate_subquery_relevance = MagicMock(return_value=True)
-
-        # Both loops return the same result
-        p.searcher.websearch_pipeline.return_value = [
-            make_search_result("http://a.com", "same snippet"),
-        ]
-
-        result = p.process_record({"input": "q"})
-
-        assert "http://a.com" in result["sources"]
-        assert len(result["sources"]["http://a.com"]) == 1

--- a/tests/test_websearch_pipeline.py
+++ b/tests/test_websearch_pipeline.py
@@ -255,7 +255,7 @@ class TestSnippetBudget:
                 # Budget is exhausted after the first result
                 return [
                     {
-                        "url": "http://{call_count}.com",
+                        "url": f"http://{call_count}.com",
                         "snippet": "word " * 10,
                         "title": "t",
                     }

--- a/tests/test_websearch_pipeline.py
+++ b/tests/test_websearch_pipeline.py
@@ -1,0 +1,669 @@
+from unittest.mock import MagicMock, patch
+
+from mmore.websearchRAG.config import WebsearchConfig
+from mmore.websearchRAG.pipeline import WebsearchPipeline
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_pipeline(
+    max_context_tokens=100,
+    n_subqueries=2,
+    n_loops=1,
+    use_summary=False,
+    use_rag=False,
+    search_provider="tavily",
+    **config_overrides,
+):
+    """Build a WebsearchPipeline with all I/O and LLM mocked out."""
+    config = WebsearchConfig(
+        rag_config_path="dummy.yaml",
+        output_file="dummy_out.json",
+        max_context_tokens=max_context_tokens,
+        n_subqueries=n_subqueries,
+        n_loops=n_loops,
+        use_summary=use_summary,
+        use_rag=use_rag,
+        search_provider=search_provider,
+        **config_overrides,
+    )
+    with patch.object(WebsearchPipeline, "__init__", lambda self, cfg: None):
+        pipeline = WebsearchPipeline(config)
+
+    pipeline.config = config
+    pipeline.rag_results = None
+    pipeline._tokenizer = None
+
+    mock_llm = MagicMock()
+    mock_llm.get_num_tokens = lambda text: len(text.split())
+    mock_llm.invoke.return_value = MagicMock(
+        content="short answer: ok\ndetailed answer: detailed ok"
+    )
+    pipeline.llm = mock_llm
+
+    pipeline.searcher = MagicMock()
+    pipeline.searcher.websearch_pipeline.return_value = []
+
+    return pipeline
+
+
+def make_search_result(url, snippet, title="t"):
+    """Shorthand for a web-search result dict (websearch.py output format)."""
+    return {"body": snippet, "href": url, "title": title}
+
+
+# ---------------------------------------------------------------------------
+# Smoke test
+# ---------------------------------------------------------------------------
+
+
+class TestSmoke:
+    def test_process_record_returns_expected_keys(self):
+        """Minimal end-to-end: no web results, pipeline still returns valid structure."""
+        p = make_pipeline(n_loops=1, n_subqueries=1)
+        p.searcher.websearch_pipeline.return_value = []
+
+        result = p.process_record({"input": "What is Python?"})
+
+        assert "query" in result
+        assert "short_answer" in result
+        assert "detailed_answer" in result
+        assert "sources" in result
+        assert result["query"] == "What is Python?"
+        assert result["sources"] == {}
+
+
+# ---------------------------------------------------------------------------
+# Token-budget boundary tests – snippet accumulation
+# ---------------------------------------------------------------------------
+
+
+class TestSnippetBudget:
+    """Verify token-aware snippet accumulation and early stopping."""
+
+    def test_snippets_within_budget_are_all_collected(self):
+        """When total snippet tokens < budget, all snippets are kept."""
+        p = make_pipeline(max_context_tokens=5000, n_subqueries=1, n_loops=1)
+        # Ensure generate_subqueries returns exactly 1 subquery
+        p.generate_subqueries = lambda *a, **kw: ["sq1"]
+
+        p.searcher.websearch_pipeline.return_value = [
+            make_search_result("http://a.com", "small snippet one"),
+            make_search_result("http://b.com", "small snippet two"),
+        ]
+
+        result = p.process_record({"input": "test query"})
+
+        assert "http://a.com" in result["sources"]
+        assert "http://b.com" in result["sources"]
+
+    def test_budget_exhaustion_stops_accumulation(self):
+        """When a snippet would exceed the budget, it and all subsequent are skipped."""
+        # With 1-word = 1-token counting and max_context_tokens set very low,
+        # the snippet budget (after subtracting fixed prompt overhead) will be tiny.
+        # We need the budget to allow roughly 1 snippet but not 2.
+        #
+        # Fixed overhead for query "q" (use_summary=False):
+        #   SYNTHESIS_SYSTEM_MSG  ~ 21 words
+        #   SYNTHESIS_PREFIX      ~ 12 words  (with original="q", rag_doc="No RAG sources")
+        #   SYNTHESIS_SUFFIX      ~ 23 words
+        #   Total fixed           ~ 56 words
+        #
+        # With max_context_tokens=80, snippet budget = 80 - 56 = 24 tokens.
+        # "alpha bravo charlie\n" = 4 tokens -> fits (total=4).
+        # "delta echo foxtrot golf hotel india juliet kilo\n" = 9 tokens -> 4+9=13 fits too.
+        # So we need a tighter budget.  Use max_context_tokens=62 -> budget = 6 tokens.
+        # First snippet (4 tokens): 0+4 > 6? No -> accepted (total=4).
+        # Second snippet (9 tokens): 4+9 > 6? Yes -> skipped.
+        p = make_pipeline(max_context_tokens=62, n_subqueries=1, n_loops=1)
+        p.generate_subqueries = lambda *a, **kw: ["sq1"]
+
+        p.searcher.websearch_pipeline.return_value = [
+            make_search_result("http://a.com", "alpha bravo charlie"),
+            make_search_result(
+                "http://b.com", "delta echo foxtrot golf hotel india juliet kilo"
+            ),
+        ]
+
+        result = p.process_record({"input": "q"})
+
+        # First snippet should fit; second should be skipped due to budget
+        assert "http://a.com" in result["sources"]
+        assert "http://b.com" not in result["sources"]
+
+    def test_budget_exhaustion_stops_subsequent_subqueries(self):
+        """Once budget_exhausted is set, remaining subqueries are skipped entirely."""
+        p = make_pipeline(max_context_tokens=80, n_subqueries=3, n_loops=1)
+        p.generate_subqueries = lambda *a, **kw: ["sq1", "sq2", "sq3"]
+
+        call_count = {"n": 0}
+
+        def counting_web_search(query):
+            call_count["n"] += 1
+            # First subquery returns a big snippet that fills the budget
+            if call_count["n"] == 1:
+                return [
+                    {"url": "http://a.com", "snippet": "word " * 60, "title": "t"},
+                ]
+            return [
+                {
+                    "url": f"http://{call_count['n']}.com",
+                    "snippet": "other",
+                    "title": "t",
+                },
+            ]
+
+        p.web_search = counting_web_search
+
+        p.process_record({"input": "q"})
+
+        # budget_exhausted should prevent calling web_search for subqueries 2 and 3
+        assert call_count["n"] == 1
+
+    def test_exact_boundary_snippet_is_accepted(self):
+        """A snippet that exactly fills the remaining budget is accepted (uses >)."""
+        # The code checks `total_tokens + snippet_tokens > snippet_budget`
+        # so a snippet that exactly equals remaining budget should be ACCEPTED.
+        p = make_pipeline(max_context_tokens=5000, n_subqueries=1, n_loops=1)
+        p.generate_subqueries = lambda *a, **kw: ["sq1"]
+
+        # We'll control _count_tokens to make arithmetic precise
+        p._count_tokens = lambda text: 10  # every text = 10 tokens
+
+        # snippet_budget = max_context_tokens - fixed overhead
+        # With _count_tokens returning 10 for each fixed part (3 parts) = 30
+        # snippet_budget = 5000 - 30 = 4970
+        # Each snippet costs 10 tokens. total_tokens starts at 0.
+        # 0 + 10 > 4970? No -> accepted. This will accept up to 497 snippets.
+        # Let's just verify 2 snippets both get accepted.
+        p.searcher.websearch_pipeline.return_value = [
+            make_search_result("http://a.com", "s1"),
+            make_search_result("http://b.com", "s2"),
+        ]
+
+        result = p.process_record({"input": "q"})
+
+        assert "http://a.com" in result["sources"]
+        assert "http://b.com" in result["sources"]
+
+
+# ---------------------------------------------------------------------------
+# Deduplication tests
+# ---------------------------------------------------------------------------
+
+
+class TestDeduplication:
+    """Verify (url, snippet) deduplication logic."""
+
+    def test_exact_duplicate_is_skipped(self):
+        """Same (url, snippet) pair returned twice -> only counted once."""
+        p = make_pipeline(max_context_tokens=5000, n_subqueries=1, n_loops=1)
+        p.generate_subqueries = lambda *a, **kw: ["sub1"]
+
+        p.searcher.websearch_pipeline.return_value = [
+            make_search_result("http://a.com", "same snippet"),
+            make_search_result("http://a.com", "same snippet"),  # duplicate
+        ]
+
+        result = p.process_record({"input": "q"})
+
+        assert "http://a.com" in result["sources"]
+        # Only one title entry despite two identical results
+        assert len(result["sources"]["http://a.com"]) == 1
+
+    def test_same_url_different_snippet_is_kept(self):
+        """Same URL but different snippet -> both are kept (not a duplicate)."""
+        p = make_pipeline(max_context_tokens=5000, n_subqueries=1, n_loops=1)
+        p.generate_subqueries = lambda *a, **kw: ["sub1"]
+
+        p.searcher.websearch_pipeline.return_value = [
+            make_search_result("http://a.com", "snippet alpha", title="Title A"),
+            make_search_result("http://a.com", "snippet beta", title="Title B"),
+        ]
+
+        result = p.process_record({"input": "q"})
+
+        # Both titles should be recorded under the same URL
+        assert len(result["sources"]["http://a.com"]) == 2
+
+    def test_same_snippet_different_url_is_kept(self):
+        """Same snippet but different URL -> both are kept."""
+        p = make_pipeline(max_context_tokens=5000, n_subqueries=1, n_loops=1)
+        p.generate_subqueries = lambda *a, **kw: ["sub1"]
+
+        p.searcher.websearch_pipeline.return_value = [
+            make_search_result("http://a.com", "identical text"),
+            make_search_result("http://b.com", "identical text"),
+        ]
+
+        result = p.process_record({"input": "q"})
+
+        assert "http://a.com" in result["sources"]
+        assert "http://b.com" in result["sources"]
+
+    def test_duplicates_across_subqueries_are_skipped(self):
+        """Dedup set persists across subqueries within a loop."""
+        p = make_pipeline(max_context_tokens=5000, n_subqueries=2, n_loops=1)
+        p.generate_subqueries = lambda *a, **kw: ["sub1", "sub2"]
+
+        call_count = {"n": 0}
+
+        def web_search_side_effect(query):
+            call_count["n"] += 1
+            # Both subqueries return the same result
+            return [
+                {"url": "http://shared.com", "snippet": "shared content", "title": "t"},
+            ]
+
+        p.web_search = web_search_side_effect
+
+        result = p.process_record({"input": "q"})
+
+        # web_search called for both subqueries
+        assert call_count["n"] == 2
+        # But the snippet is only accepted once (from subquery 1)
+        assert "http://shared.com" in result["sources"]
+        assert len(result["sources"]["http://shared.com"]) == 1
+
+    def test_duplicates_do_not_consume_budget(self):
+        """Skipped duplicates should NOT increment total_tokens."""
+        p = make_pipeline(max_context_tokens=5000, n_subqueries=1, n_loops=1)
+        p.generate_subqueries = lambda *a, **kw: ["sub1"]
+
+        p.searcher.websearch_pipeline.return_value = [
+            make_search_result("http://a.com", "real content"),
+            make_search_result("http://a.com", "real content"),  # dup, 0 token cost
+            make_search_result("http://b.com", "more content"),
+        ]
+
+        result = p.process_record({"input": "q"})
+
+        # All non-duplicate URLs should appear
+        assert "http://a.com" in result["sources"]
+        assert "http://b.com" in result["sources"]
+
+
+# ---------------------------------------------------------------------------
+# Multi-loop budget behavior and RAG context growth
+# ---------------------------------------------------------------------------
+
+
+class TestMultiLoopBudget:
+    """Verify budget accounting across multiple loops and RAG context growth."""
+
+    def test_second_loop_runs_when_relevance_is_true(self):
+        """When evaluate_subquery_relevance returns True, loop 2 executes."""
+        p = make_pipeline(max_context_tokens=5000, n_subqueries=1, n_loops=2)
+        p.generate_subqueries = lambda *a, **kw: ["sub1"]
+
+        search_calls = {"n": 0}
+
+        def web_search_side_effect(query):
+            search_calls["n"] += 1
+            return [
+                {
+                    "url": f"http://{search_calls['n']}.com",
+                    "snippet": "info",
+                    "title": "t",
+                },
+            ]
+
+        p.web_search = web_search_side_effect
+        p.evaluate_subquery_relevance = MagicMock(return_value=True)
+
+        p.process_record({"input": "q"})
+
+        # Both loops should have triggered web_search
+        assert search_calls["n"] == 2  # 1 subquery x 2 loops
+
+    def test_second_loop_skipped_when_relevance_is_false(self):
+        """When evaluate_subquery_relevance returns False on loop 2, it breaks."""
+        p = make_pipeline(max_context_tokens=5000, n_subqueries=1, n_loops=2)
+        p.generate_subqueries = lambda *a, **kw: ["sub1"]
+
+        search_calls = {"n": 0}
+
+        def web_search_side_effect(query):
+            search_calls["n"] += 1
+            return [
+                {
+                    "url": f"http://{search_calls['n']}.com",
+                    "snippet": "info",
+                    "title": "t",
+                },
+            ]
+
+        p.web_search = web_search_side_effect
+        p.evaluate_subquery_relevance = MagicMock(return_value=False)
+
+        p.process_record({"input": "q"})
+
+        # Only loop 0 should run (loop 1 breaks before web_search)
+        assert search_calls["n"] == 1
+
+    def test_rag_context_grows_across_loops(self):
+        """current_context is updated to final_detailed after each loop,
+        causing rag_for_llm to grow and contain Prior answer."""
+        p = make_pipeline(max_context_tokens=5000, n_subqueries=1, n_loops=2)
+        p.generate_subqueries = lambda *a, **kw: ["sub1"]
+
+        # Track what integrate_with_llm receives as rag_doc across loops
+        rag_docs_seen = []
+
+        def tracking_integrate(original, rag_doc, web_content):
+            rag_docs_seen.append(rag_doc)
+            return {"short": "s", "detailed": "long detailed answer for context growth"}
+
+        p.integrate_with_llm = tracking_integrate
+        p.evaluate_subquery_relevance = MagicMock(return_value=True)
+
+        def web_search_side_effect(query):
+            return [
+                {"url": "http://x.com", "snippet": f"snippet for {query}", "title": "t"}
+            ]
+
+        p.web_search = web_search_side_effect
+
+        p.process_record({"input": "q"})
+
+        # Loop 0: rag_for_llm is "" (no rag, no prior context)
+        assert rag_docs_seen[0] == ""
+        # Loop 1: rag_for_llm should contain "Prior answer:" from loop 0
+        assert "Prior answer:" in rag_docs_seen[1]
+        assert "long detailed answer for context growth" in rag_docs_seen[1]
+
+    def test_snippet_budget_shrinks_with_growing_context(self):
+        """As rag_for_llm grows across loops, snippet_budget decreases
+        (because the synthesis prefix contains the growing rag_doc)."""
+        p = make_pipeline(max_context_tokens=200, n_subqueries=1, n_loops=2)
+        p.generate_subqueries = lambda *a, **kw: ["sub1"]
+
+        budgets_seen = []
+
+        original_compute = p._compute_content_budget
+
+        def tracking_compute(*fixed_parts):
+            budget = original_compute(*fixed_parts)
+            budgets_seen.append(budget)
+            return budget
+
+        p._compute_content_budget = tracking_compute
+        p.evaluate_subquery_relevance = MagicMock(return_value=True)
+
+        def web_search_side_effect(query):
+            return [{"url": "http://x.com", "snippet": "data", "title": "t"}]
+
+        p.web_search = web_search_side_effect
+
+        # LLM returns a long detailed answer so context grows significantly
+        p.llm.invoke.return_value = MagicMock(
+            content="short answer: s\ndetailed answer: " + "word " * 30
+        )
+
+        p.process_record({"input": "q"})
+
+        # _compute_content_budget is called for snippet_budget and summary_budget per loop.
+        # With 2 loops we expect at least 4 calls (snippet + summary per loop).
+        assert len(budgets_seen) >= 4
+        # The snippet budget in loop 1 should be smaller than loop 0.
+        # budgets_seen[0] = snippet budget loop 0, budgets_seen[2] = snippet budget loop 1
+        # (indices 1, 3 are summary budgets)
+        snippet_budget_loop0 = budgets_seen[0]
+        snippet_budget_loop1 = budgets_seen[2]
+        assert snippet_budget_loop1 < snippet_budget_loop0
+
+
+# ---------------------------------------------------------------------------
+# Summary budget (per-subquery) tests
+# ---------------------------------------------------------------------------
+
+
+class TestSummaryBudget:
+    """Verify per-subquery summary_budget caps snippets for generate_summary."""
+
+    def test_summary_budget_limits_snippets_per_subquery(self):
+        """Snippets exceeding the per-subquery summary_budget are excluded
+        from that subquery's batch, even if global snippet_budget has room."""
+        # Set max_context_tokens so that the summary_budget (which subtracts
+        # SUMMARY_SYSTEM_MSG + SUMMARY_PREFIX + SUMMARY_SUFFIX overhead) is small,
+        # but the global snippet_budget is larger.
+        p = make_pipeline(max_context_tokens=100, n_subqueries=1, n_loops=1)
+        p.generate_subqueries = lambda *a, **kw: ["sub1"]
+
+        # Track what generate_summary receives (per-subquery call)
+        summary_inputs = []
+
+        def tracking_summary(content, query):
+            summary_inputs.append(content)
+            return "summary"
+
+        p.generate_summary = tracking_summary
+
+        # Return 3 snippets: the third is large and should exceed summary_budget
+        p.searcher.websearch_pipeline.return_value = [
+            make_search_result("http://a.com", "word " * 3),
+            make_search_result("http://b.com", "word " * 3),
+            make_search_result("http://c.com", "word " * 50),  # large
+        ]
+
+        p.process_record({"input": "q"})
+
+        # The per-subquery summary call (first call) should have received
+        # fewer snippets than the total 3 returned by web search
+        assert len(summary_inputs) >= 1
+
+    def test_use_summary_mode_sets_snippet_budget_to_max_context(self):
+        """When use_summary=True, snippet_budget = max_context_tokens
+        (no synthesis overhead subtracted), so more snippets fit."""
+        p = make_pipeline(
+            max_context_tokens=200, n_subqueries=1, n_loops=1, use_summary=True
+        )
+        p.generate_subqueries = lambda *a, **kw: ["sub1"]
+
+        p.searcher.websearch_pipeline.return_value = [
+            make_search_result("http://a.com", "snippet"),
+        ]
+
+        result = p.process_record({"input": "q"})
+
+        assert "http://a.com" in result["sources"]
+
+
+# ---------------------------------------------------------------------------
+# Token helper unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestTokenHelpers:
+    """Unit tests for _count_tokens, _truncate_to_token_limit, _fit_to_budget."""
+
+    def test_count_tokens_uses_llm_when_no_tokenizer(self):
+        """When _tokenizer is None, delegates to llm.get_num_tokens."""
+        p = make_pipeline()
+        p._tokenizer = None
+
+        assert p._count_tokens("one two three") == 3  # 1 word = 1 token
+
+    def test_count_tokens_uses_local_tokenizer_when_available(self):
+        """When _tokenizer is set, uses _encode instead of llm."""
+        p = make_pipeline()
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.encode.return_value = [1, 2, 3, 4, 5]  # 5 tokens
+        p._tokenizer = mock_tokenizer
+
+        assert p._count_tokens("some text") == 5
+        mock_tokenizer.encode.assert_called_once_with(
+            "some text", add_special_tokens=False
+        )
+
+    def test_truncate_no_op_when_within_limit(self):
+        """Text within budget is returned unchanged."""
+        p = make_pipeline()
+        result = p._truncate_to_token_limit("one two three", max_tokens=10)
+        assert result == "one two three"
+
+    def test_truncate_binary_search_shortens_text(self):
+        """Text exceeding budget is shortened (binary search path)."""
+        p = make_pipeline()
+        long_text = "word " * 100  # 100+ tokens with word-splitting
+        result = p._truncate_to_token_limit(long_text, max_tokens=5)
+
+        # Result should be shorter than original
+        assert len(result) < len(long_text)
+        # And within budget
+        assert p._count_tokens(result) <= 5
+
+    def test_truncate_with_local_tokenizer(self):
+        """When tokenizer is available, uses encode/decode path."""
+        p = make_pipeline()
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.encode.return_value = list(range(20))  # 20 tokens
+        mock_tokenizer.decode.return_value = "truncated text"
+        p._tokenizer = mock_tokenizer
+
+        result = p._truncate_to_token_limit("some long text", max_tokens=5)
+
+        assert result == "truncated text"
+        mock_tokenizer.decode.assert_called_once_with(
+            list(range(5)), skip_special_tokens=True
+        )
+
+    def test_fit_to_budget_truncates_content(self):
+        """Content is truncated so total (fixed + content) fits max_context_tokens."""
+        p = make_pipeline(max_context_tokens=20)
+
+        # fixed parts: "system prompt" (2 tokens) + "prefix" (1 token) = 3 tokens
+        # available = 20 - 3 = 17 tokens
+        result = p._fit_to_budget("word " * 30, "system prompt", "prefix")
+
+        assert p._count_tokens(result) <= 17
+
+    def test_fit_to_budget_returns_empty_when_fixed_exceeds_max(self):
+        """When fixed parts alone exceed max_context_tokens, returns empty."""
+        p = make_pipeline(max_context_tokens=5)
+
+        result = p._fit_to_budget(
+            "content", "this is a very long system prompt that exceeds everything"
+        )
+
+        assert result == ""
+
+    def test_compute_content_budget_basic(self):
+        """Returns max_context_tokens minus token count of fixed parts."""
+        p = make_pipeline(max_context_tokens=100)
+
+        # "hello world" = 2 tokens, "foo" = 1 token -> fixed = 3
+        budget = p._compute_content_budget("hello world", "foo")
+
+        assert budget == 100 - 3
+
+    def test_compute_content_budget_clamps_to_zero(self):
+        """Returns 0 (not negative) when fixed parts exceed max."""
+        p = make_pipeline(max_context_tokens=5)
+
+        budget = p._compute_content_budget("a " * 100)
+
+        assert budget == 0
+
+
+# ---------------------------------------------------------------------------
+# extract_response unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractResponse:
+    """Unit tests for the extract_response helper."""
+
+    def test_string_input(self):
+        from mmore.websearchRAG.pipeline import extract_response
+
+        assert extract_response("hello") == "hello"
+
+    def test_list_of_strings(self):
+        from mmore.websearchRAG.pipeline import extract_response
+
+        assert extract_response(["first", "second"]) == "second"
+
+    def test_list_of_dicts(self):
+        from mmore.websearchRAG.pipeline import extract_response
+
+        result = extract_response([{"content": "from dict"}])
+        assert result == "from dict"
+
+    def test_list_of_dicts_missing_content(self):
+        from mmore.websearchRAG.pipeline import extract_response
+
+        result = extract_response([{"other": "value"}])
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Edge cases for process_record."""
+
+    def test_empty_query(self):
+        """Empty input string should not crash."""
+        p = make_pipeline(n_subqueries=1, n_loops=1)
+        p.searcher.websearch_pipeline.return_value = []
+
+        result = p.process_record({"input": ""})
+
+        assert result["query"] == ""
+
+    def test_web_search_returns_empty(self):
+        """When web search returns no results, pipeline completes with empty sources."""
+        p = make_pipeline(n_subqueries=2, n_loops=1)
+        p.generate_subqueries = lambda *a, **kw: ["sub1", "sub2"]
+        p.searcher.websearch_pipeline.return_value = []
+
+        result = p.process_record({"input": "obscure query"})
+
+        assert result["sources"] == {}
+
+    def test_zero_max_context_tokens(self):
+        """With very small max_context_tokens, no snippets are collected."""
+        p = make_pipeline(max_context_tokens=1, n_subqueries=1, n_loops=1)
+        p.generate_subqueries = lambda *a, **kw: ["sub1"]
+
+        p.searcher.websearch_pipeline.return_value = [
+            make_search_result("http://a.com", "data"),
+        ]
+
+        result = p.process_record({"input": "q"})
+
+        # With such a tiny budget, no snippets should make it through
+        assert result["sources"] == {}
+
+    def test_clean_llm_output_with_delimiter(self):
+        """_clean_llm_output strips HF special tokens."""
+        p = make_pipeline()
+        raw = "garbage<|eot_id|><|start_header_id|>assistant<|end_header_id|>actual answer"
+        result = p._clean_llm_output(raw)
+        assert result == "actual answer"
+
+    def test_clean_llm_output_without_delimiter(self):
+        """_clean_llm_output returns input unchanged when no delimiter."""
+        p = make_pipeline()
+        assert p._clean_llm_output("normal text") == "normal text"
+
+    def test_dedup_across_loops(self):
+        """seen_results set persists across loops, deduplicating across iterations."""
+        p = make_pipeline(max_context_tokens=5000, n_subqueries=1, n_loops=2)
+        p.generate_subqueries = lambda *a, **kw: ["sub1"]
+        p.evaluate_subquery_relevance = MagicMock(return_value=True)
+
+        # Both loops return the same result
+        p.searcher.websearch_pipeline.return_value = [
+            make_search_result("http://a.com", "same snippet"),
+        ]
+
+        result = p.process_record({"input": "q"})
+
+        assert "http://a.com" in result["sources"]
+        assert len(result["sources"]["http://a.com"]) == 1

--- a/tests/test_websearch_pipeline.py
+++ b/tests/test_websearch_pipeline.py
@@ -225,8 +225,9 @@ class TestSnippetBudget:
         assert "http://b.com" in result["sources"]
 
     def test_budget_exhaustion_stops_accumulation(self):
-        """First snippet (3 tokens) fits in ~5-token budget; second (8 tokens) doesn't."""
-        p = make_pipeline(max_context_tokens=62)
+        """First snippet (3 tokens) fits in 5-token budget; second (8 tokens) doesn't."""
+        p = make_pipeline()
+        p._compute_content_budget = lambda *_: 5
 
         p.searcher.websearch_pipeline.return_value = [
             make_search_result("http://a.com", "alpha bravo charlie"),
@@ -242,9 +243,8 @@ class TestSnippetBudget:
 
     def test_budget_exhaustion_skips_remaining_subqueries(self):
         """Once budget is exhausted, subsequent subqueries never call web_search."""
-        p = make_pipeline(
-            max_context_tokens=80, n_subqueries=3, subqueries=["sub1", "sub2", "sub3"]
-        )
+        p = make_pipeline(n_subqueries=3, subqueries=["sub1", "sub2", "sub3"])
+        p._compute_content_budget = lambda *_: 5
 
         call_count = 0
 
@@ -252,7 +252,14 @@ class TestSnippetBudget:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                return [{"url": "http://a.com", "snippet": "word " * 60, "title": "t"}]
+                # Budget is exhausted after the first result
+                return [
+                    {
+                        "url": "http://{call_count}.com",
+                        "snippet": "word " * 10,
+                        "title": "t",
+                    }
+                ]
             return [
                 {"url": f"http://{call_count}.com", "snippet": "other", "title": "t"}
             ]
@@ -267,9 +274,9 @@ class TestSnippetBudget:
         p = make_pipeline()
 
         # Make every text 10 tokens long
-        p._count_tokens = lambda text: 10
+        p._count_tokens = lambda _: 10
         # Set content budget manually to 20 tokens
-        p._compute_content_budget = lambda *parts: 20
+        p._compute_content_budget = lambda *_: 20
 
         p.searcher.websearch_pipeline.return_value = [
             make_search_result(
@@ -370,9 +377,9 @@ class TestDeduplication:
     def test_duplicates_do_not_consume_budget(self):
         """If a dup consumed budget, the third snippet would be rejected."""
         p = make_pipeline(max_context_tokens=5000)
-        p._count_tokens = lambda text: 10
+        p._count_tokens = lambda _: 10
         # Budget fits 2 snippets (20 tokens) but not 3 (30 tokens)
-        p._compute_content_budget = lambda *parts: 25
+        p._compute_content_budget = lambda *_: 25
 
         p.searcher.websearch_pipeline.return_value = [
             make_search_result("http://a.com", "real content"),  # 10 tokens, accepted
@@ -497,14 +504,13 @@ class TestMultiLoopBudget:
             {"url": "http://x.com", "snippet": "data", "title": "t"}
         ]
 
-        # Long detailed answer to grow the context
         p.llm.invoke.return_value = MagicMock(
             content="short answer: s\ndetailed answer: " + "word " * 30
         )
 
         p.process_record({"input": "test query"})
 
-        # budgets_seen[0] = snippet budget loop 0, budgets_seen[2] = snippet budget loop 1
+        # Ensure budget gets smaller across loops
         assert len(budgets_seen) >= 4
         assert budgets_seen[2] < budgets_seen[0]
 
@@ -518,7 +524,8 @@ class TestSummaryBudget:
     def test_large_snippet_excluded_by_summary_budget(self):
         """Per-subquery summary_budget excludes snippets that overflow it,
         even if the global snippet_budget has room."""
-        p = make_pipeline(max_context_tokens=100)
+        p = make_pipeline()
+        p._compute_content_budget = lambda *_: 10
 
         summary_inputs = []
 

--- a/tests/test_websearch_pipeline.py
+++ b/tests/test_websearch_pipeline.py
@@ -160,12 +160,11 @@ class TestTokenHelpers:
 
     def test_fit_to_budget_truncates_content(self):
         # "system prompt" = 2 tokens, "prefix" = 1 token -> available = 20 - 3 = 17
+        # The 10% safety margin means the result may be slightly shorter than 17.
         string = "word " * 30
         p = make_pipeline(max_context_tokens=20)
         result = p._fit_to_budget(string, "system prompt", "prefix")
-        assert p._count_tokens(result) == p._count_tokens(
-            string[: int(len(string) * 17 / p._count_tokens(string))]
-        )
+        assert p._count_tokens(result) <= 17
 
     def test_fit_to_budget_returns_empty_when_fixed_exceeds_max(self):
         p = make_pipeline(max_context_tokens=5)

--- a/tests/test_websearch_pipeline.py
+++ b/tests/test_websearch_pipeline.py
@@ -545,21 +545,19 @@ class TestSummaryBudget:
         assert large.strip() not in per_subquery_input
 
     def test_use_summary_bypasses_synthesis_overhead(self):
-        """With a tight budget, use_summary=True accepts what use_summary=False rejects.
-
-        Synthesis prompt overhead is ~57 tokens for query "test query". At max_context_tokens=60,
-        use_summary=False leaves ~3 tokens for snippets, while
-        use_summary=True gives the full 60 tokens.
-        """
+        """use_summary=True skips synthesis overhead, so a tight budget accepts
+        what use_summary=False rejects."""
         snippet = "this snippet has six words total"
 
         p_no = make_pipeline(max_context_tokens=60, use_summary=False)
+        p_no._compute_content_budget = MagicMock(return_value=3)
         p_no.searcher.websearch_pipeline.return_value = [
             make_search_result("http://a.com", snippet),
         ]
         result_no = p_no.process_record({"input": "test query"})
 
         p_yes = make_pipeline(max_context_tokens=60, use_summary=True)
+        p_yes._compute_content_budget = MagicMock(return_value=60)
         p_yes.searcher.websearch_pipeline.return_value = [
             make_search_result("http://a.com", snippet),
         ]

--- a/tests/test_websearch_pipeline.py
+++ b/tests/test_websearch_pipeline.py
@@ -18,11 +18,9 @@ def make_pipeline(
     subqueries=("sub1",),
     **config_overrides,
 ):
-    """Build a WebsearchPipeline with all I/O and LLM mocked out.
+    """Build a test WebsearchPipeline and a mocked LLM.
 
-    Args:
-        subqueries: List of subquery strings returned by generate_subqueries.
-            Set to None to keep the real (LLM-driven) implementation.
+    When subqueries is None, generate_subqueries falls back to the mocked LLM.
     """
     config = WebsearchConfig(
         rag_config_path="dummy.yaml",
@@ -150,9 +148,12 @@ class TestTokenHelpers:
 
     def test_fit_to_budget_truncates_content(self):
         # "system prompt" = 2 tokens, "prefix" = 1 token -> available = 20 - 3 = 17
+        string = "word " * 30
         p = make_pipeline(max_context_tokens=20)
-        result = p._fit_to_budget("word " * 30, "system prompt", "prefix")
-        assert p._count_tokens(result) <= 17
+        result = p._fit_to_budget(string, "system prompt", "prefix")
+        assert p._count_tokens(result) == p._count_tokens(
+            string[: int(len(string) * 17 / p._count_tokens(string))]
+        )
 
     def test_fit_to_budget_returns_empty_when_fixed_exceeds_max(self):
         p = make_pipeline(max_context_tokens=5)
@@ -160,15 +161,6 @@ class TestTokenHelpers:
             "content", "this is a very long system prompt that exceeds everything"
         )
         assert result == ""
-
-    def test_compute_content_budget_subtracts_fixed_tokens(self):
-        p = make_pipeline(max_context_tokens=100)
-        # "hello world" = 2 tokens, "foo" = 1 token
-        assert p._compute_content_budget("hello world", "foo") == 97
-
-    def test_compute_content_budget_clamps_to_zero(self):
-        p = make_pipeline(max_context_tokens=5)
-        assert p._compute_content_budget("a " * 100) == 0
 
 
 # ---------------------------------------------------------------------------
@@ -178,16 +170,24 @@ class TestTokenHelpers:
 
 class TestSmoke:
     def test_process_record_returns_expected_keys(self):
-        """No web results -> valid structure with empty sources."""
+        """No web results yields valid structure with empty sources."""
         p = make_pipeline(n_loops=1, n_subqueries=1, subqueries=None)
         p.searcher.websearch_pipeline.return_value = []
 
-        result = p.process_record({"input": "What is Python?"})
+        result = p.process_record({"input": "What's the weather like today?"})
 
-        assert result["query"] == "What is Python?"
+        assert result["query"] == "What's the weather like today?"
         for key in ("query", "short_answer", "detailed_answer", "sources"):
             assert key in result
         assert result["sources"] == {}
+
+    def test_empty_query(self):
+        p = make_pipeline(n_loops=1, subqueries=None)
+        p.searcher.websearch_pipeline.return_value = []
+
+        result = p.process_record({"input": ""})
+
+        assert result["query"] == ""
 
 
 # ---------------------------------------------------------------------------
@@ -212,7 +212,7 @@ class TestSnippetBudget:
         assert "http://b.com" in result["sources"]
 
     def test_budget_exhaustion_stops_accumulation(self):
-        """First snippet (4 tokens) fits in ~6-token budget; second (9 tokens) doesn't."""
+        """First snippet (3 tokens) fits in ~5-token budget; second (8 tokens) doesn't."""
         p = make_pipeline(max_context_tokens=62)
 
         p.searcher.websearch_pipeline.return_value = [
@@ -222,7 +222,7 @@ class TestSnippetBudget:
             ),
         ]
 
-        result = p.process_record({"input": "q"})
+        result = p.process_record({"input": "test query"})
 
         assert "http://a.com" in result["sources"]
         assert "http://b.com" not in result["sources"]
@@ -245,18 +245,17 @@ class TestSnippetBudget:
             ]
 
         p.web_search = counting_web_search
-        p.process_record({"input": "q"})
+        p.process_record({"input": "test query"})
 
         assert call_count == 1
 
     def test_snippet_at_exact_boundary_is_accepted(self):
-        """total + snippet == budget is accepted (strict >, not >=)."""
-        p = make_pipeline(max_context_tokens=5000)
+        """When total + snippet == budget, snippet is accepted."""
+        p = make_pipeline()
 
-        # Make arithmetic deterministic: every text = 10 tokens
+        # Make every text 10 tokens long
         p._count_tokens = lambda text: 10
-        # Fixed overhead: 3 parts x 10 tokens = 30 -> snippet_budget = 4970
-        # Override snippet_budget by also controlling _compute_content_budget
+        # Set content budget manually to 20 tokens
         p._compute_content_budget = lambda *parts: 20
 
         p.searcher.websearch_pipeline.return_value = [
@@ -271,11 +270,22 @@ class TestSnippetBudget:
             ),  # 10 tokens, total=30, 30 > 20? Yes
         ]
 
-        result = p.process_record({"input": "q"})
+        result = p.process_record({"input": "test query"})
 
         assert "http://a.com" in result["sources"]
         assert "http://b.com" in result["sources"]
         assert "http://c.com" not in result["sources"]
+
+    def test_tiny_budget_rejects_all_snippets(self):
+        p = make_pipeline(max_context_tokens=1)
+
+        p.searcher.websearch_pipeline.return_value = [
+            make_search_result("http://a.com", "data"),
+        ]
+
+        result = p.process_record({"input": "test query"})
+
+        assert result["sources"] == {}
 
 
 # ---------------------------------------------------------------------------
@@ -287,38 +297,38 @@ class TestDeduplication:
     """(url, snippet) deduplication logic."""
 
     def test_exact_duplicate_is_skipped(self):
-        p = make_pipeline(max_context_tokens=5000)
+        p = make_pipeline()
 
         p.searcher.websearch_pipeline.return_value = [
             make_search_result("http://a.com", "same snippet"),
             make_search_result("http://a.com", "same snippet"),
         ]
 
-        result = p.process_record({"input": "q"})
+        result = p.process_record({"input": "test query"})
 
         assert len(result["sources"]["http://a.com"]) == 1
 
     def test_same_url_different_snippet_kept(self):
-        p = make_pipeline(max_context_tokens=5000)
+        p = make_pipeline()
 
         p.searcher.websearch_pipeline.return_value = [
             make_search_result("http://a.com", "snippet alpha", title="Title A"),
             make_search_result("http://a.com", "snippet beta", title="Title B"),
         ]
 
-        result = p.process_record({"input": "q"})
+        result = p.process_record({"input": "test query"})
 
         assert len(result["sources"]["http://a.com"]) == 2
 
     def test_same_snippet_different_url_kept(self):
-        p = make_pipeline(max_context_tokens=5000)
+        p = make_pipeline()
 
         p.searcher.websearch_pipeline.return_value = [
             make_search_result("http://a.com", "identical text"),
             make_search_result("http://b.com", "identical text"),
         ]
 
-        result = p.process_record({"input": "q"})
+        result = p.process_record({"input": "test query"})
 
         assert "http://a.com" in result["sources"]
         assert "http://b.com" in result["sources"]
@@ -339,7 +349,7 @@ class TestDeduplication:
 
         p.web_search = web_search_returning_same
 
-        result = p.process_record({"input": "q"})
+        result = p.process_record({"input": "test query"})
 
         assert call_count == 2  # both subqueries searched
         assert len(result["sources"]["http://shared.com"]) == 1  # but only one kept
@@ -359,7 +369,7 @@ class TestDeduplication:
             ),  # 10 tokens, fits only if dup didn't count
         ]
 
-        result = p.process_record({"input": "q"})
+        result = p.process_record({"input": "test query"})
 
         assert "http://b.com" in result["sources"]
 
@@ -373,7 +383,7 @@ class TestDeduplication:
         def web_search_per_loop(query):
             nonlocal call_count
             call_count += 1
-            # Same url+snippet but different title each loop
+            # Same (url, snippet) but different title each loop
             return [
                 {
                     "url": "http://a.com",
@@ -384,9 +394,9 @@ class TestDeduplication:
 
         p.web_search = web_search_per_loop
 
-        result = p.process_record({"input": "q"})
+        result = p.process_record({"input": "test query"})
 
-        # Only loop 0's title kept; loop 1's result was deduped before title check
+        # Only the first loop title is kept (second loop is a duplicate even if different title)
         assert result["sources"]["http://a.com"] == ["Title Loop 1"]
 
 
@@ -411,7 +421,7 @@ class TestMultiLoopBudget:
         p.web_search = counting_web_search
         p.evaluate_subquery_relevance = MagicMock(return_value=True)
 
-        p.process_record({"input": "q"})
+        p.process_record({"input": "test query"})
 
         assert call_count == 2
 
@@ -430,7 +440,7 @@ class TestMultiLoopBudget:
         p.web_search = counting_web_search
         p.evaluate_subquery_relevance = MagicMock(return_value=False)
 
-        p.process_record({"input": "q"})
+        p.process_record({"input": "test query"})
 
         assert call_count == 1
 
@@ -450,7 +460,7 @@ class TestMultiLoopBudget:
             {"url": "http://x.com", "snippet": "data", "title": "t"}
         ]
 
-        p.process_record({"input": "q"})
+        p.process_record({"input": "test query"})
 
         assert rag_docs_seen[0] == ""
         assert "Prior answer:" in rag_docs_seen[1]
@@ -479,7 +489,7 @@ class TestMultiLoopBudget:
             content="short answer: s\ndetailed answer: " + "word " * 30
         )
 
-        p.process_record({"input": "q"})
+        p.process_record({"input": "test query"})
 
         # budgets_seen[0] = snippet budget loop 0, budgets_seen[2] = snippet budget loop 1
         assert len(budgets_seen) >= 4
@@ -513,7 +523,7 @@ class TestSummaryBudget:
             make_search_result("http://c.com", large),
         ]
 
-        p.process_record({"input": "q"})
+        p.process_record({"input": "test query"})
 
         # First generate_summary call is the per-subquery one
         assert len(summary_inputs) >= 1
@@ -524,49 +534,23 @@ class TestSummaryBudget:
     def test_use_summary_bypasses_synthesis_overhead(self):
         """With a tight budget, use_summary=True accepts what use_summary=False rejects.
 
-        Synthesis prompt overhead is ~56 tokens for query "q". At max_context_tokens=60,
-        use_summary=False leaves ~4 tokens for snippets (too few), while
+        Synthesis prompt overhead is ~57 tokens for query "test query". At max_context_tokens=60,
+        use_summary=False leaves ~3 tokens for snippets, while
         use_summary=True gives the full 60 tokens.
         """
-        snippet = "this snippet has seven words total"
+        snippet = "this snippet has six words total"
 
         p_no = make_pipeline(max_context_tokens=60, use_summary=False)
         p_no.searcher.websearch_pipeline.return_value = [
             make_search_result("http://a.com", snippet),
         ]
-        result_no = p_no.process_record({"input": "q"})
+        result_no = p_no.process_record({"input": "test query"})
 
         p_yes = make_pipeline(max_context_tokens=60, use_summary=True)
         p_yes.searcher.websearch_pipeline.return_value = [
             make_search_result("http://a.com", snippet),
         ]
-        result_yes = p_yes.process_record({"input": "q"})
+        result_yes = p_yes.process_record({"input": "test query"})
 
         assert "http://a.com" not in result_no["sources"]
         assert "http://a.com" in result_yes["sources"]
-
-
-# ---------------------------------------------------------------------------
-# Edge cases
-# ---------------------------------------------------------------------------
-
-
-class TestEdgeCases:
-    def test_empty_query(self):
-        p = make_pipeline(n_loops=1, subqueries=None)
-        p.searcher.websearch_pipeline.return_value = []
-
-        result = p.process_record({"input": ""})
-
-        assert result["query"] == ""
-
-    def test_tiny_budget_rejects_all_snippets(self):
-        p = make_pipeline(max_context_tokens=1)
-
-        p.searcher.websearch_pipeline.return_value = [
-            make_search_result("http://a.com", "data"),
-        ]
-
-        result = p.process_record({"input": "q"})
-
-        assert result["sources"] == {}

--- a/tests/test_websearch_pipeline.py
+++ b/tests/test_websearch_pipeline.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from mmore.websearchRAG.config import WebsearchConfig
 from mmore.websearchRAG.pipeline import WebsearchPipeline, extract_response
 
@@ -166,12 +168,12 @@ class TestTokenHelpers:
         result = p._fit_to_budget(string, "system prompt", "prefix")
         assert p._count_tokens(result) <= 17
 
-    def test_fit_to_budget_returns_empty_when_fixed_exceeds_max(self):
+    def test_fit_to_budget_raises_when_fixed_exceeds_max(self):
         p = make_pipeline(max_context_tokens=5)
-        result = p._fit_to_budget(
-            "content", "this is a very long system prompt that exceeds everything"
-        )
-        assert result == ""
+        with pytest.raises(ValueError, match="exceed max_context_tokens"):
+            p._fit_to_budget(
+                "content", "this is a very long system prompt that exceeds everything"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -287,16 +289,16 @@ class TestSnippetBudget:
         assert "http://b.com" in result["sources"]
         assert "http://c.com" not in result["sources"]
 
-    def test_tiny_budget_rejects_all_snippets(self):
+    def test_tiny_budget_raises(self):
+        """With a budget too small for the fixed prompt parts, fail loudly."""
         p = make_pipeline(max_context_tokens=1)
 
         p.searcher.websearch_pipeline.return_value = [
             make_search_result("http://a.com", "data"),
         ]
 
-        result = p.process_record({"input": "test query"})
-
-        assert result["sources"] == {}
+        with pytest.raises(ValueError, match="exceed max_context_tokens"):
+            p.process_record({"input": "test query"})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Related issue: #258                                                                                                                                                                
                                                                                                                                                                                                
  - Torch is now optional: only required for HF models, not API providers (OpenAI, Anthropic, ...)                                                                                              
  - Stops collecting snippets when `max_context_tokens` budget is reached, instead of collecting everything then truncating (no more mid-sentence cuts, unnecessary web searches, and wasted LLM  
  calls)                                                                                                                                                                                        
  - Token counting now uses the LLM's own tokenizer for truncation if prompt exceeds token budget (default behavior can be overridden using heuristic ~4 chars/token with the new `fast_tokenizer`
   parameter in the websearch config)                                                                                                                                                           
  - Prompts are improved and standardized across all pipeline steps (summary generation, subquery relevance evaluation, subquery generation, final answer synthesis) with structured          
  `---CONTEXT---` / `---SOURCES---` delimiters and stricter output format instructions                                                                                                              
  - New function `_fit_to_budget` acts as a safety net inside `generate_summary` for inputs not covered by accumulation (RAG answer, concatenated summaries)                                                                                                 
  - Duplicate web results are now filtered out by `(url, snippet)` pair
  - Fixed all extra in `pyproject.toml` to include `"websearch"`                                                                                                                                      
  - Prior loop answers are now passed to the synthesis step, so each search round builds on the previous answer instead of starting from scratch (previously, `use_summary=True` dropped previous    
  context, and `use_summary=False` mixed it with RAG data in the wrong prompt slot)
  - Added 33 tests for the websearch pipeline


## Performance comparison

**Config**: 4 questions asked to `claude-haiku-4-5` using websearch, `use_rag=false`, `n_subqueries=2`, `n_loops=2`, `max_searches=3`, `use_summary=true`, `max_context_tokens=2048`

| Metric | Old / DDGS | New / DDGS | Δ DDGS | Old / Tavily | New / Tavily | Δ Tavily |
|---|---|---|---|---|---|---|
| **TOTAL TIME** | 119.63s | 111.16s | **−7.1%** | 95.61s | 68.96s | **−27.8%** |
| **Avg time / question** | 29.91s | 27.79s | −7.1% | 23.85s | 17.18s | −27.9% |
| LLM calls | 52 | 52 | 0 | 51 | 44 | −13.7% |
| LLM total time | 68.58s | 59.13s | −13.8% | 75.98s | 54.64s | −28.1% |
| LLM avg latency / call | 1.319s | 1.137s | −13.8% | 1.490s | 1.242s | −16.6% |
| Web search calls | 16 | 16 | 0 | 15 | 14 | −6.7% |
| Web search total time | 18.98s | 19.15s | +0.9% | 19.39s | 13.22s | −31.8% |
| `generate_summary` calls | 32 | 32 | 0 | 31 | 25 | **−19.4%** |
| `generate_summary` total | 42.45s | 34.47s | −18.8% | 46.44s | 33.97s | −26.8% |
| `integrate_with_llm` calls | 8 | 8 | 0 | 8 | 7 | −12.5% |
| `integrate_with_llm` total | 14.36s | 12.67s | −11.8% | 15.96s | 9.91s | −37.9% |
| `generate_subqueries` total | 8.52s | 8.85s | +3.9% | 10.65s | 8.01s | −24.8% |
| `evaluate_subquery_relevance` total | 3.25s | 3.18s | −2.2% | 2.94s | 2.79s | −5.1% |
| DDGS sleep overhead | 32.06s | 32.06s | 0 | — | — | — |
| Token counting overhead | — | ~0.81s | — | — | ~0.81s | — |

Tavily benefits the most (−28%) because each result comes back with more text. The new code keeps track of how many snippet tokens have been collected and sets a `budget_exhausted` flag once they go over `snippet_budget` (set to 2048). When that happens, the subquery loop stops early, skipping the remaining web searches and the `generate_summary` calls that go with them. Since Tavily results have longer content, this happens more often (which explains the drop after optimization from 31→25 `generate_summary` calls and 15→14 web searches). Fewer and smaller prompts going to the LLM means both the call count (51→44) and avg latency (1.490s→1.242s) go down.

DDGS gains less (−7%) because its snippets are short and almost never hit the 2048-token budget, so the early stop almost never triggers. The fixed 32s rate-limit sleep (unchanged) also puts a hard cap on how much time can be saved.

The overhead from the new token counting is tiny: ~0.81s total across 252 `_count_tokens` calls, way less than what we save on LLM calls.

Note that these savings in calls and time don't come at the cost of output quality (results can be provided on request)
