### PR TITLE
Add file change detection for incremental reprocessing

### DIFF
--- a/docs/process.md
+++ b/docs/process.md
@@ -79,7 +79,7 @@ The optional top-level `previous_results` parameter lets you reuse results from 
 previous_results: examples/process/outputs/merged/merged_results.jsonl
 ```
 
-Point it to a `merged_results.jsonl` produced by an earlier run. On the next run, each input file is compared against that JSONL:
+Point it to a `merged_results.jsonl` produced by an earlier run. On the next run, each local input file is compared against that JSONL (meanwhile URL inputs are always reprocessed):
 
 - Unchanged files: their previous samples are reused as-is.
 - New or modified files: they are processed normally.

--- a/docs/process.md
+++ b/docs/process.md
@@ -73,7 +73,7 @@ You can configure parameters by providing a custom config file. You can find an 
 
 ### :recycle: Incremental reprocessing
 
-The optional top-level `previous_results` parameter lets you reuse results from a prior run to avoid reprocessing unchanged files so to save time and compute costs.
+The optional top-level `previous_results` parameter lets you reuse results from a prior run to avoid reprocessing unchanged files so as to save time and compute costs.
 
 ```yaml
 previous_results: examples/process/outputs/merged/merged_results.jsonl

--- a/docs/process.md
+++ b/docs/process.md
@@ -71,6 +71,20 @@ You can configure parameters by providing a custom config file. You can find an 
 
 :rotating_light: Not all parameters are configurable yet :wink:
 
+### :recycle: Incremental reprocessing
+
+The optional top-level `previous_results` parameter lets you reuse results from a prior run to avoid reprocessing unchanged files so to save time and compute costs.
+
+```yaml
+previous_results: examples/process/outputs/merged/merged_results.jsonl
+```
+
+Point it to a `merged_results.jsonl` produced by an earlier run. On the next run, each input file is compared against that JSONL:
+
+- Unchanged files: their previous samples are reused as-is.
+- New or modified files: they are processed normally.
+- Removed files: their samples are dropped from the output.
+
 ## :scroll: More information on what's under the hood
 
 ### :construction: Pipeline architecture
@@ -126,5 +140,13 @@ python3 -m mmore postprocess --config-file examples/postprocessor/config.yaml --
 ```
 
 Specify with `--input-data` the path (absolute or relative to the root of the repository) to the JSONL recoding of the output of the initial processing phase.
+
+### :recycle: Incremental post-processing
+
+Like the processing pipeline, the post-processor accepts an optional `previous_results` parameter to reuse results from a prior post-processing run and skip unchanged documents.
+
+```yaml
+previous_results: examples/postprocessor/outputs/merged/results.jsonl
+```
 
 New post-processors can easily be implemented, and pipelines can be configured through lightweight YAML files. The post-processing stage produces a new JSONL file containing cleaned and optionally enhanced document samples.

--- a/examples/postprocessor/config.yaml
+++ b/examples/postprocessor/config.yaml
@@ -1,4 +1,4 @@
-previous_results: null  # Path to a previous post-processed JSONL to reuse when unchanged
+previous_results: null  # Path to a previous post-processed JSONL to reuse when unchanged documents
 
 pp_modules:
   - type: chunker

--- a/examples/postprocessor/config.yaml
+++ b/examples/postprocessor/config.yaml
@@ -1,4 +1,4 @@
-previous_results: null  # Path to a previous post-processed JSONL to reuse when unchanged documents
+previous_results: null  # Path to a previously post-processed JSONL to reuse when documents are unchanged
 
 pp_modules:
   - type: chunker

--- a/examples/postprocessor/config.yaml
+++ b/examples/postprocessor/config.yaml
@@ -1,3 +1,5 @@
+previous_results: null  # Path to a previous post-processed JSONL to reuse when unchanged
+
 pp_modules:
   - type: chunker
     args:

--- a/examples/process/config.yaml
+++ b/examples/process/config.yaml
@@ -1,6 +1,6 @@
 data_path: examples/sample_data/ #put absolute path! Possible to pass a list of folders as well
 google_drive_ids: [] #put ids of google drive folders
-previous_results: null  # Path to a previous processed JSONL to reuse when unchanged documents
+previous_results: null  # Path to a previously processed JSONL to reuse when documents are unchanged
 dispatcher_config:
   output_path: examples/process/outputs/ #put absolute path or relative to the root of the module
   use_fast_processors: false

--- a/examples/process/config.yaml
+++ b/examples/process/config.yaml
@@ -1,5 +1,6 @@
 data_path: examples/sample_data/ #put absolute path! Possible to pass a list of folders as well
 google_drive_ids: [] #put ids of google drive folders
+previous_results: null  # Path to a previous merged_results.jsonl to reuse when unchanged
 dispatcher_config:
   output_path: examples/process/outputs/ #put absolute path or relative to the root of the module
   use_fast_processors: false

--- a/examples/process/config.yaml
+++ b/examples/process/config.yaml
@@ -1,6 +1,6 @@
 data_path: examples/sample_data/ #put absolute path! Possible to pass a list of folders as well
 google_drive_ids: [] #put ids of google drive folders
-previous_results: null  # Path to a previous merged_results.jsonl to reuse when unchanged
+previous_results: null  # Path to a previous processed JSONL to reuse when unchanged documents
 dispatcher_config:
   output_path: examples/process/outputs/ #put absolute path or relative to the root of the module
   use_fast_processors: false

--- a/src/mmore/process/crawler.py
+++ b/src/mmore/process/crawler.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 from typing import Dict, List, Optional
@@ -95,72 +94,6 @@ class DispatcherReadyResult:
             for key, file_list in data["file_paths"].items()
         }
         return DispatcherReadyResult(urls=urls, file_paths=file_paths)
-
-
-class FindAlreadyComputedFiles:
-    """
-    This class is used to get the list of all files that have already been processed.
-    It will traverse the output_path directory and get all the results.jsonl files
-    where in each line (representing a sample) we have the metadata of the file_path that was used to create that sample.
-    > See create_sample in utils.py (file_path is in metadata of the sample).
-
-    Reminder here is the structure of the output_path directory (see DispatcherConfig):
-    output_path
-    ├── processors
-    | ├── Processor_type_1
-    | | └── results.jsonl
-    | ├── Processor_type_2
-    | | └── results.jsonl
-    | ├── ...
-    |
-    └── merged
-        └── merged_results.jsonl
-    """
-
-    def __init__(self, output_path: str):
-        """
-        output_path: the path where the output of the Process is stored.
-        """
-        if output_path is None:
-            raise ValueError("output_path must be provided.")
-        self.output_path = output_path
-
-    def _get_all_samples_jsonl_paths(self, output_path):
-        # Get all the results.jsonl files in the output_path directory.
-        samples_files = []
-        for root, _, files in os.walk(output_path):
-            for file in files:
-                if file.endswith("results.jsonl"):
-                    samples_files.append(os.path.join(root, file))
-        return samples_files
-
-    def _get_metadata_jsonl_path(self, results_jsonl_path):
-        # read jsonl file and for each item in the file, get the metadata's file_path
-        # return the list of all file_path in this jsonl file
-        file_paths = []
-        with open(results_jsonl_path, "r") as f:
-            for i, line in enumerate(f):
-                data = json.loads(line)
-                if "metadata" in data and "file_path" in data["metadata"]:
-                    file_paths.append(data["metadata"]["file_path"])
-                else:
-                    logger.error(
-                        f"Warning file_path not found in metadate (line{i} of {results_jsonl_path})"
-                    )
-        return file_paths
-
-    def get_all_files_already_processed(self) -> set[str]:
-        """
-        This function returns the set of all files path's that have already been processed.
-        Returns:
-             set of all files path's that have already been processed.
-        """
-        samples = self._get_all_samples_jsonl_paths(self.output_path)
-        files_already_processed = set()
-        for f in samples:
-            line = self._get_metadata_jsonl_path(f)
-            files_already_processed.update(line)
-        return files_already_processed
 
 
 class CrawlerConfig:
@@ -308,40 +241,9 @@ class Crawler:
                             FileDescriptor.from_filename(filepath)
                         )
 
-    def _filter_out_already_processed_files(
-        self, files: Dict[str, List[FileDescriptor]], output_path: str
-    ) -> Dict[str, List[FileDescriptor]]:
-        """
-        Avoid processing files that have already been processed.
-        Immutable function.
-        Args:
-            files: the crawled files that want to be processed. We want to remove the files that have already been processed.
-            output_path: the path where the outputs of the "process" is stored.
-        Returns:
-            filtered out 'files' to process.
-        """
-        all_files_done: set[str] = FindAlreadyComputedFiles(
-            output_path
-        ).get_all_files_already_processed()
-        logger.info(f"Found {len(all_files_done)} files already processed.")
-
-        for root_dir, files_in_dir in files.items():
-            files[root_dir] = [
-                f for f in files_in_dir if f.file_path not in all_files_done
-            ]
-
-        if len(all_files_done) > 0:
-            logger.info(f"Removed {len(all_files_done)} files already processed.")
-            logger.info(
-                f"New total files to process: {sum(len(files) for files in files.values())}"
-            )
-        return files
-
-    def crawl(self, skip_already_processed: bool = False) -> DispatcherReadyResult:
+    def crawl(self) -> DispatcherReadyResult:
         """
         Crawl the configured directories and URLs.
-        Args:
-            skip_already_processed (bool): if set to True, the crawler will scan the outputs folder and detect files that correspond to them, and skip them.
         Returns:
             DispatcherReadyResult: The result of the crawl operation, ready to be dispatched to the processors.
         """
@@ -367,13 +269,5 @@ class Crawler:
 
         urls: List[URLDescriptor] = self.files["url"]
         file_paths: Dict[str, List[FileDescriptor]] = self.files["local"]
-
-        if self.config.output_path and skip_already_processed:
-            logger.info(
-                "Checking if some of those files to process have already been processed."
-            )
-            file_paths = self._filter_out_already_processed_files(
-                files=file_paths, output_path=self.config.output_path
-            )
 
         return DispatcherReadyResult(urls=urls, file_paths=file_paths)

--- a/src/mmore/process/dispatcher.py
+++ b/src/mmore/process/dispatcher.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from dataclasses import dataclass
+from datetime import datetime
 from operator import itemgetter
 from typing import Dict, Iterator, List, Optional, Tuple, Type, Union, cast
 
@@ -402,6 +403,11 @@ class Dispatcher:
     ) -> None:
         if not self.config.output_path:
             return
+
+        processed_at = datetime.now().isoformat()
+        for sample in results:
+            sample.metadata["processed_at"] = processed_at
+            sample.metadata["processor_type"] = cls_name
 
         processor_output_path = os.path.join(
             self.config.output_path, "processors", cls_name

--- a/src/mmore/process/dispatcher.py
+++ b/src/mmore/process/dispatcher.py
@@ -322,10 +322,24 @@ class Dispatcher:
 
         return results
 
+    def _clear_per_processor_results(self) -> None:
+        """Clear per-processor result JSONL files.
+        This is needed because :meth:`MultimodalSample.to_jsonl` uses append by default."""
+        if not self.config.output_path:
+            return
+        processors_dir = os.path.join(self.config.output_path, "processors")
+        if not os.path.isdir(processors_dir):
+            return
+        for processor_name in os.listdir(processors_dir):
+            results_path = os.path.join(processors_dir, processor_name, "results.jsonl")
+            if os.path.exists(results_path):
+                os.remove(results_path)
+
     def dispatch(self) -> List[List[MultimodalSample]]:
         """
         Dispatches the result to the appropriate processor.
         """
+        self._clear_per_processor_results()
 
         def batch_list(
             lst: List, obj_batch_size: int, processor: Type[Processor]

--- a/src/mmore/process/incremental.py
+++ b/src/mmore/process/incremental.py
@@ -74,6 +74,8 @@ def is_reusable_process(file_path: str, previous: Dict[str, MultimodalSample]) -
         return False
 
     processed_at = datetime.fromisoformat(processed_at_str)
+    if not os.path.exists(file_path):
+        return False
     file_mtime = datetime.fromtimestamp(os.path.getmtime(file_path))
     return file_mtime <= processed_at
 

--- a/src/mmore/process/incremental.py
+++ b/src/mmore/process/incremental.py
@@ -33,7 +33,7 @@ def load_previous_process_results(path: str) -> Dict[str, MultimodalSample]:
         if len(samples) > 1:
             logger.warning(
                 "Duplicate samples for file_path %s: keeping latest processed_at, "
-                "dropping %d",
+                "dropping %d samples",
                 file_path,
                 len(samples) - 1,
             )

--- a/src/mmore/process/post_processor/pipeline.py
+++ b/src/mmore/process/post_processor/pipeline.py
@@ -158,7 +158,6 @@ class PPPipeline:
         }
 
         if not to_process_file_paths:
-            logger.info("No document changes detected, reusing all previous results")
             merged_samples = merge_results(reused, [], current_file_paths)
             save_samples(merged_samples, self.output_config.output_path)
             return merged_samples

--- a/src/mmore/process/post_processor/pipeline.py
+++ b/src/mmore/process/post_processor/pipeline.py
@@ -39,15 +39,15 @@ class PPPipeline:
     def __init__(
         self,
         *processors: BasePostProcessor,
-        output_config: Optional[OutputConfig] = None,
         previous_results_path: Optional[str] = None,
+        output_config: Optional[OutputConfig] = None,
     ):
         if output_config is None:
             output_config = OutputConfig(output_path="./results")
 
         self.post_processors = processors
-        self.output_config = output_config
         self.previous_results_path = previous_results_path
+        self.output_config = output_config
 
         # Log the pipeline
         self._log_plan()
@@ -56,8 +56,8 @@ class PPPipeline:
         return PPPipeline(
             *self.post_processors,
             *other.post_processors,
-            output_config=self.output_config,
             previous_results_path=self.previous_results_path,
+            output_config=self.output_config,
         )
 
     def _log_plan(self):
@@ -74,14 +74,12 @@ class PPPipeline:
         ]
         return cls(
             *post_processors,
-            output_config=config.output,
             previous_results_path=config.previous_results,
+            output_config=config.output,
         )
 
-    def __call__(
-        self, samples: List[MultimodalSample], **kwargs
-    ) -> List[MultimodalSample]:
-        return self.run(samples, **kwargs)
+    def __call__(self, samples: List[MultimodalSample]) -> List[MultimodalSample]:
+        return self.run(samples)
 
     def run(self, samples: List[MultimodalSample]) -> List[MultimodalSample]:
         """
@@ -99,7 +97,7 @@ class PPPipeline:
         return self._run_full(samples)
 
     def _run_full(self, samples: List[MultimodalSample]) -> List[MultimodalSample]:
-        """Run all processors on all samples (original behavior)."""
+        """Run all processors on all samples."""
         output_dir = os.path.dirname(self.output_config.output_path) or "."
         for i, processor in enumerate(self.post_processors):
             tmp_save_path = None
@@ -132,57 +130,51 @@ class PPPipeline:
         # Group input samples by file_path
         groups: dict[str, List[MultimodalSample]] = {}
         for sample in samples:
-            fp = sample.metadata.get("file_path", "__unknown__")
+            fp = sample.metadata["file_path"]
             groups.setdefault(fp, []).append(sample)
 
-        current_fps = set(groups.keys())
+        current_file_paths = set(groups.keys())
 
         # For each group, get max(processed_at) from input samples
-        reusable_fps = []
-        to_process_fps = []
+        reusable_file_paths: set[str] = set()
+        to_process_file_paths: set[str] = set()
         for fp, group_samples in groups.items():
-            pts = [
+            sample_timestamps = [
                 s.metadata.get("processed_at")
                 for s in group_samples
                 if s.metadata.get("processed_at")
             ]
-            if pts:
-                input_processed_at = max(pts)
+            if sample_timestamps:
+                input_processed_at = max(sample_timestamps)
             else:
-                # No processed_at on input → treat as new
-                to_process_fps.append(fp)
+                # When no processed_at on input, post process it as a new one
+                to_process_file_paths.add(fp)
                 continue
 
             if is_reusable_postprocess(fp, input_processed_at, previous):
-                reusable_fps.append(fp)
+                reusable_file_paths.add(fp)
             else:
-                to_process_fps.append(fp)
+                to_process_file_paths.add(fp)
 
         n_deleted = len(set(previous.keys()) - set(groups.keys()))
         logger.info(
-            f"PP incremental: {len(reusable_fps)} reused, "
-            f"{len(to_process_fps)} to process, {n_deleted} deleted"
+            f"Post-process pipeline: {len(reusable_file_paths)} reused, "
+            f"{len(to_process_file_paths)} to process, {n_deleted} deleted"
         )
 
-        # Collect reused sample dicts from previous results
-        reused: dict[str, List[dict]] = {
-            fp: previous[fp] for fp in reusable_fps if fp in previous
+        # Collect reused samples from previous results
+        reused: dict[str, List[MultimodalSample]] = {
+            fp: previous[fp] for fp in reusable_file_paths
         }
 
-        if not to_process_fps:
+        if not to_process_file_paths:
             logger.info("No document changes detected, reusing all previous results")
-            merged_dicts = merge_results(reused, [], current_fps)
-            merged_samples = [MultimodalSample.from_dict(d) for d in merged_dicts]
+            merged_samples = merge_results(reused, [], current_file_paths)
             save_samples(merged_samples, self.output_config.output_path)
             return merged_samples
 
         # Collect samples to process
-        to_process_set = set(to_process_fps)
-        samples_to_process = [
-            s
-            for s in samples
-            if s.metadata.get("file_path", "__unknown__") in to_process_set
-        ]
+        samples_to_process = [s for fp in to_process_file_paths for s in groups[fp]]
 
         # Run through pipeline
         processed = samples_to_process
@@ -199,16 +191,11 @@ class PPPipeline:
                 save_every=self.output_config.save_every,
             )
 
-        # Enrich newly processed with processed_at
+        # Add processed_at to newly processed samples
         processed_at = datetime.now().isoformat()
         for sample in processed:
             sample.metadata["processed_at"] = processed_at
 
-        # Convert processed to dicts and merge with reused
-        new_dicts = [s.to_dict() for s in processed]
-        merged_dicts = merge_results(reused, new_dicts, current_fps)
-
-        # Convert merged dicts back to MultimodalSample and save
-        merged_samples = [MultimodalSample.from_dict(d) for d in merged_dicts]
+        merged_samples = merge_results(reused, processed, current_file_paths)
         save_samples(merged_samples, self.output_config.output_path)
         return merged_samples

--- a/src/mmore/process/post_processor/pipeline.py
+++ b/src/mmore/process/post_processor/pipeline.py
@@ -138,15 +138,13 @@ class PPPipeline:
         to_process_file_paths: set[str] = set()
         for fp, sample in index.items():
             input_processed_at = sample.metadata.get("processed_at")
-            if input_processed_at is None:
-                # When no processed_at on input, post process it as a new one
+            if input_processed_at is None or not is_reusable_postprocess(
+                fp, input_processed_at, previous
+            ):
+                # When no processed_at on input or not reusable, post process it as a new one
                 to_process_file_paths.add(fp)
-                continue
-
-            if is_reusable_postprocess(fp, input_processed_at, previous):
-                reusable_file_paths.add(fp)
             else:
-                to_process_file_paths.add(fp)
+                reusable_file_paths.add(fp)
 
         n_deleted = len(set(previous.keys()) - set(index.keys()))
         logger.info(

--- a/src/mmore/process/post_processor/pipeline.py
+++ b/src/mmore/process/post_processor/pipeline.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from typing import List, Optional
 
 from ...type import MultimodalSample
-from ..previous_results import (
+from ..incremental import (
     is_reusable_postprocess,
     load_previous_postprocess_results,
     merge_results,

--- a/src/mmore/process/post_processor/pipeline.py
+++ b/src/mmore/process/post_processor/pipeline.py
@@ -1,9 +1,15 @@
 import logging
 import os
 from dataclasses import dataclass
+from datetime import datetime
 from typing import List, Optional
 
 from ...type import MultimodalSample
+from ..previous_results import (
+    is_reusable_postprocess,
+    load_previous_results,
+    merge_results,
+)
 from ..utils import save_samples
 from . import BasePostProcessor, BasePostProcessorConfig, load_postprocessor
 
@@ -26,6 +32,7 @@ class OutputConfig:
 class PPPipelineConfig:
     pp_modules: List[BasePostProcessorConfig]
     output: OutputConfig
+    previous_results: Optional[str] = None
 
 
 class PPPipeline:
@@ -33,12 +40,14 @@ class PPPipeline:
         self,
         *processors: BasePostProcessor,
         output_config: Optional[OutputConfig] = None,
+        previous_results_path: Optional[str] = None,
     ):
         if output_config is None:
             output_config = OutputConfig(output_path="./results")
 
         self.post_processors = processors
         self.output_config = output_config
+        self.previous_results_path = previous_results_path
 
         # Log the pipeline
         self._log_plan()
@@ -48,6 +57,7 @@ class PPPipeline:
             *self.post_processors,
             *other.post_processors,
             output_config=self.output_config,
+            previous_results_path=self.previous_results_path,
         )
 
     def _log_plan(self):
@@ -62,10 +72,16 @@ class PPPipeline:
         post_processors = [
             load_postprocessor(pp_config) for pp_config in config.pp_modules
         ]
-        return cls(*post_processors, output_config=config.output)
+        return cls(
+            *post_processors,
+            output_config=config.output,
+            previous_results_path=config.previous_results,
+        )
 
-    def __call__(self, samples: List[MultimodalSample]) -> List[MultimodalSample]:
-        return self.run(samples)
+    def __call__(
+        self, samples: List[MultimodalSample], **kwargs
+    ) -> List[MultimodalSample]:
+        return self.run(samples, **kwargs)
 
     def run(self, samples: List[MultimodalSample]) -> List[MultimodalSample]:
         """
@@ -78,9 +94,13 @@ class PPPipeline:
         Returns:
             List[MultimodalSample]: Post-processed multimodal samples.
         """
+        if self.previous_results_path is not None:
+            return self._run_incremental(samples)
+        return self._run_full(samples)
 
+    def _run_full(self, samples: List[MultimodalSample]) -> List[MultimodalSample]:
+        """Run all processors on all samples (original behavior)."""
         output_dir = os.path.dirname(self.output_config.output_path) or "."
-
         for i, processor in enumerate(self.post_processors):
             tmp_save_path = None
             if self.output_config.save_each_step:
@@ -88,12 +108,107 @@ class PPPipeline:
                     output_dir,
                     f"{i + 1}___{processor.name}.jsonl",
                 )
-
             samples = processor.batch_process(
                 samples,
                 tmp_save_path=tmp_save_path,
                 save_every=self.output_config.save_every,
             )
 
+        processed_at = datetime.now().isoformat()
+        for sample in samples:
+            sample.metadata["processed_at"] = processed_at
+
         save_samples(samples, self.output_config.output_path)
         return samples
+
+    def _run_incremental(
+        self, samples: List[MultimodalSample]
+    ) -> List[MultimodalSample]:
+        """Run processors only on samples from new/changed source documents."""
+        output_dir = os.path.dirname(self.output_config.output_path) or "."
+
+        previous = load_previous_results(self.previous_results_path)
+
+        # Group input samples by file_path
+        groups: dict[str, List[MultimodalSample]] = {}
+        for sample in samples:
+            fp = sample.metadata.get("file_path", "__unknown__")
+            groups.setdefault(fp, []).append(sample)
+
+        current_fps = set(groups.keys())
+
+        # For each group, get max(processed_at) from input samples
+        reusable_fps = []
+        to_process_fps = []
+        for fp, group_samples in groups.items():
+            pts = [
+                s.metadata.get("processed_at")
+                for s in group_samples
+                if s.metadata.get("processed_at")
+            ]
+            if pts:
+                input_processed_at = max(pts)
+            else:
+                # No processed_at on input → treat as new
+                to_process_fps.append(fp)
+                continue
+
+            if is_reusable_postprocess(fp, input_processed_at, previous):
+                reusable_fps.append(fp)
+            else:
+                to_process_fps.append(fp)
+
+        n_deleted = len(set(previous.keys()) - set(groups.keys()))
+        logger.info(
+            f"PP incremental: {len(reusable_fps)} reused, "
+            f"{len(to_process_fps)} to process, {n_deleted} deleted"
+        )
+
+        # Collect reused sample dicts from previous results
+        reused: dict[str, List[dict]] = {
+            fp: previous[fp] for fp in reusable_fps if fp in previous
+        }
+
+        if not to_process_fps:
+            logger.info("No document changes detected, reusing all previous results")
+            merged_dicts = merge_results(reused, [], current_fps)
+            merged_samples = [MultimodalSample.from_dict(d) for d in merged_dicts]
+            save_samples(merged_samples, self.output_config.output_path)
+            return merged_samples
+
+        # Collect samples to process
+        to_process_set = set(to_process_fps)
+        samples_to_process = [
+            s
+            for s in samples
+            if s.metadata.get("file_path", "__unknown__") in to_process_set
+        ]
+
+        # Run through pipeline
+        processed = samples_to_process
+        for i, processor in enumerate(self.post_processors):
+            tmp_save_path = None
+            if self.output_config.save_each_step:
+                tmp_save_path = os.path.join(
+                    output_dir,
+                    f"{i + 1}___{processor.name}_incremental.jsonl",
+                )
+            processed = processor.batch_process(
+                processed,
+                tmp_save_path=tmp_save_path,
+                save_every=self.output_config.save_every,
+            )
+
+        # Enrich newly processed with processed_at
+        processed_at = datetime.now().isoformat()
+        for sample in processed:
+            sample.metadata["processed_at"] = processed_at
+
+        # Convert processed to dicts and merge with reused
+        new_dicts = [s.to_dict() for s in processed]
+        merged_dicts = merge_results(reused, new_dicts, current_fps)
+
+        # Convert merged dicts back to MultimodalSample and save
+        merged_samples = [MultimodalSample.from_dict(d) for d in merged_dicts]
+        save_samples(merged_samples, self.output_config.output_path)
+        return merged_samples

--- a/src/mmore/process/post_processor/pipeline.py
+++ b/src/mmore/process/post_processor/pipeline.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 from ...type import MultimodalSample
 from ..previous_results import (
     is_reusable_postprocess,
-    load_previous_results,
+    load_previous_postprocess_results,
     merge_results,
 )
 from ..utils import save_samples
@@ -125,28 +125,20 @@ class PPPipeline:
         """Run processors only on samples from new/changed source documents."""
         output_dir = os.path.dirname(self.output_config.output_path) or "."
 
-        previous = load_previous_results(self.previous_results_path)
+        previous = load_previous_postprocess_results(self.previous_results_path)
 
         # Group input samples by file_path
-        groups: dict[str, List[MultimodalSample]] = {}
+        index: dict[str, MultimodalSample] = {}
         for sample in samples:
-            fp = sample.metadata["file_path"]
-            groups.setdefault(fp, []).append(sample)
+            index[sample.metadata["file_path"]] = sample
 
-        current_file_paths = set(groups.keys())
+        current_file_paths = set(index.keys())
 
-        # For each group, get max(processed_at) from input samples
         reusable_file_paths: set[str] = set()
         to_process_file_paths: set[str] = set()
-        for fp, group_samples in groups.items():
-            sample_timestamps = [
-                s.metadata.get("processed_at")
-                for s in group_samples
-                if s.metadata.get("processed_at")
-            ]
-            if sample_timestamps:
-                input_processed_at = max(sample_timestamps)
-            else:
+        for fp, sample in index.items():
+            input_processed_at = sample.metadata.get("processed_at")
+            if input_processed_at is None:
                 # When no processed_at on input, post process it as a new one
                 to_process_file_paths.add(fp)
                 continue
@@ -156,7 +148,7 @@ class PPPipeline:
             else:
                 to_process_file_paths.add(fp)
 
-        n_deleted = len(set(previous.keys()) - set(groups.keys()))
+        n_deleted = len(set(previous.keys()) - set(index.keys()))
         logger.info(
             f"Post-process pipeline: {len(reusable_file_paths)} reused, "
             f"{len(to_process_file_paths)} to process, {n_deleted} deleted"
@@ -174,7 +166,7 @@ class PPPipeline:
             return merged_samples
 
         # Collect samples to process
-        samples_to_process = [s for fp in to_process_file_paths for s in groups[fp]]
+        samples_to_process = [index[fp] for fp in to_process_file_paths]
 
         # Run through pipeline
         processed = samples_to_process

--- a/src/mmore/process/post_processor/pipeline.py
+++ b/src/mmore/process/post_processor/pipeline.py
@@ -154,7 +154,7 @@ class PPPipeline:
 
         # Collect reused samples from previous results
         reused: dict[str, List[MultimodalSample]] = {
-            fp: previous[fp] for fp in reusable_file_paths
+            fp: previous[fp] for fp in sorted(reusable_file_paths)
         }
 
         if not to_process_file_paths:
@@ -163,7 +163,7 @@ class PPPipeline:
             return merged_samples
 
         # Collect samples to process
-        samples_to_process = [index[fp] for fp in to_process_file_paths]
+        samples_to_process = [index[fp] for fp in sorted(to_process_file_paths)]
 
         # Run through pipeline
         processed = samples_to_process

--- a/src/mmore/process/previous_results.py
+++ b/src/mmore/process/previous_results.py
@@ -3,51 +3,52 @@ import os
 from datetime import datetime
 from typing import Dict, List
 
+from ..type import MultimodalSample
 
-def load_previous_results(path: str) -> Dict[str, List[dict]]:
+
+def load_previous_results(path: str) -> Dict[str, List[MultimodalSample]]:
     """Load a JSONL file and index samples by ``metadata.file_path``.
 
     Args:
         path: Absolute path to the JSONL file produced by a previous run.
 
     Returns:
-        A dict mapping each ``file_path`` string to the list of sample dicts
+        A dict mapping each ``file_path`` string to the list of samples
         whose ``metadata.file_path`` equals that key.
 
     Raises:
-        FileNotFoundError: If *path* does not exist on disk.
+        FileNotFoundError: If path does not exist on disk.
     """
     if not os.path.exists(path):
         raise FileNotFoundError(f"Previous results file not found: {path}")
 
-    index: Dict[str, List[dict]] = {}
+    index: Dict[str, List[MultimodalSample]] = {}
     with open(path, "r") as f:
         for line in f:
             line = line.strip()
             if not line:
                 continue
-            sample = json.loads(line)
-            file_path = sample.get("metadata", {}).get("file_path", "__unknown__")
-            index.setdefault(file_path, []).append(sample)
+            sample = MultimodalSample.from_dict(json.loads(line))
+            index.setdefault(sample.metadata["file_path"], []).append(sample)
     return index
 
 
 def is_reusable_process(
-    file_path: str, previous_results: Dict[str, List[dict]]
+    file_path: str, previous_results: Dict[str, List[MultimodalSample]]
 ) -> bool:
-    """Decide whether the process-stage cache for *file_path* is still valid.
+    """Decide whether the process-stage cache for ``file_path`` is still valid.
 
     A cached result is considered valid when the source file has not been
     modified since it was last processed, i.e.::
 
-        current_mtime <= max(processed_at for each cached sample)
+        file_mtime <= max(processed_at for each cached sample)
 
     Args:
         file_path: Path to the source file on disk.
         previous_results: Index returned by :func:`load_previous_results`.
 
     Returns:
-        ``True`` if the cache is usable; ``False`` otherwise.
+        ``True`` if the cache is usable, ``False`` otherwise.
     """
     if file_path not in previous_results:
         return False
@@ -57,38 +58,36 @@ def is_reusable_process(
         return False
 
     timestamps = [
-        s["metadata"]["processed_at"]
-        for s in samples
-        if s.get("metadata", {}).get("processed_at")
+        s.metadata["processed_at"] for s in samples if s.metadata.get("processed_at")
     ]
     if not timestamps:
         return False
 
     max_processed_at = max(datetime.fromisoformat(t) for t in timestamps)
-    mtime = datetime.fromtimestamp(os.path.getmtime(file_path))
-    return mtime <= max_processed_at
+    file_mtime = datetime.fromtimestamp(os.path.getmtime(file_path))
+    return file_mtime <= max_processed_at
 
 
 def is_reusable_postprocess(
     file_path: str,
     input_processed_at: str,
-    previous_results: Dict[str, List[dict]],
+    previous_results: Dict[str, List[MultimodalSample]],
 ) -> bool:
-    """Decide whether the post-process-stage cache for *file_path* is still valid.
+    """Decide whether the post-process-stage cache for ``file_path`` is still valid.
 
-    A cached result is considered valid when the post-processor ran *after* the
+    A cached result is considered valid when the post-processor ran after the
     process stage produced its output, i.e.::
 
         input_processed_at <= max(processed_at for each cached sample)
 
     Args:
         file_path: The source-document path used as the grouping key.
-        input_processed_at: ISO 8601 timestamp of when the process stage last
-            produced output for this file.
+        input_processed_at: ISO timestamp of when the process stage last produced an
+            output for this file.
         previous_results: Index returned by :func:`load_previous_results`.
 
     Returns:
-        ``True`` if the cache is usable; ``False`` otherwise.
+        ``True`` if the cache is usable, ``False`` otherwise.
     """
     if file_path not in previous_results:
         return False
@@ -98,47 +97,39 @@ def is_reusable_postprocess(
         return False
 
     timestamps = [
-        s["metadata"]["processed_at"]
-        for s in samples
-        if s.get("metadata", {}).get("processed_at")
+        s.metadata["processed_at"] for s in samples if s.metadata.get("processed_at")
     ]
     if not timestamps:
         return False
 
-    max_cached_at = max(datetime.fromisoformat(t) for t in timestamps)
-    input_dt = datetime.fromisoformat(input_processed_at)
-    return input_dt <= max_cached_at
+    max_processed_at = max(datetime.fromisoformat(t) for t in timestamps)
+    return datetime.fromisoformat(input_processed_at) <= max_processed_at
 
 
 def merge_results(
-    reused: Dict[str, List[dict]],
-    new_results: List[dict],
+    reused: Dict[str, List[MultimodalSample]],
+    new_results: List[MultimodalSample],
     current_file_paths: set,
-) -> List[dict]:
-    """Combine reused samples and newly processed samples into a flat list.
-
-    Entries whose ``metadata.file_path`` is **not** in *current_file_paths* are
-    silently dropped so that output for deleted files does not accumulate.
+) -> List[MultimodalSample]:
+    """Combine reused samples and newly processed samples into a list.
 
     Args:
-        reused: Mapping of ``file_path`` → list of cached sample dicts to keep.
-        new_results: Flat list of freshly processed sample dicts.
-        current_file_paths: Set of file paths that currently exist (i.e. were
-            present in the crawl that triggered this run).
+        reused: Dictionary mapping ``file_path`` to a list of saved samples to keep.
+        new_results: List of newly processed samples.
+        current_file_paths: Set of source file paths present in the current run.
 
     Returns:
-        A flat list of sample dicts containing valid cached entries followed by
-        newly processed entries, with deleted-file entries removed.
+        A list of samples containing reused entries followed by newly processed
+        ones, with deleted-file entries removed.
     """
-    merged: List[dict] = []
+    merged: List[MultimodalSample] = []
 
     for file_path, samples in reused.items():
         if file_path in current_file_paths:
             merged.extend(samples)
 
     for sample in new_results:
-        fp = sample.get("metadata", {}).get("file_path", "__unknown__")
-        if fp in current_file_paths:
+        if sample.metadata["file_path"] in current_file_paths:
             merged.append(sample)
 
     return merged

--- a/src/mmore/process/previous_results.py
+++ b/src/mmore/process/previous_results.py
@@ -1,0 +1,144 @@
+import json
+import os
+from datetime import datetime
+from typing import Dict, List
+
+
+def load_previous_results(path: str) -> Dict[str, List[dict]]:
+    """Load a JSONL file and index samples by ``metadata.file_path``.
+
+    Args:
+        path: Absolute path to the JSONL file produced by a previous run.
+
+    Returns:
+        A dict mapping each ``file_path`` string to the list of sample dicts
+        whose ``metadata.file_path`` equals that key.
+
+    Raises:
+        FileNotFoundError: If *path* does not exist on disk.
+    """
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"Previous results file not found: {path}")
+
+    index: Dict[str, List[dict]] = {}
+    with open(path, "r") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            sample = json.loads(line)
+            file_path = sample.get("metadata", {}).get("file_path", "__unknown__")
+            index.setdefault(file_path, []).append(sample)
+    return index
+
+
+def is_reusable_process(
+    file_path: str, previous_results: Dict[str, List[dict]]
+) -> bool:
+    """Decide whether the process-stage cache for *file_path* is still valid.
+
+    A cached result is considered valid when the source file has not been
+    modified since it was last processed, i.e.::
+
+        current_mtime <= max(processed_at for each cached sample)
+
+    Args:
+        file_path: Path to the source file on disk.
+        previous_results: Index returned by :func:`load_previous_results`.
+
+    Returns:
+        ``True`` if the cache is usable; ``False`` otherwise.
+    """
+    if file_path not in previous_results:
+        return False
+
+    samples = previous_results[file_path]
+    if not samples:
+        return False
+
+    timestamps = [
+        s["metadata"]["processed_at"]
+        for s in samples
+        if s.get("metadata", {}).get("processed_at")
+    ]
+    if not timestamps:
+        return False
+
+    max_processed_at = max(datetime.fromisoformat(t) for t in timestamps)
+    mtime = datetime.fromtimestamp(os.path.getmtime(file_path))
+    return mtime <= max_processed_at
+
+
+def is_reusable_postprocess(
+    file_path: str,
+    input_processed_at: str,
+    previous_results: Dict[str, List[dict]],
+) -> bool:
+    """Decide whether the post-process-stage cache for *file_path* is still valid.
+
+    A cached result is considered valid when the post-processor ran *after* the
+    process stage produced its output, i.e.::
+
+        input_processed_at <= max(processed_at for each cached sample)
+
+    Args:
+        file_path: The source-document path used as the grouping key.
+        input_processed_at: ISO 8601 timestamp of when the process stage last
+            produced output for this file.
+        previous_results: Index returned by :func:`load_previous_results`.
+
+    Returns:
+        ``True`` if the cache is usable; ``False`` otherwise.
+    """
+    if file_path not in previous_results:
+        return False
+
+    samples = previous_results[file_path]
+    if not samples:
+        return False
+
+    timestamps = [
+        s["metadata"]["processed_at"]
+        for s in samples
+        if s.get("metadata", {}).get("processed_at")
+    ]
+    if not timestamps:
+        return False
+
+    max_cached_at = max(datetime.fromisoformat(t) for t in timestamps)
+    input_dt = datetime.fromisoformat(input_processed_at)
+    return input_dt <= max_cached_at
+
+
+def merge_results(
+    reused: Dict[str, List[dict]],
+    new_results: List[dict],
+    current_file_paths: set,
+) -> List[dict]:
+    """Combine reused samples and newly processed samples into a flat list.
+
+    Entries whose ``metadata.file_path`` is **not** in *current_file_paths* are
+    silently dropped so that output for deleted files does not accumulate.
+
+    Args:
+        reused: Mapping of ``file_path`` → list of cached sample dicts to keep.
+        new_results: Flat list of freshly processed sample dicts.
+        current_file_paths: Set of file paths that currently exist (i.e. were
+            present in the crawl that triggered this run).
+
+    Returns:
+        A flat list of sample dicts containing valid cached entries followed by
+        newly processed entries, with deleted-file entries removed.
+    """
+    merged: List[dict] = []
+
+    for file_path, samples in reused.items():
+        if file_path in current_file_paths:
+            merged.extend(samples)
+
+    for sample in new_results:
+        fp = sample.get("metadata", {}).get("file_path", "__unknown__")
+        if fp in current_file_paths:
+            merged.append(sample)
+
+    return merged

--- a/src/mmore/process/previous_results.py
+++ b/src/mmore/process/previous_results.py
@@ -1,135 +1,120 @@
 import json
+import logging
 import os
 from datetime import datetime
-from typing import Dict, List
+from typing import Dict, List, Set
 
 from ..type import MultimodalSample
 
+logger = logging.getLogger(__name__)
 
-def load_previous_results(path: str) -> Dict[str, List[MultimodalSample]]:
-    """Load a JSONL file and index samples by ``metadata.file_path``.
 
-    Args:
-        path: Absolute path to the JSONL file produced by a previous run.
-
-    Returns:
-        A dict mapping each ``file_path`` string to the list of samples
-        whose ``metadata.file_path`` equals that key.
-
-    Raises:
-        FileNotFoundError: If path does not exist on disk.
-    """
+def _iter_samples_jsonl(path: str):
+    """Helper function to stream line by line a JSONL to avoid loading it fully in memory."""
     if not os.path.exists(path):
         raise FileNotFoundError(f"Previous results file not found: {path}")
-
-    index: Dict[str, List[MultimodalSample]] = {}
     with open(path, "r") as f:
         for line in f:
             line = line.strip()
             if not line:
                 continue
-            sample = MultimodalSample.from_dict(json.loads(line))
-            index.setdefault(sample.metadata["file_path"], []).append(sample)
+            yield MultimodalSample.from_dict(json.loads(line))
+
+
+def load_previous_process_results(path: str) -> Dict[str, MultimodalSample]:
+    """Index samples by ``metadata.file_path`` for the processing pipeline,
+    keeping the latest ``processed_at`` if there are any duplicates."""
+    samples_by_file_path: Dict[str, List[MultimodalSample]] = {}
+    for sample in _iter_samples_jsonl(path):
+        samples_by_file_path.setdefault(sample.metadata["file_path"], []).append(sample)
+
+    index: Dict[str, MultimodalSample] = {}
+    for file_path, samples in samples_by_file_path.items():
+        if len(samples) > 1:
+            logger.warning(
+                "Duplicate samples for file_path %s: keeping latest processed_at, "
+                "dropping %d",
+                file_path,
+                len(samples) - 1,
+            )
+
+        index[file_path] = max(
+            samples,
+            key=lambda s: datetime.fromisoformat(s.metadata["processed_at"])
+            if s.metadata.get("processed_at") is not None
+            else datetime.min,
+        )
     return index
 
 
-def is_reusable_process(
-    file_path: str, previous_results: Dict[str, List[MultimodalSample]]
-) -> bool:
-    """Decide whether the process-stage cache for ``file_path`` is still valid.
+def load_previous_postprocess_results(
+    path: str,
+) -> Dict[str, List[MultimodalSample]]:
+    """Index samples by ``metadata.file_path`` for the post-processing pipeline."""
+    index: Dict[str, List[MultimodalSample]] = {}
+    for sample in _iter_samples_jsonl(path):
+        index.setdefault(sample.metadata["file_path"], []).append(sample)
+    return index
 
-    A cached result is considered valid when the source file has not been
-    modified since it was last processed, i.e.::
 
-        file_mtime <= max(processed_at for each cached sample)
+def is_reusable_process(file_path: str, previous: Dict[str, MultimodalSample]) -> bool:
+    """Check whether the previous processed sample the given file can be reused.
 
-    Args:
-        file_path: Path to the source file on disk.
-        previous_results: Index returned by :func:`load_previous_results`.
-
-    Returns:
-        ``True`` if the cache is usable, ``False`` otherwise.
+    Conditions (all required):
+    - ``file_path`` is present in ``previous``
+    - the cached sample has a ``processed_at`` timestamp
+    - the source file has not been modified since (``file_mtime <= processed_at``)
     """
-    if file_path not in previous_results:
+    sample = previous.get(file_path)
+    if sample is None:
         return False
 
-    samples = previous_results[file_path]
-    if not samples:
+    processed_at_str = sample.metadata.get("processed_at")
+    if processed_at_str is None:
         return False
 
-    timestamps = [
-        s.metadata["processed_at"] for s in samples if s.metadata.get("processed_at")
-    ]
-    if not timestamps:
-        return False
-
-    max_processed_at = max(datetime.fromisoformat(t) for t in timestamps)
+    processed_at = datetime.fromisoformat(processed_at_str)
     file_mtime = datetime.fromtimestamp(os.path.getmtime(file_path))
-    return file_mtime <= max_processed_at
+    return file_mtime <= processed_at
 
 
 def is_reusable_postprocess(
     file_path: str,
     input_processed_at: str,
-    previous_results: Dict[str, List[MultimodalSample]],
+    previous: Dict[str, List[MultimodalSample]],
 ) -> bool:
-    """Decide whether the post-process-stage cache for ``file_path`` is still valid.
+    """Check whether the previous post-processed samples of the given file can be reused.
 
-    A cached result is considered valid when the post-processor ran after the
-    process stage produced its output, i.e.::
-
-        input_processed_at <= max(processed_at for each cached sample)
-
-    Args:
-        file_path: The source-document path used as the grouping key.
-        input_processed_at: ISO timestamp of when the process stage last produced an
-            output for this file.
-        previous_results: Index returned by :func:`load_previous_results`.
-
-    Returns:
-        ``True`` if the cache is usable, ``False`` otherwise.
+    Conditions (all required):
+    - ``file_path`` has at least one cached sample in ``previous``
+    - every cached sample has a ``processed_at`` timestamp
+    - ``input_processed_at <= min(cached processed_at)``
     """
-    if file_path not in previous_results:
-        return False
-
-    samples = previous_results[file_path]
+    samples = previous.get(file_path)
     if not samples:
         return False
 
-    timestamps = [
-        s.metadata["processed_at"] for s in samples if s.metadata.get("processed_at")
-    ]
-    if not timestamps:
-        return False
+    timestamps: List[datetime] = []
+    for s in samples:
+        timestamp_str = s.metadata.get("processed_at")
+        if timestamp_str is None:
+            return False
+        timestamps.append(datetime.fromisoformat(timestamp_str))
 
-    max_processed_at = max(datetime.fromisoformat(t) for t in timestamps)
-    return datetime.fromisoformat(input_processed_at) <= max_processed_at
+    return datetime.fromisoformat(input_processed_at) <= min(timestamps)
 
 
 def merge_results(
     reused: Dict[str, List[MultimodalSample]],
     new_results: List[MultimodalSample],
-    current_file_paths: set,
+    current_file_paths: Set[str],
 ) -> List[MultimodalSample]:
-    """Combine reused samples and newly processed samples into a list.
-
-    Args:
-        reused: Dictionary mapping ``file_path`` to a list of saved samples to keep.
-        new_results: List of newly processed samples.
-        current_file_paths: Set of source file paths present in the current run.
-
-    Returns:
-        A list of samples containing reused entries followed by newly processed
-        ones, with deleted-file entries removed.
-    """
+    """Combine reused and newly processed/post-processed samples."""
     merged: List[MultimodalSample] = []
-
     for file_path, samples in reused.items():
         if file_path in current_file_paths:
             merged.extend(samples)
-
     for sample in new_results:
         if sample.metadata["file_path"] in current_file_paths:
             merged.append(sample)
-
     return merged

--- a/src/mmore/run_process.py
+++ b/src/mmore/run_process.py
@@ -44,8 +44,7 @@ class ProcessInference:
 
 
 def _clear_processor_results(output_path):
-    """Remove per-processor results.jsonl files before a fresh dispatch.
-    Needed because MultimodalSample.to_jsonl uses append mode."""
+    """Remove per-processor results.jsonl files before a fresh dispatch."""
     processors_dir = os.path.join(output_path, "processors")
     if not os.path.isdir(processors_dir):
         return
@@ -56,7 +55,7 @@ def _clear_processor_results(output_path):
 
 
 def _build_merged_results(output_path, reused_samples=None):
-    """Build merged_results.jsonl from per-processor results + reused samples."""
+    """Build merged_results.jsonl from per-processor results and reused samples."""
     merged_output_path = os.path.join(output_path, "merged")
     output_file = os.path.join(merged_output_path, "merged_results.jsonl")
     os.makedirs(merged_output_path, exist_ok=True)
@@ -73,7 +72,8 @@ def _build_merged_results(output_path, reused_samples=None):
                         if line:
                             new_results.append(json.loads(line))
 
-    all_results = (reused_samples or []) + new_results
+    reused_dicts = [s.to_dict() for s in (reused_samples or [])]
+    all_results = reused_dicts + new_results
 
     with open(output_file, "w") as f:
         for sample in all_results:
@@ -144,7 +144,7 @@ def process(config_file: str):
     crawl_time = crawl_end_time - crawl_start_time
     logger.info(f"Crawling completed in {crawl_time:.2f} seconds")
 
-    # Collect all crawled file paths for deletion filtering
+    # Collect all crawled file paths (excluding this way deleted files)
     all_crawled_paths = {
         fd.file_path
         for file_list in crawl_result.file_paths.values()
@@ -162,7 +162,7 @@ def process(config_file: str):
             if is_reusable_process(fp, previous):
                 reusable_paths.add(fp)
 
-        # Collect reused samples (only for files still present in the crawl)
+        # Collect reused samples
         for fp in reusable_paths:
             reused_samples.extend(previous[fp])
 
@@ -174,55 +174,42 @@ def process(config_file: str):
 
         n_deleted = len(set(previous.keys()) - all_crawled_paths)
         logger.info(
-            f"Change detection: {len(reusable_paths)} reused, "
+            f"Process pipeline: {len(reusable_paths)} reused, "
             f"{len(crawl_result)} to process, {n_deleted} deleted"
         )
 
     output_path = config.dispatcher_config.output_path
 
     if len(crawl_result) == 0 and not reused_samples:
-        logger.warning("\u26a0\ufe0f Found no file to process")
+        logger.warning("⚠️ Found no file to process")
         return
 
-    if len(crawl_result) == 0 and reused_samples:
-        logger.info("No new files to process; writing reused samples only.")
-        _clear_processor_results(output_path)
-        _build_merged_results(output_path, reused_samples)
-        if ggdrive_downloader:
-            ggdrive_downloader.remove_downloads()
-        overall_end_time = time.time()
-        overall_time = overall_end_time - overall_start_time
-        logger.info(f"Total execution time: {overall_time:.2f} seconds")
-        return
-
-    dispatcher_config: DispatcherConfig = config.dispatcher_config
-
-    url = dispatcher_config.dashboard_backend_url
-    DashboardClient(url).init_db(len(crawl_result))
-
-    logger.info(f"Using dispatcher configuration: {dispatcher_config}")
-
-    # Clear per-processor files before dispatch — to_jsonl uses append mode,
-    # so stale files from a prior run would cause duplicates.
+    # Clear per-processor files as to_jsonl uses append mode
     _clear_processor_results(output_path)
 
-    dispatcher = Dispatcher(result=crawl_result, config=dispatcher_config)
+    if len(crawl_result) > 0:
+        dispatcher_config: DispatcherConfig = config.dispatcher_config
+        DashboardClient(dispatcher_config.dashboard_backend_url).init_db(
+            len(crawl_result)
+        )
+        logger.info(f"Using dispatcher configuration: {dispatcher_config}")
 
-    dispatch_start_time = time.time()
-    list(dispatcher())
-
-    dispatch_end_time = time.time()
-    dispatch_time = dispatch_end_time - dispatch_start_time
-
-    logger.info(f"Dispatching and processing completed in {dispatch_time:.2f} seconds")
+        dispatcher = Dispatcher(result=crawl_result, config=dispatcher_config)
+        dispatch_start_time = time.time()
+        list(dispatcher())
+        dispatch_time = time.time() - dispatch_start_time
+        logger.info(
+            f"Dispatching and processing completed in {dispatch_time:.2f} seconds"
+        )
+    else:
+        logger.info("No new files to process, reusing previous samples only.")
 
     _build_merged_results(output_path, reused_samples if previous is not None else None)
 
     if ggdrive_downloader:
         ggdrive_downloader.remove_downloads()
 
-    overall_end_time = time.time()
-    overall_time = overall_end_time - overall_start_time
+    overall_time = time.time() - overall_start_time
     logger.info(f"Total execution time: {overall_time:.2f} seconds")
 
 

--- a/src/mmore/run_process.py
+++ b/src/mmore/run_process.py
@@ -51,29 +51,27 @@ def _write_merged_results(output_path, reused_samples, dispatched=True):
     output_file = os.path.join(merged_output_path, "merged_results.jsonl")
     os.makedirs(merged_output_path, exist_ok=True)
 
-    new_results = []
-    if dispatched:
-        processors_dir = os.path.join(output_path, "processors")
-        if os.path.isdir(processors_dir):
-            for processor_name in sorted(os.listdir(processors_dir)):
-                results_path = os.path.join(
-                    processors_dir, processor_name, "results.jsonl"
-                )
-                if os.path.exists(results_path):
-                    with open(results_path, "r") as f:
-                        for line in f:
-                            line = line.strip()
-                            if line:
-                                new_results.append(json.loads(line))
-
-    reused_dicts = [s.to_dict() for s in (reused_samples or [])]
-    all_results = reused_dicts + new_results
-
+    total_results = 0
     with open(output_file, "w") as f:
-        for sample in all_results:
-            f.write(json.dumps(sample) + "\n")
+        for sample in reused_samples or []:
+            f.write(json.dumps(sample.to_dict()) + "\n")
+            total_results += 1
+        if dispatched:
+            processors_dir = os.path.join(output_path, "processors")
+            if os.path.isdir(processors_dir):
+                for processor_name in sorted(os.listdir(processors_dir)):
+                    results_path = os.path.join(
+                        processors_dir, processor_name, "results.jsonl"
+                    )
+                    if os.path.exists(results_path):
+                        with open(results_path, "r") as processor_file:
+                            for line in processor_file:
+                                stripped_line = line.strip()
+                                if stripped_line:
+                                    f.write(stripped_line + "\n")
+                                    total_results += 1
 
-    logger.info(f"Merged results ({len(all_results)} samples) saved to {output_file}")
+    logger.info(f"Merged results ({total_results} samples) saved to {output_file}")
 
 
 @profile_function()

--- a/src/mmore/run_process.py
+++ b/src/mmore/run_process.py
@@ -42,7 +42,6 @@ class ProcessInference:
     data_path: Union[List[str], str]
     google_drive_ids: List[str]
     dispatcher_config: DispatcherConfig
-    skip_already_processed: bool = False
     previous_results: Optional[str] = None
 
 
@@ -134,7 +133,7 @@ def process(config_file: str):
     crawler = Crawler(config=crawler_config)
 
     crawl_start_time = time.time()
-    crawl_result = crawler.crawl(skip_already_processed=config.skip_already_processed)
+    crawl_result = crawler.crawl()
     crawl_end_time = time.time()
     crawl_time = crawl_end_time - crawl_start_time
     logger.info(f"Crawling completed in {crawl_time:.2f} seconds")

--- a/src/mmore/run_process.py
+++ b/src/mmore/run_process.py
@@ -1,9 +1,10 @@
 import argparse
+import json
 import logging
 import os
 import time
 from dataclasses import dataclass
-from typing import List, Union
+from typing import List, Optional, Union
 
 import click
 import torch
@@ -12,8 +13,8 @@ from mmore.dashboard.backend.client import DashboardClient
 from mmore.process.crawler import Crawler, CrawlerConfig
 from mmore.process.dispatcher import Dispatcher, DispatcherConfig
 from mmore.process.drive_download import GoogleDriveDownloader
+from mmore.process.previous_results import is_reusable_process, load_previous_results
 from mmore.profiler import enable_profiling_from_env, profile_function
-from mmore.type import MultimodalSample
 from mmore.utils import load_config
 
 PROCESS_EMOJI = "🚀"
@@ -39,6 +40,46 @@ class ProcessInference:
     google_drive_ids: List[str]
     dispatcher_config: DispatcherConfig
     skip_already_processed: bool = False
+    previous_results: Optional[str] = None
+
+
+def _clear_processor_results(output_path):
+    """Remove per-processor results.jsonl files before a fresh dispatch.
+    Needed because MultimodalSample.to_jsonl uses append mode."""
+    processors_dir = os.path.join(output_path, "processors")
+    if not os.path.isdir(processors_dir):
+        return
+    for processor_name in os.listdir(processors_dir):
+        results_path = os.path.join(processors_dir, processor_name, "results.jsonl")
+        if os.path.exists(results_path):
+            os.remove(results_path)
+
+
+def _build_merged_results(output_path, reused_samples=None):
+    """Build merged_results.jsonl from per-processor results + reused samples."""
+    merged_output_path = os.path.join(output_path, "merged")
+    output_file = os.path.join(merged_output_path, "merged_results.jsonl")
+    os.makedirs(merged_output_path, exist_ok=True)
+
+    new_results = []
+    processors_dir = os.path.join(output_path, "processors")
+    if os.path.isdir(processors_dir):
+        for processor_name in sorted(os.listdir(processors_dir)):
+            results_path = os.path.join(processors_dir, processor_name, "results.jsonl")
+            if os.path.exists(results_path):
+                with open(results_path, "r") as f:
+                    for line in f:
+                        line = line.strip()
+                        if line:
+                            new_results.append(json.loads(line))
+
+    all_results = (reused_samples or []) + new_results
+
+    with open(output_file, "w") as f:
+        for sample in all_results:
+            f.write(json.dumps(sample) + "\n")
+
+    logger.info(f"Merged results ({len(all_results)} samples) saved to {output_file}")
 
 
 @profile_function()
@@ -103,8 +144,55 @@ def process(config_file: str):
     crawl_time = crawl_end_time - crawl_start_time
     logger.info(f"Crawling completed in {crawl_time:.2f} seconds")
 
-    if len(crawl_result) == 0:
-        logger.warning("⚠️ Found no file to process")
+    # Collect all crawled file paths for deletion filtering
+    all_crawled_paths = {
+        fd.file_path
+        for file_list in crawl_result.file_paths.values()
+        for fd in file_list
+    }
+
+    previous = None
+    reused_samples = []
+    reusable_paths = set()
+
+    if config.previous_results:
+        previous = load_previous_results(config.previous_results)
+
+        for fp in all_crawled_paths:
+            if is_reusable_process(fp, previous):
+                reusable_paths.add(fp)
+
+        # Collect reused samples (only for files still present in the crawl)
+        for fp in reusable_paths:
+            reused_samples.extend(previous[fp])
+
+        # Remove reusable files from crawl_result so they are not re-processed
+        crawl_result.file_paths = {
+            root_dir: [fd for fd in file_list if fd.file_path not in reusable_paths]
+            for root_dir, file_list in crawl_result.file_paths.items()
+        }
+
+        n_deleted = len(set(previous.keys()) - all_crawled_paths)
+        logger.info(
+            f"Change detection: {len(reusable_paths)} reused, "
+            f"{len(crawl_result)} to process, {n_deleted} deleted"
+        )
+
+    output_path = config.dispatcher_config.output_path
+
+    if len(crawl_result) == 0 and not reused_samples:
+        logger.warning("\u26a0\ufe0f Found no file to process")
+        return
+
+    if len(crawl_result) == 0 and reused_samples:
+        logger.info("No new files to process; writing reused samples only.")
+        _clear_processor_results(output_path)
+        _build_merged_results(output_path, reused_samples)
+        if ggdrive_downloader:
+            ggdrive_downloader.remove_downloads()
+        overall_end_time = time.time()
+        overall_time = overall_end_time - overall_start_time
+        logger.info(f"Total execution time: {overall_time:.2f} seconds")
         return
 
     dispatcher_config: DispatcherConfig = config.dispatcher_config
@@ -113,25 +201,22 @@ def process(config_file: str):
     DashboardClient(url).init_db(len(crawl_result))
 
     logger.info(f"Using dispatcher configuration: {dispatcher_config}")
+
+    # Clear per-processor files before dispatch — to_jsonl uses append mode,
+    # so stale files from a prior run would cause duplicates.
+    _clear_processor_results(output_path)
+
     dispatcher = Dispatcher(result=crawl_result, config=dispatcher_config)
 
     dispatch_start_time = time.time()
-    results = list(dispatcher())
+    list(dispatcher())
 
     dispatch_end_time = time.time()
     dispatch_time = dispatch_end_time - dispatch_start_time
 
     logger.info(f"Dispatching and processing completed in {dispatch_time:.2f} seconds")
 
-    output_path = config.dispatcher_config.output_path
-    merged_output_path = os.path.join(output_path, "merged")
-    output_file = os.path.join(merged_output_path, "merged_results.jsonl")
-
-    os.makedirs(merged_output_path, exist_ok=True)
-    for res in results:
-        MultimodalSample.to_jsonl(output_file, res)
-
-    logger.info(f"Merged results ({len(results)} items) saved to {output_file}")
+    _build_merged_results(output_path, reused_samples if previous is not None else None)
 
     if ggdrive_downloader:
         ggdrive_downloader.remove_downloads()

--- a/src/mmore/run_process.py
+++ b/src/mmore/run_process.py
@@ -136,12 +136,13 @@ def process(config_file: str):
     crawl_time = crawl_end_time - crawl_start_time
     logger.info(f"Crawling completed in {crawl_time:.2f} seconds")
 
-    # Collect all crawled file paths (excluding this way deleted files)
+    # Collect all crawled file paths and urls (excluding this way deleted files)
     all_crawled_paths = {
         fd.file_path
         for file_list in crawl_result.file_paths.values()
         for fd in file_list
     }
+    all_crawled_paths.update(url.file_path for url in crawl_result.urls)
 
     previous = None
     reused_samples = []

--- a/src/mmore/run_process.py
+++ b/src/mmore/run_process.py
@@ -43,34 +43,26 @@ class ProcessInference:
     previous_results: Optional[str] = None
 
 
-def _clear_processor_results(output_path):
-    """Remove per-processor results.jsonl files before a fresh dispatch."""
-    processors_dir = os.path.join(output_path, "processors")
-    if not os.path.isdir(processors_dir):
-        return
-    for processor_name in os.listdir(processors_dir):
-        results_path = os.path.join(processors_dir, processor_name, "results.jsonl")
-        if os.path.exists(results_path):
-            os.remove(results_path)
-
-
-def _build_merged_results(output_path, reused_samples=None):
-    """Build merged_results.jsonl from per-processor results and reused samples."""
+def _write_merged_results(output_path, reused_samples, dispatched=True):
+    """Merge per-processor JSONL files and reused samples into a single output."""
     merged_output_path = os.path.join(output_path, "merged")
     output_file = os.path.join(merged_output_path, "merged_results.jsonl")
     os.makedirs(merged_output_path, exist_ok=True)
 
     new_results = []
-    processors_dir = os.path.join(output_path, "processors")
-    if os.path.isdir(processors_dir):
-        for processor_name in sorted(os.listdir(processors_dir)):
-            results_path = os.path.join(processors_dir, processor_name, "results.jsonl")
-            if os.path.exists(results_path):
-                with open(results_path, "r") as f:
-                    for line in f:
-                        line = line.strip()
-                        if line:
-                            new_results.append(json.loads(line))
+    if dispatched:
+        processors_dir = os.path.join(output_path, "processors")
+        if os.path.isdir(processors_dir):
+            for processor_name in sorted(os.listdir(processors_dir)):
+                results_path = os.path.join(
+                    processors_dir, processor_name, "results.jsonl"
+                )
+                if os.path.exists(results_path):
+                    with open(results_path, "r") as f:
+                        for line in f:
+                            line = line.strip()
+                            if line:
+                                new_results.append(json.loads(line))
 
     reused_dicts = [s.to_dict() for s in (reused_samples or [])]
     all_results = reused_dicts + new_results
@@ -184,10 +176,8 @@ def process(config_file: str):
         logger.warning("⚠️ Found no file to process")
         return
 
-    # Clear per-processor files as to_jsonl uses append mode
-    _clear_processor_results(output_path)
-
-    if len(crawl_result) > 0:
+    dispatched = len(crawl_result) > 0
+    if dispatched:
         dispatcher_config: DispatcherConfig = config.dispatcher_config
         DashboardClient(dispatcher_config.dashboard_backend_url).init_db(
             len(crawl_result)
@@ -204,7 +194,11 @@ def process(config_file: str):
     else:
         logger.info("No new files to process, reusing previous samples only.")
 
-    _build_merged_results(output_path, reused_samples if previous is not None else None)
+    _write_merged_results(
+        output_path,
+        reused_samples if previous is not None else None,
+        dispatched=dispatched,
+    )
 
     if ggdrive_downloader:
         ggdrive_downloader.remove_downloads()

--- a/src/mmore/run_process.py
+++ b/src/mmore/run_process.py
@@ -13,7 +13,7 @@ from mmore.dashboard.backend.client import DashboardClient
 from mmore.process.crawler import Crawler, CrawlerConfig
 from mmore.process.dispatcher import Dispatcher, DispatcherConfig
 from mmore.process.drive_download import GoogleDriveDownloader
-from mmore.process.previous_results import (
+from mmore.process.incremental import (
     is_reusable_process,
     load_previous_process_results,
 )

--- a/src/mmore/run_process.py
+++ b/src/mmore/run_process.py
@@ -155,7 +155,7 @@ def process(config_file: str):
             if is_reusable_process(fp, previous):
                 reusable_paths.add(fp)
 
-        reused_samples = [previous[fp] for fp in reusable_paths]
+        reused_samples = [previous[fp] for fp in sorted(reusable_paths)]
 
         # Remove reusable files from crawl_result so they are not re-processed
         crawl_result.file_paths = {

--- a/src/mmore/run_process.py
+++ b/src/mmore/run_process.py
@@ -13,7 +13,10 @@ from mmore.dashboard.backend.client import DashboardClient
 from mmore.process.crawler import Crawler, CrawlerConfig
 from mmore.process.dispatcher import Dispatcher, DispatcherConfig
 from mmore.process.drive_download import GoogleDriveDownloader
-from mmore.process.previous_results import is_reusable_process, load_previous_results
+from mmore.process.previous_results import (
+    is_reusable_process,
+    load_previous_process_results,
+)
 from mmore.profiler import enable_profiling_from_env, profile_function
 from mmore.utils import load_config
 
@@ -148,15 +151,13 @@ def process(config_file: str):
     reusable_paths = set()
 
     if config.previous_results:
-        previous = load_previous_results(config.previous_results)
+        previous = load_previous_process_results(config.previous_results)
 
         for fp in all_crawled_paths:
             if is_reusable_process(fp, previous):
                 reusable_paths.add(fp)
 
-        # Collect reused samples
-        for fp in reusable_paths:
-            reused_samples.extend(previous[fp])
+        reused_samples = [previous[fp] for fp in reusable_paths]
 
         # Remove reusable files from crawl_result so they are not re-processed
         crawl_result.file_paths = {

--- a/src/mmore/run_process.py
+++ b/src/mmore/run_process.py
@@ -53,7 +53,7 @@ def _write_merged_results(output_path, reused_samples, dispatched=True):
 
     total_results = 0
     with open(output_file, "w") as f:
-        for sample in reused_samples or []:
+        for sample in reused_samples:
             f.write(json.dumps(sample.to_dict()) + "\n")
             total_results += 1
         if dispatched:
@@ -171,11 +171,13 @@ def process(config_file: str):
 
     output_path = config.dispatcher_config.output_path
 
-    if len(crawl_result) == 0 and not reused_samples:
-        logger.warning("⚠️ Found no file to process")
-        return
-
     dispatched = len(crawl_result) > 0
+
+    if not dispatched and not reused_samples:
+        logger.warning("⚠️ Found no file to process")
+        if previous is None:
+            return
+
     if dispatched:
         dispatcher_config: DispatcherConfig = config.dispatcher_config
         DashboardClient(dispatcher_config.dashboard_backend_url).init_db(
@@ -190,12 +192,14 @@ def process(config_file: str):
         logger.info(
             f"Dispatching and processing completed in {dispatch_time:.2f} seconds"
         )
-    else:
+    elif reused_samples:
         logger.info("No new files to process, reusing previous samples only.")
+    else:
+        logger.info("No new files to process and no samples to reuse.")
 
     _write_merged_results(
         output_path,
-        reused_samples if previous is not None else None,
+        reused_samples,
         dispatched=dispatched,
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,29 @@
+import json
+
+import pytest
+
+from mmore.type import MultimodalSample
+
+
+@pytest.fixture
+def make_sample():
+    def _make(file_path: str, text: str = "x", **metadata) -> MultimodalSample:
+        return MultimodalSample.from_dict(
+            {
+                "text": text,
+                "modalities": [],
+                "metadata": {"file_path": file_path, **metadata},
+            }
+        )
+
+    return _make
+
+
+@pytest.fixture
+def write_jsonl():
+    def _write(path: str, samples: list[MultimodalSample]) -> None:
+        with open(path, "w") as f:
+            for s in samples:
+                f.write(json.dumps(s.to_dict()) + "\n")
+
+    return _write

--- a/tests/test_change_detection_postprocess.py
+++ b/tests/test_change_detection_postprocess.py
@@ -1,7 +1,7 @@
 from mmore.process.post_processor.pipeline import OutputConfig, PPPipelineConfig
 from mmore.process.previous_results import (
     is_reusable_postprocess,
-    load_previous_results,
+    load_previous_postprocess_results,
     merge_results,
 )
 
@@ -23,7 +23,7 @@ class TestPostProcessPipelineReuse:
             ],
         )
 
-        previous = load_previous_results(str(prev_path))
+        previous = load_previous_postprocess_results(str(prev_path))
         assert is_reusable_postprocess("/a.pdf", "2026-01-01T00:00:00", previous)
 
     def test_reprocesses_changed_documents(self, tmp_path, make_sample, write_jsonl):
@@ -40,7 +40,7 @@ class TestPostProcessPipelineReuse:
             ],
         )
 
-        previous = load_previous_results(str(prev_path))
+        previous = load_previous_postprocess_results(str(prev_path))
         assert not is_reusable_postprocess("/doc.pdf", "2026-06-01T00:00:00", previous)
 
     def test_processes_new_documents(self):

--- a/tests/test_change_detection_postprocess.py
+++ b/tests/test_change_detection_postprocess.py
@@ -1,9 +1,9 @@
-from mmore.process.post_processor.pipeline import OutputConfig, PPPipelineConfig
-from mmore.process.previous_results import (
+from mmore.process.incremental import (
     is_reusable_postprocess,
     load_previous_postprocess_results,
     merge_results,
 )
+from mmore.process.post_processor.pipeline import OutputConfig, PPPipelineConfig
 
 
 class TestPostProcessPipelineReuse:

--- a/tests/test_change_detection_postprocess.py
+++ b/tests/test_change_detection_postprocess.py
@@ -1,0 +1,103 @@
+import json
+
+from mmore.process.post_processor.pipeline import OutputConfig, PPPipelineConfig
+from mmore.process.previous_results import (
+    is_reusable_postprocess,
+    load_previous_results,
+    merge_results,
+)
+
+
+class TestPostprocessStageReuse:
+    """Test the post-process incremental workflow."""
+
+    def _write_jsonl(self, path, samples):
+        with open(path, "w") as f:
+            for s in samples:
+                f.write(json.dumps(s) + "\n")
+
+    def test_reuses_unchanged_documents(self, tmp_path):
+        """Document groups where input processed_at <= cached processed_at are reused."""
+        prev_path = tmp_path / "prev_pp.jsonl"
+        self._write_jsonl(
+            str(prev_path),
+            [
+                {
+                    "text": "chunked",
+                    "modalities": [],
+                    "metadata": {
+                        "file_path": "/a.pdf",
+                        "processed_at": "2026-06-01T00:00:00",
+                    },
+                },
+            ],
+        )
+
+        previous = load_previous_results(str(prev_path))
+        assert (
+            is_reusable_postprocess("/a.pdf", "2026-01-01T00:00:00", previous) is True
+        )
+
+    def test_reprocesses_changed_documents(self, tmp_path):
+        """Document groups where input processed_at > cached processed_at need reprocessing."""
+        prev_path = tmp_path / "prev_pp.jsonl"
+        self._write_jsonl(
+            str(prev_path),
+            [
+                {
+                    "text": "old chunked",
+                    "modalities": [],
+                    "metadata": {
+                        "file_path": "/a.pdf",
+                        "processed_at": "2026-01-01T00:00:00",
+                    },
+                },
+            ],
+        )
+
+        previous = load_previous_results(str(prev_path))
+        assert (
+            is_reusable_postprocess("/a.pdf", "2026-06-01T00:00:00", previous) is False
+        )
+
+    def test_processes_new_documents(self):
+        """New documents not in previous results are not reusable."""
+        assert is_reusable_postprocess("/new.pdf", "2026-01-01T00:00:00", {}) is False
+
+    def test_drops_deleted_documents(self):
+        """Documents absent from input are dropped from merge."""
+        reused = {
+            "/a.pdf": [
+                {"text": "a", "modalities": [], "metadata": {"file_path": "/a.pdf"}}
+            ],
+            "/gone.pdf": [
+                {
+                    "text": "gone",
+                    "modalities": [],
+                    "metadata": {"file_path": "/gone.pdf"},
+                }
+            ],
+        }
+        current_fps = {"/a.pdf", "/new.pdf"}
+        new = [{"text": "new", "modalities": [], "metadata": {"file_path": "/new.pdf"}}]
+
+        merged = merge_results(reused, new, current_fps)
+        fps = {s["metadata"]["file_path"] for s in merged}
+        assert fps == {"/a.pdf", "/new.pdf"}
+
+
+class TestPPPipelineConfig:
+    def test_previous_results_default_none(self):
+        config = PPPipelineConfig(
+            pp_modules=[],
+            output=OutputConfig(output_path="/tmp/test_mmore_pp.jsonl"),
+        )
+        assert config.previous_results is None
+
+    def test_previous_results_can_be_set(self):
+        config = PPPipelineConfig(
+            pp_modules=[],
+            output=OutputConfig(output_path="/tmp/test_mmore_pp2.jsonl"),
+            previous_results="/path/to/prev.jsonl",
+        )
+        assert config.previous_results == "/path/to/prev.jsonl"

--- a/tests/test_change_detection_postprocess.py
+++ b/tests/test_change_detection_postprocess.py
@@ -1,92 +1,68 @@
-import json
-
 from mmore.process.post_processor.pipeline import OutputConfig, PPPipelineConfig
 from mmore.process.previous_results import (
     is_reusable_postprocess,
     load_previous_results,
     merge_results,
 )
-from mmore.type import MultimodalSample
 
 
-def _sample(file_path: str, **metadata) -> MultimodalSample:
-    return MultimodalSample.from_dict(
-        {
-            "text": "x",
-            "modalities": [],
-            "metadata": {"file_path": file_path, **metadata},
-        }
-    )
+class TestPostProcessPipelineReuse:
+    """Test the post-process pipeline incremental workflow."""
 
-
-class TestPostprocessStageReuse:
-    """Test the post-process incremental workflow."""
-
-    def _write_jsonl(self, path, samples):
-        with open(path, "w") as f:
-            for s in samples:
-                f.write(json.dumps(s) + "\n")
-
-    def test_reuses_unchanged_documents(self, tmp_path):
+    def test_reuses_unchanged_documents(self, tmp_path, make_sample, write_jsonl):
         """Document groups where input processed_at <= cached processed_at are reused."""
         prev_path = tmp_path / "prev_pp.jsonl"
-        self._write_jsonl(
+        write_jsonl(
             str(prev_path),
             [
-                {
-                    "text": "chunked",
-                    "modalities": [],
-                    "metadata": {
-                        "file_path": "/a.pdf",
-                        "processed_at": "2026-06-01T00:00:00",
-                    },
-                },
+                make_sample(
+                    "/a.pdf",
+                    text="chunked",
+                    processed_at="2026-06-01T00:00:00",
+                ),
             ],
         )
 
         previous = load_previous_results(str(prev_path))
-        assert (
-            is_reusable_postprocess("/a.pdf", "2026-01-01T00:00:00", previous) is True
-        )
+        assert is_reusable_postprocess("/a.pdf", "2026-01-01T00:00:00", previous)
 
-    def test_reprocesses_changed_documents(self, tmp_path):
+    def test_reprocesses_changed_documents(self, tmp_path, make_sample, write_jsonl):
         """Document groups where input processed_at > cached processed_at need reprocessing."""
         prev_path = tmp_path / "prev_pp.jsonl"
-        self._write_jsonl(
+        write_jsonl(
             str(prev_path),
             [
-                {
-                    "text": "old chunked",
-                    "modalities": [],
-                    "metadata": {
-                        "file_path": "/a.pdf",
-                        "processed_at": "2026-01-01T00:00:00",
-                    },
-                },
+                make_sample(
+                    "/doc.pdf",
+                    text="old chunked",
+                    processed_at="2026-01-01T00:00:00",
+                ),
             ],
         )
 
         previous = load_previous_results(str(prev_path))
-        assert (
-            is_reusable_postprocess("/a.pdf", "2026-06-01T00:00:00", previous) is False
-        )
+        assert not is_reusable_postprocess("/doc.pdf", "2026-06-01T00:00:00", previous)
 
     def test_processes_new_documents(self):
         """New documents not in previous results are not reusable."""
-        assert is_reusable_postprocess("/new.pdf", "2026-01-01T00:00:00", {}) is False
+        assert not is_reusable_postprocess("/new.pdf", "2026-01-01T00:00:00", {})
 
-    def test_drops_deleted_documents(self):
+    def test_drops_deleted_documents(self, tmp_path, make_sample):
         """Documents absent from input are dropped from merge."""
+        exists = str(tmp_path / "exists.pdf")
+        deleted = str(tmp_path / "deleted.pdf")
+        new_file = str(tmp_path / "new.txt")
+
         reused = {
-            "/a.pdf": [_sample("/a.pdf")],
-            "/gone.pdf": [_sample("/gone.pdf")],
+            exists: [make_sample(exists)],
+            deleted: [make_sample(deleted)],
         }
-        current_fps = {"/a.pdf", "/new.pdf"}
-        new = [_sample("/new.pdf")]
+        new = [make_sample(new_file)]
+        current_fps = {exists, new_file}
 
         merged = merge_results(reused, new, current_fps)
         fps = {s.metadata["file_path"] for s in merged}
-        assert fps == {"/a.pdf", "/new.pdf"}
+        assert fps == {exists, new_file}
 
 
 class TestPPPipelineConfig:

--- a/tests/test_change_detection_postprocess.py
+++ b/tests/test_change_detection_postprocess.py
@@ -6,6 +6,17 @@ from mmore.process.previous_results import (
     load_previous_results,
     merge_results,
 )
+from mmore.type import MultimodalSample
+
+
+def _sample(file_path: str, **metadata) -> MultimodalSample:
+    return MultimodalSample.from_dict(
+        {
+            "text": "x",
+            "modalities": [],
+            "metadata": {"file_path": file_path, **metadata},
+        }
+    )
 
 
 class TestPostprocessStageReuse:
@@ -67,22 +78,14 @@ class TestPostprocessStageReuse:
     def test_drops_deleted_documents(self):
         """Documents absent from input are dropped from merge."""
         reused = {
-            "/a.pdf": [
-                {"text": "a", "modalities": [], "metadata": {"file_path": "/a.pdf"}}
-            ],
-            "/gone.pdf": [
-                {
-                    "text": "gone",
-                    "modalities": [],
-                    "metadata": {"file_path": "/gone.pdf"},
-                }
-            ],
+            "/a.pdf": [_sample("/a.pdf")],
+            "/gone.pdf": [_sample("/gone.pdf")],
         }
         current_fps = {"/a.pdf", "/new.pdf"}
-        new = [{"text": "new", "modalities": [], "metadata": {"file_path": "/new.pdf"}}]
+        new = [_sample("/new.pdf")]
 
         merged = merge_results(reused, new, current_fps)
-        fps = {s["metadata"]["file_path"] for s in merged}
+        fps = {s.metadata["file_path"] for s in merged}
         assert fps == {"/a.pdf", "/new.pdf"}
 
 

--- a/tests/test_change_detection_process.py
+++ b/tests/test_change_detection_process.py
@@ -1,4 +1,4 @@
-from mmore.process.previous_results import (
+from mmore.process.incremental import (
     is_reusable_process,
     load_previous_process_results,
     merge_results,

--- a/tests/test_change_detection_process.py
+++ b/tests/test_change_detection_process.py
@@ -1,115 +1,89 @@
-import json
-
-from mmore.process.dispatcher import DispatcherConfig
 from mmore.process.previous_results import (
     is_reusable_process,
     load_previous_results,
     merge_results,
 )
-from mmore.run_process import ProcessInference
-from mmore.type import MultimodalSample
 
 
-def _sample(file_path, **metadata) -> MultimodalSample:
-    return MultimodalSample.from_dict(
-        {
-            "text": "x",
-            "modalities": [],
-            "metadata": {"file_path": file_path, **metadata},
-        }
-    )
+class TestProcessPipelineReuse:
+    """Test the full process pipeline incremental workflow."""
 
-
-class TestProcessStageReuse:
-    """Test the full process-stage incremental workflow."""
-
-    def _write_jsonl(self, path, samples):
-        with open(path, "w") as f:
-            for s in samples:
-                f.write(json.dumps(s) + "\n")
-
-    def test_skips_unchanged_files(self, tmp_path):
+    def test_skips_unchanged_files(self, tmp_path, make_sample, write_jsonl):
         """Files with mtime <= processed_at are reused."""
         doc = tmp_path / "doc.pdf"
         doc.write_text("content")
 
         prev_path = tmp_path / "prev.jsonl"
-        self._write_jsonl(
+        write_jsonl(
             str(prev_path),
             [
-                {
-                    "text": "old result",
-                    "modalities": [],
-                    "metadata": {
-                        "file_path": str(doc),
-                        "processed_at": "2099-01-01T00:00:00",
-                        "processor_type": "PDFProcessor",
-                    },
-                },
+                make_sample(
+                    str(doc),
+                    text="old result",
+                    processed_at="2099-01-01T00:00:00",
+                    processor_type="PDFProcessor",
+                ),
             ],
         )
 
         previous = load_previous_results(str(prev_path))
-        assert is_reusable_process(str(doc), previous) is True
+        assert is_reusable_process(str(doc), previous)
 
-    def test_reprocesses_modified_files(self, tmp_path):
+    def test_reprocesses_modified_files(self, tmp_path, make_sample, write_jsonl):
         """Files with mtime > processed_at are not reused."""
         doc = tmp_path / "doc.pdf"
         doc.write_text("content")
 
         prev_path = tmp_path / "prev.jsonl"
-        self._write_jsonl(
+        write_jsonl(
             str(prev_path),
             [
-                {
-                    "text": "old result",
-                    "modalities": [],
-                    "metadata": {
-                        "file_path": str(doc),
-                        "processed_at": "2000-01-01T00:00:00",
-                        "processor_type": "PDFProcessor",
-                    },
-                },
+                make_sample(
+                    str(doc),
+                    text="old result",
+                    processed_at="2000-01-01T00:00:00",
+                    processor_type="PDFProcessor",
+                ),
             ],
         )
 
         previous = load_previous_results(str(prev_path))
-        assert is_reusable_process(str(doc), previous) is False
+        assert not is_reusable_process(str(doc), previous)
 
     def test_processes_new_files(self, tmp_path):
         """Files not in previous results are not reusable."""
         new_doc = tmp_path / "new.pdf"
         new_doc.write_text("new content")
-        assert is_reusable_process(str(new_doc), {}) is False
+        assert not is_reusable_process(str(new_doc), {})
 
-    def test_drops_deleted_from_merge(self):
+    def test_drops_deleted_from_merge(self, tmp_path, make_sample):
         """Deleted files are excluded from merge output."""
+        exists = str(tmp_path / "exists.pdf")
+        deleted = str(tmp_path / "deleted.pdf")
+        new_file = str(tmp_path / "new.txt")
+
         reused = {
-            "/exists.pdf": [_sample("/exists.pdf")],
-            "/deleted.pdf": [_sample("/deleted.pdf")],
+            exists: [make_sample(exists)],
+            deleted: [make_sample(deleted)],
         }
-        new = [_sample("/new.txt")]
-        current = {"/exists.pdf", "/new.txt"}
+        new = [make_sample(new_file)]
+        current = {exists, new_file}
 
         merged = merge_results(reused, new, current)
         fps = {s.metadata["file_path"] for s in merged}
-        assert fps == {"/exists.pdf", "/new.txt"}
+        assert fps == {exists, new_file}
 
-    def test_metadata_fields_present(self, tmp_path):
+    def test_metadata_fields_present(self, tmp_path, make_sample, write_jsonl):
         """Previous results have expected metadata fields."""
         prev_path = tmp_path / "prev.jsonl"
-        self._write_jsonl(
+        write_jsonl(
             str(prev_path),
             [
-                {
-                    "text": "x",
-                    "modalities": [],
-                    "metadata": {
-                        "file_path": "/x.pdf",
-                        "processed_at": "2026-01-01T00:00:00",
-                        "processor_type": "PDFProcessor",
-                    },
-                },
+                make_sample(
+                    "/x.pdf",
+                    processed_at="2026-01-01T00:00:00",
+                    processor_type="PDFProcessor",
+                ),
             ],
         )
 
@@ -117,22 +91,3 @@ class TestProcessStageReuse:
         sample = previous["/x.pdf"][0]
         assert "processed_at" in sample.metadata
         assert "processor_type" in sample.metadata
-
-
-class TestProcessInferenceConfig:
-    def test_previous_results_default_none(self):
-        config = ProcessInference(
-            data_path=".",
-            google_drive_ids=[],
-            dispatcher_config=DispatcherConfig(output_path="/tmp/test_mmore_proc"),
-        )
-        assert config.previous_results is None
-
-    def test_previous_results_can_be_set(self):
-        config = ProcessInference(
-            data_path=".",
-            google_drive_ids=[],
-            dispatcher_config=DispatcherConfig(output_path="/tmp/test_mmore_proc2"),
-            previous_results="/path/to/prev.jsonl",
-        )
-        assert config.previous_results == "/path/to/prev.jsonl"

--- a/tests/test_change_detection_process.py
+++ b/tests/test_change_detection_process.py
@@ -1,6 +1,6 @@
 from mmore.process.previous_results import (
     is_reusable_process,
-    load_previous_results,
+    load_previous_process_results,
     merge_results,
 )
 
@@ -26,7 +26,7 @@ class TestProcessPipelineReuse:
             ],
         )
 
-        previous = load_previous_results(str(prev_path))
+        previous = load_previous_process_results(str(prev_path))
         assert is_reusable_process(str(doc), previous)
 
     def test_reprocesses_modified_files(self, tmp_path, make_sample, write_jsonl):
@@ -47,7 +47,7 @@ class TestProcessPipelineReuse:
             ],
         )
 
-        previous = load_previous_results(str(prev_path))
+        previous = load_previous_process_results(str(prev_path))
         assert not is_reusable_process(str(doc), previous)
 
     def test_processes_new_files(self, tmp_path):
@@ -87,7 +87,7 @@ class TestProcessPipelineReuse:
             ],
         )
 
-        previous = load_previous_results(str(prev_path))
-        sample = previous["/x.pdf"][0]
+        previous = load_previous_process_results(str(prev_path))
+        sample = previous["/x.pdf"]
         assert "processed_at" in sample.metadata
         assert "processor_type" in sample.metadata

--- a/tests/test_change_detection_process.py
+++ b/tests/test_change_detection_process.py
@@ -1,3 +1,5 @@
+import pytest
+
 from mmore.process.incremental import (
     is_reusable_process,
     load_previous_process_results,
@@ -72,6 +74,36 @@ class TestProcessPipelineReuse:
         merged = merge_results(reused, new, current)
         fps = {s.metadata["file_path"] for s in merged}
         assert fps == {exists, new_file}
+
+    @pytest.mark.parametrize(
+        "include_url, expected_deleted",
+        [(True, 0), (False, 1)],
+        ids=["url_still_present", "url_removed"],
+    )
+    def test_deleted_count_with_url_in_previous(
+        self, tmp_path, make_sample, write_jsonl, include_url, expected_deleted
+    ):
+        """URLs in previous results are only counted as deleted when not present in the crawl."""
+        local_file = tmp_path / "doc.pdf"
+        local_file.write_text("content")
+        url = "https://example.com/page"
+
+        prev_path = tmp_path / "prev.jsonl"
+        write_jsonl(
+            str(prev_path),
+            [
+                make_sample(str(local_file), processed_at="2099-01-01T00:00:00"),
+                make_sample(url, processed_at="2099-01-01T00:00:00"),
+            ],
+        )
+
+        previous = load_previous_process_results(str(prev_path))
+        all_crawled_paths = {str(local_file)}
+        if include_url:
+            all_crawled_paths.add(url)
+
+        n_deleted = len(set(previous.keys()) - all_crawled_paths)
+        assert n_deleted == expected_deleted
 
     def test_metadata_fields_present(self, tmp_path, make_sample, write_jsonl):
         """Previous results have expected metadata fields."""

--- a/tests/test_change_detection_process.py
+++ b/tests/test_change_detection_process.py
@@ -1,0 +1,139 @@
+import json
+
+from mmore.process.dispatcher import DispatcherConfig
+from mmore.process.previous_results import (
+    is_reusable_process,
+    load_previous_results,
+    merge_results,
+)
+from mmore.run_process import ProcessInference
+
+
+class TestProcessStageReuse:
+    """Test the full process-stage incremental workflow."""
+
+    def _write_jsonl(self, path, samples):
+        with open(path, "w") as f:
+            for s in samples:
+                f.write(json.dumps(s) + "\n")
+
+    def test_skips_unchanged_files(self, tmp_path):
+        """Files with mtime <= processed_at are reused."""
+        doc = tmp_path / "doc.pdf"
+        doc.write_text("content")
+
+        prev_path = tmp_path / "prev.jsonl"
+        self._write_jsonl(
+            str(prev_path),
+            [
+                {
+                    "text": "old result",
+                    "modalities": [],
+                    "metadata": {
+                        "file_path": str(doc),
+                        "processed_at": "2099-01-01T00:00:00",
+                        "processor_type": "PDFProcessor",
+                    },
+                },
+            ],
+        )
+
+        previous = load_previous_results(str(prev_path))
+        assert is_reusable_process(str(doc), previous) is True
+
+    def test_reprocesses_modified_files(self, tmp_path):
+        """Files with mtime > processed_at are not reused."""
+        doc = tmp_path / "doc.pdf"
+        doc.write_text("content")
+
+        prev_path = tmp_path / "prev.jsonl"
+        self._write_jsonl(
+            str(prev_path),
+            [
+                {
+                    "text": "old result",
+                    "modalities": [],
+                    "metadata": {
+                        "file_path": str(doc),
+                        "processed_at": "2000-01-01T00:00:00",
+                        "processor_type": "PDFProcessor",
+                    },
+                },
+            ],
+        )
+
+        previous = load_previous_results(str(prev_path))
+        assert is_reusable_process(str(doc), previous) is False
+
+    def test_processes_new_files(self, tmp_path):
+        """Files not in previous results are not reusable."""
+        new_doc = tmp_path / "new.pdf"
+        new_doc.write_text("new content")
+        assert is_reusable_process(str(new_doc), {}) is False
+
+    def test_drops_deleted_from_merge(self):
+        """Deleted files are excluded from merge output."""
+        reused = {
+            "/exists.pdf": [
+                {
+                    "text": "a",
+                    "modalities": [],
+                    "metadata": {"file_path": "/exists.pdf"},
+                }
+            ],
+            "/deleted.pdf": [
+                {
+                    "text": "b",
+                    "modalities": [],
+                    "metadata": {"file_path": "/deleted.pdf"},
+                }
+            ],
+        }
+        new = [{"text": "c", "modalities": [], "metadata": {"file_path": "/new.txt"}}]
+        current = {"/exists.pdf", "/new.txt"}
+
+        merged = merge_results(reused, new, current)
+        fps = {s["metadata"]["file_path"] for s in merged}
+        assert fps == {"/exists.pdf", "/new.txt"}
+
+    def test_metadata_fields_present(self, tmp_path):
+        """Previous results have expected metadata fields."""
+        prev_path = tmp_path / "prev.jsonl"
+        self._write_jsonl(
+            str(prev_path),
+            [
+                {
+                    "text": "x",
+                    "modalities": [],
+                    "metadata": {
+                        "file_path": "/x.pdf",
+                        "processed_at": "2026-01-01T00:00:00",
+                        "processor_type": "PDFProcessor",
+                    },
+                },
+            ],
+        )
+
+        previous = load_previous_results(str(prev_path))
+        sample = previous["/x.pdf"][0]
+        assert "processed_at" in sample["metadata"]
+        assert "processor_type" in sample["metadata"]
+
+
+class TestProcessInferenceConfig:
+    def test_previous_results_default_none(self):
+        config = ProcessInference(
+            data_path=".",
+            google_drive_ids=[],
+            dispatcher_config=DispatcherConfig(output_path="/tmp/test_mmore_proc"),
+        )
+        assert config.previous_results is None
+
+    def test_previous_results_can_be_set(self):
+        config = ProcessInference(
+            data_path=".",
+            google_drive_ids=[],
+            dispatcher_config=DispatcherConfig(output_path="/tmp/test_mmore_proc2"),
+            previous_results="/path/to/prev.jsonl",
+        )
+        assert config.previous_results == "/path/to/prev.jsonl"

--- a/tests/test_change_detection_process.py
+++ b/tests/test_change_detection_process.py
@@ -7,6 +7,17 @@ from mmore.process.previous_results import (
     merge_results,
 )
 from mmore.run_process import ProcessInference
+from mmore.type import MultimodalSample
+
+
+def _sample(file_path, **metadata) -> MultimodalSample:
+    return MultimodalSample.from_dict(
+        {
+            "text": "x",
+            "modalities": [],
+            "metadata": {"file_path": file_path, **metadata},
+        }
+    )
 
 
 class TestProcessStageReuse:
@@ -74,26 +85,14 @@ class TestProcessStageReuse:
     def test_drops_deleted_from_merge(self):
         """Deleted files are excluded from merge output."""
         reused = {
-            "/exists.pdf": [
-                {
-                    "text": "a",
-                    "modalities": [],
-                    "metadata": {"file_path": "/exists.pdf"},
-                }
-            ],
-            "/deleted.pdf": [
-                {
-                    "text": "b",
-                    "modalities": [],
-                    "metadata": {"file_path": "/deleted.pdf"},
-                }
-            ],
+            "/exists.pdf": [_sample("/exists.pdf")],
+            "/deleted.pdf": [_sample("/deleted.pdf")],
         }
-        new = [{"text": "c", "modalities": [], "metadata": {"file_path": "/new.txt"}}]
+        new = [_sample("/new.txt")]
         current = {"/exists.pdf", "/new.txt"}
 
         merged = merge_results(reused, new, current)
-        fps = {s["metadata"]["file_path"] for s in merged}
+        fps = {s.metadata["file_path"] for s in merged}
         assert fps == {"/exists.pdf", "/new.txt"}
 
     def test_metadata_fields_present(self, tmp_path):
@@ -116,8 +115,8 @@ class TestProcessStageReuse:
 
         previous = load_previous_results(str(prev_path))
         sample = previous["/x.pdf"][0]
-        assert "processed_at" in sample["metadata"]
-        assert "processor_type" in sample["metadata"]
+        assert "processed_at" in sample.metadata
+        assert "processor_type" in sample.metadata
 
 
 class TestProcessInferenceConfig:

--- a/tests/test_previous_results.py
+++ b/tests/test_previous_results.py
@@ -1,4 +1,3 @@
-import json
 import os
 from datetime import datetime, timedelta
 
@@ -13,61 +12,35 @@ from mmore.process.previous_results import (
 from mmore.type import MultimodalSample
 
 # ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _make_sample_dict(file_path: str, processed_at: str) -> dict:
-    """Build a minimal sample dict as stored in a JSONL file."""
-    return {
-        "text": f"content of {file_path}",
-        "modalities": [],
-        "metadata": {
-            "file_path": file_path,
-            "processed_at": processed_at,
-        },
-    }
-
-
-def _make_sample(file_path: str, processed_at: str) -> MultimodalSample:
-    """Build a minimal MultimodalSample for tests."""
-    return MultimodalSample.from_dict(_make_sample_dict(file_path, processed_at))
-
-
-def _write_jsonl(path: str, samples: list[dict]) -> None:
-    with open(path, "w") as f:
-        for s in samples:
-            f.write(json.dumps(s) + "\n")
-
-
-# ---------------------------------------------------------------------------
 # load_previous_results
 # ---------------------------------------------------------------------------
 
 
 class TestLoadPreviousResults:
-    def test_loads_and_indexes_by_file_path(self, tmp_path):
+    def test_loads_and_indexes_by_file_path(self, tmp_path, make_sample, write_jsonl):
         jsonl = str(tmp_path / "results.jsonl")
         samples = [
-            _make_sample_dict("/data/a.pdf", "2026-01-01T10:00:00"),
-            _make_sample_dict("/data/a.pdf", "2026-01-01T10:00:01"),
-            _make_sample_dict("/data/b.txt", "2026-01-01T11:00:00"),
+            make_sample("/data/a.pdf", processed_at="2026-01-01T10:00:00"),
+            make_sample("/data/a.pdf", processed_at="2026-01-01T10:00:01"),
+            make_sample("/data/b.txt", processed_at="2026-01-01T11:00:00"),
         ]
-        _write_jsonl(jsonl, samples)
+        write_jsonl(jsonl, samples)
 
         result = load_previous_results(jsonl)
         assert set(result.keys()) == {"/data/a.pdf", "/data/b.txt"}
         assert len(result["/data/a.pdf"]) == 2
         assert len(result["/data/b.txt"]) == 1
 
-    def test_samples_preserved(self, tmp_path):
+    def test_samples_preserved(self, tmp_path, make_sample, write_jsonl):
         jsonl = str(tmp_path / "results.jsonl")
-        sample = _make_sample_dict("/data/a.pdf", "2026-01-01T10:00:00")
-        _write_jsonl(jsonl, [sample])
+        sample = make_sample(
+            "/data/a.pdf", text="custom content", processed_at="2026-01-01T10:00:00"
+        )
+        write_jsonl(jsonl, [sample])
 
         result = load_previous_results(jsonl)
         assert isinstance(result["/data/a.pdf"][0], MultimodalSample)
-        assert result["/data/a.pdf"][0].text == "content of /data/a.pdf"
+        assert result["/data/a.pdf"][0].text == "custom content"
         assert (
             result["/data/a.pdf"][0].metadata["processed_at"] == "2026-01-01T10:00:00"
         )
@@ -85,18 +58,6 @@ class TestLoadPreviousResults:
         with pytest.raises(FileNotFoundError):
             load_previous_results(missing)
 
-    def test_single_sample_per_file(self, tmp_path):
-        jsonl = str(tmp_path / "results.jsonl")
-        samples = [
-            _make_sample_dict("/data/x.docx", "2026-03-01T08:00:00"),
-        ]
-        _write_jsonl(jsonl, samples)
-
-        result = load_previous_results(jsonl)
-        assert len(result) == 1
-        assert "/data/x.docx" in result
-        assert len(result["/data/x.docx"]) == 1
-
 
 # ---------------------------------------------------------------------------
 # is_reusable_process
@@ -104,38 +65,36 @@ class TestLoadPreviousResults:
 
 
 class TestIsReusableProcess:
-    def test_true_when_file_unchanged(self, tmp_path):
-        """mtime is older than processed_at → reusable."""
+    def test_true_when_file_unchanged(self, tmp_path, make_sample):
+        """mtime is older than processed_at yields reusable."""
         real_file = str(tmp_path / "doc.pdf")
         with open(real_file, "w") as f:
             f.write("content")
 
-        # processed_at is in the future relative to mtime → reusable
         future = (datetime.now() + timedelta(hours=1)).isoformat()
-        previous = {real_file: [_make_sample(real_file, future)]}
+        previous = {real_file: [make_sample(real_file, processed_at=future)]}
 
-        assert is_reusable_process(real_file, previous) is True
+        assert is_reusable_process(real_file, previous)
 
-    def test_false_when_file_modified_after_processing(self, tmp_path):
-        """mtime is newer than processed_at → not reusable."""
+    def test_false_when_file_modified_after_processing(self, tmp_path, make_sample):
+        """mtime is newer than processed_at yields not reusable."""
         real_file = str(tmp_path / "doc.pdf")
         with open(real_file, "w") as f:
             f.write("content")
 
-        # processed_at is in the past relative to mtime → not reusable
         past = (datetime.now() - timedelta(hours=1)).isoformat()
-        previous = {real_file: [_make_sample(real_file, past)]}
+        previous = {real_file: [make_sample(real_file, processed_at=past)]}
 
-        assert is_reusable_process(real_file, previous) is False
+        assert not is_reusable_process(real_file, previous)
 
     def test_false_when_not_in_previous_results(self, tmp_path):
         real_file = str(tmp_path / "doc.pdf")
         with open(real_file, "w") as f:
             f.write("content")
 
-        assert is_reusable_process(real_file, {}) is False
+        assert not is_reusable_process(real_file, {})
 
-    def test_uses_max_processed_at_across_samples(self, tmp_path):
+    def test_uses_max_processed_at_across_samples(self, tmp_path, make_sample):
         """When a file has multiple cached samples, uses the max processed_at."""
         real_file = str(tmp_path / "doc.pdf")
         with open(real_file, "w") as f:
@@ -146,14 +105,14 @@ class TestIsReusableProcess:
         future = (datetime.now() + timedelta(hours=2)).isoformat()
         previous = {
             real_file: [
-                _make_sample(real_file, past),
-                _make_sample(real_file, future),
+                make_sample(real_file, processed_at=past),
+                make_sample(real_file, processed_at=future),
             ]
         }
 
-        assert is_reusable_process(real_file, previous) is True
+        assert is_reusable_process(real_file, previous)
 
-    def test_uses_max_processed_at_all_past(self, tmp_path):
+    def test_uses_max_processed_at_all_past(self, tmp_path, make_sample):
         """All cached samples have past processed_at → not reusable."""
         real_file = str(tmp_path / "doc.pdf")
         with open(real_file, "w") as f:
@@ -163,14 +122,14 @@ class TestIsReusableProcess:
         past2 = (datetime.now() - timedelta(hours=1)).isoformat()
         previous = {
             real_file: [
-                _make_sample(real_file, past1),
-                _make_sample(real_file, past2),
+                make_sample(real_file, processed_at=past1),
+                make_sample(real_file, processed_at=past2),
             ]
         }
 
-        assert is_reusable_process(real_file, previous) is False
+        assert not is_reusable_process(real_file, previous)
 
-    def test_mtime_equal_to_processed_at_is_reusable(self, tmp_path):
+    def test_mtime_equal_to_processed_at_is_reusable(self, tmp_path, make_sample):
         """When mtime == processed_at, should be considered reusable (<=)."""
         real_file = str(tmp_path / "doc.pdf")
         with open(real_file, "w") as f:
@@ -179,9 +138,9 @@ class TestIsReusableProcess:
         # Get the actual mtime and use it as processed_at
         mtime = os.path.getmtime(real_file)
         processed_at = datetime.fromtimestamp(mtime).isoformat()
-        previous = {real_file: [_make_sample(real_file, processed_at)]}
+        previous = {real_file: [make_sample(real_file, processed_at=processed_at)]}
 
-        assert is_reusable_process(real_file, previous) is True
+        assert is_reusable_process(real_file, previous)
 
 
 # ---------------------------------------------------------------------------
@@ -190,68 +149,64 @@ class TestIsReusableProcess:
 
 
 class TestIsReusablePostprocess:
-    def test_true_when_input_older_than_cached(self):
+    def test_true_when_input_older_than_cached(self, make_sample):
         """input_processed_at <= cached processed_at → reusable."""
         file_path = "/data/doc.pdf"
         cached_time = "2026-03-01T12:00:00"
         input_time = "2026-03-01T11:00:00"  # older than cached
-        previous = {file_path: [_make_sample(file_path, cached_time)]}
+        previous = {file_path: [make_sample(file_path, processed_at=cached_time)]}
 
-        assert is_reusable_postprocess(file_path, input_time, previous) is True
+        assert is_reusable_postprocess(file_path, input_time, previous)
 
-    def test_true_when_input_equal_to_cached(self):
+    def test_true_when_input_equal_to_cached(self, make_sample):
         """input_processed_at == cached processed_at → reusable."""
         file_path = "/data/doc.pdf"
         same_time = "2026-03-01T12:00:00"
-        previous = {file_path: [_make_sample(file_path, same_time)]}
+        previous = {file_path: [make_sample(file_path, processed_at=same_time)]}
 
-        assert is_reusable_postprocess(file_path, same_time, previous) is True
+        assert is_reusable_postprocess(file_path, same_time, previous)
 
-    def test_false_when_input_newer_than_cached(self):
+    def test_false_when_input_newer_than_cached(self, make_sample):
         """input_processed_at > cached processed_at → not reusable."""
         file_path = "/data/doc.pdf"
         cached_time = "2026-03-01T10:00:00"
         input_time = "2026-03-01T12:00:00"  # newer than cached
-        previous = {file_path: [_make_sample(file_path, cached_time)]}
+        previous = {file_path: [make_sample(file_path, processed_at=cached_time)]}
 
-        assert is_reusable_postprocess(file_path, input_time, previous) is False
+        assert not is_reusable_postprocess(file_path, input_time, previous)
 
     def test_false_when_not_in_previous_results(self):
         file_path = "/data/doc.pdf"
-        assert is_reusable_postprocess(file_path, "2026-03-01T12:00:00", {}) is False
+        assert not is_reusable_postprocess(file_path, "2026-03-01T12:00:00", {})
 
-    def test_uses_max_processed_at_across_cached_samples(self):
+    def test_uses_max_processed_at_across_cached_samples(self, make_sample):
         """Uses the max processed_at from all cached samples for the file."""
         file_path = "/data/doc.pdf"
         early = "2026-03-01T08:00:00"
         late = "2026-03-01T14:00:00"
         previous = {
             file_path: [
-                _make_sample(file_path, early),
-                _make_sample(file_path, late),
+                make_sample(file_path, processed_at=early),
+                make_sample(file_path, processed_at=late),
             ]
         }
 
         # input processed at noon, max cached is 14:00 → noon <= 14:00 → reusable
-        assert (
-            is_reusable_postprocess(file_path, "2026-03-01T12:00:00", previous) is True
-        )
+        assert is_reusable_postprocess(file_path, "2026-03-01T12:00:00", previous)
 
-    def test_uses_max_processed_at_all_older_than_input(self):
+    def test_uses_max_processed_at_all_older_than_input(self, make_sample):
         """Even taking the max of cached, it's still older than input → not reusable."""
         file_path = "/data/doc.pdf"
         t1 = "2026-03-01T08:00:00"
         t2 = "2026-03-01T10:00:00"
         previous = {
             file_path: [
-                _make_sample(file_path, t1),
-                _make_sample(file_path, t2),
+                make_sample(file_path, processed_at=t1),
+                make_sample(file_path, processed_at=t2),
             ]
         }
         # input at noon, max cached is 10:00 → noon > 10:00 → not reusable
-        assert (
-            is_reusable_postprocess(file_path, "2026-03-01T12:00:00", previous) is False
-        )
+        assert not is_reusable_postprocess(file_path, "2026-03-01T12:00:00", previous)
 
 
 # ---------------------------------------------------------------------------
@@ -260,37 +215,49 @@ class TestIsReusablePostprocess:
 
 
 class TestMergeResults:
-    def test_combines_reused_and_new(self):
+    def test_combines_reused_and_new(self, make_sample):
         current_files = {"/data/a.pdf", "/data/b.txt"}
-        reused = {"/data/a.pdf": [_make_sample("/data/a.pdf", "2026-01-01T10:00:00")]}
-        new_results = [_make_sample("/data/b.txt", "2026-01-02T10:00:00")]
+        reused = {
+            "/data/a.pdf": [
+                make_sample("/data/a.pdf", processed_at="2026-01-01T10:00:00")
+            ]
+        }
+        new_results = [make_sample("/data/b.txt", processed_at="2026-01-02T10:00:00")]
 
         result = merge_results(reused, new_results, current_files)
         assert len(result) == 2
         file_paths = {r.metadata["file_path"] for r in result}
         assert file_paths == {"/data/a.pdf", "/data/b.txt"}
 
-    def test_drops_deleted_files(self):
+    def test_drops_deleted_files(self, make_sample):
         """Entries whose file_path is not in current_file_paths are excluded."""
         current_files = {"/data/b.txt"}
-        reused = {"/data/a.pdf": [_make_sample("/data/a.pdf", "2026-01-01T10:00:00")]}
-        new_results = [_make_sample("/data/b.txt", "2026-01-02T10:00:00")]
+        reused = {
+            "/data/a.pdf": [
+                make_sample("/data/a.pdf", processed_at="2026-01-01T10:00:00")
+            ]
+        }
+        new_results = [make_sample("/data/b.txt", processed_at="2026-01-02T10:00:00")]
 
         result = merge_results(reused, new_results, current_files)
         assert len(result) == 1
         assert result[0].metadata["file_path"] == "/data/b.txt"
 
-    def test_empty_reused_returns_only_new(self):
+    def test_empty_reused_returns_only_new(self, make_sample):
         current_files = {"/data/b.txt"}
-        new_results = [_make_sample("/data/b.txt", "2026-01-02T10:00:00")]
+        new_results = [make_sample("/data/b.txt", processed_at="2026-01-02T10:00:00")]
 
         result = merge_results({}, new_results, current_files)
         assert len(result) == 1
         assert result[0].metadata["file_path"] == "/data/b.txt"
 
-    def test_empty_new_returns_only_reused(self):
+    def test_empty_new_returns_only_reused(self, make_sample):
         current_files = {"/data/a.pdf"}
-        reused = {"/data/a.pdf": [_make_sample("/data/a.pdf", "2026-01-01T10:00:00")]}
+        reused = {
+            "/data/a.pdf": [
+                make_sample("/data/a.pdf", processed_at="2026-01-01T10:00:00")
+            ]
+        }
 
         result = merge_results(reused, [], current_files)
         assert len(result) == 1
@@ -300,42 +267,42 @@ class TestMergeResults:
         result = merge_results({}, [], set())
         assert result == []
 
-    def test_multiple_samples_per_file_included(self):
+    def test_multiple_samples_per_file_included(self, make_sample):
         current_files = {"/data/a.pdf"}
         reused = {
             "/data/a.pdf": [
-                _make_sample("/data/a.pdf", "2026-01-01T10:00:00"),
-                _make_sample("/data/a.pdf", "2026-01-01T10:00:01"),
+                make_sample("/data/a.pdf", processed_at="2026-01-01T10:00:00"),
+                make_sample("/data/a.pdf", processed_at="2026-01-01T10:00:01"),
             ]
         }
 
         result = merge_results(reused, [], current_files)
         assert len(result) == 2
 
-    def test_new_results_with_deleted_file_path_dropped(self):
+    def test_new_results_with_deleted_file_path_dropped(self, make_sample):
         """new_results entries whose file_path is not in current_file_paths are also dropped."""
         current_files = {"/data/a.pdf"}
         # new_results contains a file that is no longer current
         new_results = [
-            _make_sample("/data/a.pdf", "2026-01-02T10:00:00"),
-            _make_sample("/data/deleted.pdf", "2026-01-02T11:00:00"),
+            make_sample("/data/a.pdf", processed_at="2026-01-02T10:00:00"),
+            make_sample("/data/deleted.pdf", processed_at="2026-01-02T11:00:00"),
         ]
 
         result = merge_results({}, new_results, current_files)
         assert len(result) == 1
         assert result[0].metadata["file_path"] == "/data/a.pdf"
 
-    def test_returns_flat_list(self):
+    def test_returns_flat_list(self, make_sample):
         """merge_results always returns a flat list of MultimodalSample."""
         current_files = {"/data/a.pdf", "/data/b.txt"}
         reused = {
             "/data/a.pdf": [
-                _make_sample("/data/a.pdf", "2026-01-01T10:00:00"),
-                _make_sample("/data/a.pdf", "2026-01-01T10:00:01"),
+                make_sample("/data/a.pdf", processed_at="2026-01-01T10:00:00"),
+                make_sample("/data/a.pdf", processed_at="2026-01-01T10:00:01"),
             ]
         }
         new_results = [
-            _make_sample("/data/b.txt", "2026-01-02T10:00:00"),
+            make_sample("/data/b.txt", processed_at="2026-01-02T10:00:00"),
         ]
 
         result = merge_results(reused, new_results, current_files)

--- a/tests/test_previous_results.py
+++ b/tests/test_previous_results.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 
 import pytest
 
-from mmore.process.previous_results import (
+from mmore.process.incremental import (
     is_reusable_postprocess,
     is_reusable_process,
     load_previous_postprocess_results,

--- a/tests/test_previous_results.py
+++ b/tests/test_previous_results.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from datetime import datetime, timedelta
 
@@ -6,18 +7,88 @@ import pytest
 from mmore.process.previous_results import (
     is_reusable_postprocess,
     is_reusable_process,
-    load_previous_results,
+    load_previous_postprocess_results,
+    load_previous_process_results,
     merge_results,
 )
 from mmore.type import MultimodalSample
 
 # ---------------------------------------------------------------------------
-# load_previous_results
+# load_previous_process_results
 # ---------------------------------------------------------------------------
 
 
-class TestLoadPreviousResults:
-    def test_loads_and_indexes_by_file_path(self, tmp_path, make_sample, write_jsonl):
+class TestLoadPreviousProcessResults:
+    def test_returns_single_sample_per_file_path(
+        self, tmp_path, make_sample, write_jsonl
+    ):
+        jsonl = str(tmp_path / "results.jsonl")
+        samples = [
+            make_sample("/data/a.pdf", processed_at="2026-01-01T10:00:00"),
+            make_sample("/data/b.txt", processed_at="2026-01-01T11:00:00"),
+        ]
+        write_jsonl(jsonl, samples)
+
+        result = load_previous_process_results(jsonl)
+        assert set(result.keys()) == {"/data/a.pdf", "/data/b.txt"}
+        assert isinstance(result["/data/a.pdf"], MultimodalSample)
+        assert isinstance(result["/data/b.txt"], MultimodalSample)
+
+    def test_duplicates_collapse_to_latest_processed_at(
+        self, tmp_path, make_sample, write_jsonl, caplog
+    ):
+        jsonl = str(tmp_path / "results.jsonl")
+        samples = [
+            make_sample("/data/a.pdf", text="old", processed_at="2026-01-01T10:00:00"),
+            make_sample("/data/a.pdf", text="new", processed_at="2026-01-01T10:00:05"),
+            make_sample("/data/a.pdf", text="mid", processed_at="2026-01-01T10:00:02"),
+        ]
+        write_jsonl(jsonl, samples)
+
+        with caplog.at_level(logging.WARNING):
+            result = load_previous_process_results(jsonl)
+
+        assert set(result.keys()) == {"/data/a.pdf"}
+        assert result["/data/a.pdf"].text == "new"
+        assert any("/data/a.pdf" in rec.message for rec in caplog.records)
+
+    def test_missing_processed_at_loses_tie_to_present(
+        self, tmp_path, make_sample, write_jsonl
+    ):
+        jsonl = str(tmp_path / "results.jsonl")
+        samples = [
+            make_sample("/data/a.pdf", text="no_ts"),
+            make_sample(
+                "/data/a.pdf", text="has_ts", processed_at="2026-01-01T10:00:00"
+            ),
+        ]
+        write_jsonl(jsonl, samples)
+
+        result = load_previous_process_results(jsonl)
+        assert result["/data/a.pdf"].text == "has_ts"
+
+    def test_empty_file_returns_empty_dict(self, tmp_path):
+        jsonl = str(tmp_path / "empty.jsonl")
+        open(jsonl, "w").close()
+
+        result = load_previous_process_results(jsonl)
+        assert result == {}
+
+    def test_raises_file_not_found_when_missing(self, tmp_path):
+        missing = str(tmp_path / "nonexistent.jsonl")
+        with pytest.raises(FileNotFoundError):
+            load_previous_process_results(missing)
+
+
+# ---------------------------------------------------------------------------
+# load_previous_postprocess_results
+# ---------------------------------------------------------------------------
+
+
+class TestLoadPreviousPostprocessResults:
+    def test_preserves_all_samples_per_file_path(
+        self, tmp_path, make_sample, write_jsonl
+    ):
         jsonl = str(tmp_path / "results.jsonl")
         samples = [
             make_sample("/data/a.pdf", processed_at="2026-01-01T10:00:00"),
@@ -26,7 +97,7 @@ class TestLoadPreviousResults:
         ]
         write_jsonl(jsonl, samples)
 
-        result = load_previous_results(jsonl)
+        result = load_previous_postprocess_results(jsonl)
         assert set(result.keys()) == {"/data/a.pdf", "/data/b.txt"}
         assert len(result["/data/a.pdf"]) == 2
         assert len(result["/data/b.txt"]) == 1
@@ -38,25 +109,19 @@ class TestLoadPreviousResults:
         )
         write_jsonl(jsonl, [sample])
 
-        result = load_previous_results(jsonl)
-        assert isinstance(result["/data/a.pdf"][0], MultimodalSample)
+        result = load_previous_postprocess_results(jsonl)
         assert result["/data/a.pdf"][0].text == "custom content"
-        assert (
-            result["/data/a.pdf"][0].metadata["processed_at"] == "2026-01-01T10:00:00"
-        )
 
     def test_empty_file_returns_empty_dict(self, tmp_path):
         jsonl = str(tmp_path / "empty.jsonl")
-        jsonl_path = str(jsonl)
-        open(jsonl_path, "w").close()
+        open(jsonl, "w").close()
 
-        result = load_previous_results(jsonl_path)
-        assert result == {}
+        assert load_previous_postprocess_results(jsonl) == {}
 
     def test_raises_file_not_found_when_missing(self, tmp_path):
         missing = str(tmp_path / "nonexistent.jsonl")
         with pytest.raises(FileNotFoundError):
-            load_previous_results(missing)
+            load_previous_postprocess_results(missing)
 
 
 # ---------------------------------------------------------------------------
@@ -66,24 +131,22 @@ class TestLoadPreviousResults:
 
 class TestIsReusableProcess:
     def test_true_when_file_unchanged(self, tmp_path, make_sample):
-        """mtime is older than processed_at yields reusable."""
         real_file = str(tmp_path / "doc.pdf")
         with open(real_file, "w") as f:
             f.write("content")
 
         future = (datetime.now() + timedelta(hours=1)).isoformat()
-        previous = {real_file: [make_sample(real_file, processed_at=future)]}
+        previous = {real_file: make_sample(real_file, processed_at=future)}
 
         assert is_reusable_process(real_file, previous)
 
     def test_false_when_file_modified_after_processing(self, tmp_path, make_sample):
-        """mtime is newer than processed_at yields not reusable."""
         real_file = str(tmp_path / "doc.pdf")
         with open(real_file, "w") as f:
             f.write("content")
 
         past = (datetime.now() - timedelta(hours=1)).isoformat()
-        previous = {real_file: [make_sample(real_file, processed_at=past)]}
+        previous = {real_file: make_sample(real_file, processed_at=past)}
 
         assert not is_reusable_process(real_file, previous)
 
@@ -94,51 +157,22 @@ class TestIsReusableProcess:
 
         assert not is_reusable_process(real_file, {})
 
-    def test_uses_max_processed_at_across_samples(self, tmp_path, make_sample):
-        """When a file has multiple cached samples, uses the max processed_at."""
+    def test_false_when_cached_missing_processed_at(self, tmp_path, make_sample):
         real_file = str(tmp_path / "doc.pdf")
         with open(real_file, "w") as f:
             f.write("content")
 
-        # One sample has past processed_at, another has future → max is future → reusable
-        past = (datetime.now() - timedelta(hours=2)).isoformat()
-        future = (datetime.now() + timedelta(hours=2)).isoformat()
-        previous = {
-            real_file: [
-                make_sample(real_file, processed_at=past),
-                make_sample(real_file, processed_at=future),
-            ]
-        }
-
-        assert is_reusable_process(real_file, previous)
-
-    def test_uses_max_processed_at_all_past(self, tmp_path, make_sample):
-        """All cached samples have past processed_at → not reusable."""
-        real_file = str(tmp_path / "doc.pdf")
-        with open(real_file, "w") as f:
-            f.write("content")
-
-        past1 = (datetime.now() - timedelta(hours=3)).isoformat()
-        past2 = (datetime.now() - timedelta(hours=1)).isoformat()
-        previous = {
-            real_file: [
-                make_sample(real_file, processed_at=past1),
-                make_sample(real_file, processed_at=past2),
-            ]
-        }
-
+        previous = {real_file: make_sample(real_file)}
         assert not is_reusable_process(real_file, previous)
 
     def test_mtime_equal_to_processed_at_is_reusable(self, tmp_path, make_sample):
-        """When mtime == processed_at, should be considered reusable (<=)."""
         real_file = str(tmp_path / "doc.pdf")
         with open(real_file, "w") as f:
             f.write("content")
 
-        # Get the actual mtime and use it as processed_at
         mtime = os.path.getmtime(real_file)
         processed_at = datetime.fromtimestamp(mtime).isoformat()
-        previous = {real_file: [make_sample(real_file, processed_at=processed_at)]}
+        previous = {real_file: make_sample(real_file, processed_at=processed_at)}
 
         assert is_reusable_process(real_file, previous)
 
@@ -149,68 +183,67 @@ class TestIsReusableProcess:
 
 
 class TestIsReusablePostprocess:
-    def test_true_when_input_older_than_cached(self, make_sample):
-        """input_processed_at <= cached processed_at → reusable."""
+    def test_true_when_input_older_than_all_cached(self, make_sample):
         file_path = "/data/doc.pdf"
-        cached_time = "2026-03-01T12:00:00"
-        input_time = "2026-03-01T11:00:00"  # older than cached
-        previous = {file_path: [make_sample(file_path, processed_at=cached_time)]}
+        input_time = "2026-03-01T10:00:00"
+        previous = {
+            file_path: [
+                make_sample(file_path, processed_at="2026-03-01T11:00:00"),
+                make_sample(file_path, processed_at="2026-03-01T12:00:00"),
+            ]
+        }
 
         assert is_reusable_postprocess(file_path, input_time, previous)
 
-    def test_true_when_input_equal_to_cached(self, make_sample):
-        """input_processed_at == cached processed_at → reusable."""
+    def test_true_when_input_equal_to_min_cached(self, make_sample):
         file_path = "/data/doc.pdf"
         same_time = "2026-03-01T12:00:00"
-        previous = {file_path: [make_sample(file_path, processed_at=same_time)]}
+        previous = {
+            file_path: [
+                make_sample(file_path, processed_at=same_time),
+                make_sample(file_path, processed_at="2026-03-01T13:00:00"),
+            ]
+        }
 
         assert is_reusable_postprocess(file_path, same_time, previous)
 
-    def test_false_when_input_newer_than_cached(self, make_sample):
-        """input_processed_at > cached processed_at → not reusable."""
+    def test_false_when_input_newer_than_min_cached(self, make_sample):
+        """Input between early and late cached times, min is early, not reusable."""
         file_path = "/data/doc.pdf"
-        cached_time = "2026-03-01T10:00:00"
-        input_time = "2026-03-01T12:00:00"  # newer than cached
-        previous = {file_path: [make_sample(file_path, processed_at=cached_time)]}
+        previous = {
+            file_path: [
+                make_sample(file_path, processed_at="2026-03-01T08:00:00"),
+                make_sample(file_path, processed_at="2026-03-01T14:00:00"),
+            ]
+        }
+        assert not is_reusable_postprocess(file_path, "2026-03-01T12:00:00", previous)
 
-        assert not is_reusable_postprocess(file_path, input_time, previous)
+    def test_false_when_input_newer_than_all_cached(self, make_sample):
+        file_path = "/data/doc.pdf"
+        previous = {
+            file_path: [
+                make_sample(file_path, processed_at="2026-03-01T08:00:00"),
+                make_sample(file_path, processed_at="2026-03-01T10:00:00"),
+            ]
+        }
+        assert not is_reusable_postprocess(file_path, "2026-03-01T12:00:00", previous)
 
     def test_false_when_not_in_previous_results(self):
-        file_path = "/data/doc.pdf"
-        assert not is_reusable_postprocess(file_path, "2026-03-01T12:00:00", {})
+        assert not is_reusable_postprocess("/data/doc.pdf", "2026-03-01T12:00:00", {})
 
-    def test_uses_max_processed_at_across_cached_samples(self, make_sample):
-        """Uses the max processed_at from all cached samples for the file."""
+    def test_false_when_any_cached_sample_missing_processed_at(self, make_sample):
         file_path = "/data/doc.pdf"
-        early = "2026-03-01T08:00:00"
-        late = "2026-03-01T14:00:00"
         previous = {
             file_path: [
-                make_sample(file_path, processed_at=early),
-                make_sample(file_path, processed_at=late),
+                make_sample(file_path, processed_at="2026-03-01T14:00:00"),
+                make_sample(file_path),
             ]
         }
-
-        # input processed at noon, max cached is 14:00 → noon <= 14:00 → reusable
-        assert is_reusable_postprocess(file_path, "2026-03-01T12:00:00", previous)
-
-    def test_uses_max_processed_at_all_older_than_input(self, make_sample):
-        """Even taking the max of cached, it's still older than input → not reusable."""
-        file_path = "/data/doc.pdf"
-        t1 = "2026-03-01T08:00:00"
-        t2 = "2026-03-01T10:00:00"
-        previous = {
-            file_path: [
-                make_sample(file_path, processed_at=t1),
-                make_sample(file_path, processed_at=t2),
-            ]
-        }
-        # input at noon, max cached is 10:00 → noon > 10:00 → not reusable
-        assert not is_reusable_postprocess(file_path, "2026-03-01T12:00:00", previous)
+        assert not is_reusable_postprocess(file_path, "2026-03-01T10:00:00", previous)
 
 
 # ---------------------------------------------------------------------------
-# merge_results
+# merge_results (unchanged behavior)
 # ---------------------------------------------------------------------------
 
 
@@ -230,7 +263,6 @@ class TestMergeResults:
         assert file_paths == {"/data/a.pdf", "/data/b.txt"}
 
     def test_drops_deleted_files(self, make_sample):
-        """Entries whose file_path is not in current_file_paths are excluded."""
         current_files = {"/data/b.txt"}
         reused = {
             "/data/a.pdf": [
@@ -264,8 +296,7 @@ class TestMergeResults:
         assert result[0].metadata["file_path"] == "/data/a.pdf"
 
     def test_both_empty_returns_empty_list(self):
-        result = merge_results({}, [], set())
-        assert result == []
+        assert merge_results({}, [], set()) == []
 
     def test_multiple_samples_per_file_included(self, make_sample):
         current_files = {"/data/a.pdf"}
@@ -280,9 +311,7 @@ class TestMergeResults:
         assert len(result) == 2
 
     def test_new_results_with_deleted_file_path_dropped(self, make_sample):
-        """new_results entries whose file_path is not in current_file_paths are also dropped."""
         current_files = {"/data/a.pdf"}
-        # new_results contains a file that is no longer current
         new_results = [
             make_sample("/data/a.pdf", processed_at="2026-01-02T10:00:00"),
             make_sample("/data/deleted.pdf", processed_at="2026-01-02T11:00:00"),
@@ -291,21 +320,3 @@ class TestMergeResults:
         result = merge_results({}, new_results, current_files)
         assert len(result) == 1
         assert result[0].metadata["file_path"] == "/data/a.pdf"
-
-    def test_returns_flat_list(self, make_sample):
-        """merge_results always returns a flat list of MultimodalSample."""
-        current_files = {"/data/a.pdf", "/data/b.txt"}
-        reused = {
-            "/data/a.pdf": [
-                make_sample("/data/a.pdf", processed_at="2026-01-01T10:00:00"),
-                make_sample("/data/a.pdf", processed_at="2026-01-01T10:00:01"),
-            ]
-        }
-        new_results = [
-            make_sample("/data/b.txt", processed_at="2026-01-02T10:00:00"),
-        ]
-
-        result = merge_results(reused, new_results, current_files)
-        assert isinstance(result, list)
-        assert all(isinstance(r, MultimodalSample) for r in result)
-        assert len(result) == 3

--- a/tests/test_previous_results.py
+++ b/tests/test_previous_results.py
@@ -1,0 +1,344 @@
+import json
+import os
+from datetime import datetime, timedelta
+
+import pytest
+
+from mmore.process.previous_results import (
+    is_reusable_postprocess,
+    is_reusable_process,
+    load_previous_results,
+    merge_results,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_sample_dict(file_path: str, processed_at: str) -> dict:
+    """Build a minimal sample dict as stored in a JSONL file."""
+    return {
+        "text": f"content of {file_path}",
+        "modalities": [],
+        "metadata": {
+            "file_path": file_path,
+            "processed_at": processed_at,
+        },
+    }
+
+
+def _write_jsonl(path: str, samples: list[dict]) -> None:
+    with open(path, "w") as f:
+        for s in samples:
+            f.write(json.dumps(s) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# load_previous_results
+# ---------------------------------------------------------------------------
+
+
+class TestLoadPreviousResults:
+    def test_loads_and_indexes_by_file_path(self, tmp_path):
+        jsonl = str(tmp_path / "results.jsonl")
+        samples = [
+            _make_sample_dict("/data/a.pdf", "2026-01-01T10:00:00"),
+            _make_sample_dict("/data/a.pdf", "2026-01-01T10:00:01"),
+            _make_sample_dict("/data/b.txt", "2026-01-01T11:00:00"),
+        ]
+        _write_jsonl(jsonl, samples)
+
+        result = load_previous_results(jsonl)
+        assert set(result.keys()) == {"/data/a.pdf", "/data/b.txt"}
+        assert len(result["/data/a.pdf"]) == 2
+        assert len(result["/data/b.txt"]) == 1
+
+    def test_sample_dicts_preserved(self, tmp_path):
+        jsonl = str(tmp_path / "results.jsonl")
+        sample = _make_sample_dict("/data/a.pdf", "2026-01-01T10:00:00")
+        _write_jsonl(jsonl, [sample])
+
+        result = load_previous_results(jsonl)
+        assert result["/data/a.pdf"][0]["text"] == "content of /data/a.pdf"
+        assert (
+            result["/data/a.pdf"][0]["metadata"]["processed_at"]
+            == "2026-01-01T10:00:00"
+        )
+
+    def test_empty_file_returns_empty_dict(self, tmp_path):
+        jsonl = str(tmp_path / "empty.jsonl")
+        jsonl_path = str(jsonl)
+        open(jsonl_path, "w").close()
+
+        result = load_previous_results(jsonl_path)
+        assert result == {}
+
+    def test_raises_file_not_found_when_missing(self, tmp_path):
+        missing = str(tmp_path / "nonexistent.jsonl")
+        with pytest.raises(FileNotFoundError):
+            load_previous_results(missing)
+
+    def test_single_sample_per_file(self, tmp_path):
+        jsonl = str(tmp_path / "results.jsonl")
+        samples = [
+            _make_sample_dict("/data/x.docx", "2026-03-01T08:00:00"),
+        ]
+        _write_jsonl(jsonl, samples)
+
+        result = load_previous_results(jsonl)
+        assert len(result) == 1
+        assert "/data/x.docx" in result
+        assert len(result["/data/x.docx"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# is_reusable_process
+# ---------------------------------------------------------------------------
+
+
+class TestIsReusableProcess:
+    def test_true_when_file_unchanged(self, tmp_path):
+        """mtime is older than processed_at → reusable."""
+        real_file = str(tmp_path / "doc.pdf")
+        with open(real_file, "w") as f:
+            f.write("content")
+
+        # processed_at is in the future relative to mtime → reusable
+        future = (datetime.now() + timedelta(hours=1)).isoformat()
+        previous = {real_file: [_make_sample_dict(real_file, future)]}
+
+        assert is_reusable_process(real_file, previous) is True
+
+    def test_false_when_file_modified_after_processing(self, tmp_path):
+        """mtime is newer than processed_at → not reusable."""
+        real_file = str(tmp_path / "doc.pdf")
+        with open(real_file, "w") as f:
+            f.write("content")
+
+        # processed_at is in the past relative to mtime → not reusable
+        past = (datetime.now() - timedelta(hours=1)).isoformat()
+        previous = {real_file: [_make_sample_dict(real_file, past)]}
+
+        assert is_reusable_process(real_file, previous) is False
+
+    def test_false_when_not_in_previous_results(self, tmp_path):
+        real_file = str(tmp_path / "doc.pdf")
+        with open(real_file, "w") as f:
+            f.write("content")
+
+        assert is_reusable_process(real_file, {}) is False
+
+    def test_uses_max_processed_at_across_samples(self, tmp_path):
+        """When a file has multiple cached samples, uses the max processed_at."""
+        real_file = str(tmp_path / "doc.pdf")
+        with open(real_file, "w") as f:
+            f.write("content")
+
+        # One sample has past processed_at, another has future → max is future → reusable
+        past = (datetime.now() - timedelta(hours=2)).isoformat()
+        future = (datetime.now() + timedelta(hours=2)).isoformat()
+        previous = {
+            real_file: [
+                _make_sample_dict(real_file, past),
+                _make_sample_dict(real_file, future),
+            ]
+        }
+
+        assert is_reusable_process(real_file, previous) is True
+
+    def test_uses_max_processed_at_all_past(self, tmp_path):
+        """All cached samples have past processed_at → not reusable."""
+        real_file = str(tmp_path / "doc.pdf")
+        with open(real_file, "w") as f:
+            f.write("content")
+
+        past1 = (datetime.now() - timedelta(hours=3)).isoformat()
+        past2 = (datetime.now() - timedelta(hours=1)).isoformat()
+        previous = {
+            real_file: [
+                _make_sample_dict(real_file, past1),
+                _make_sample_dict(real_file, past2),
+            ]
+        }
+
+        assert is_reusable_process(real_file, previous) is False
+
+    def test_mtime_equal_to_processed_at_is_reusable(self, tmp_path):
+        """When mtime == processed_at, should be considered reusable (<=)."""
+        real_file = str(tmp_path / "doc.pdf")
+        with open(real_file, "w") as f:
+            f.write("content")
+
+        # Get the actual mtime and use it as processed_at
+        mtime = os.path.getmtime(real_file)
+        processed_at = datetime.fromtimestamp(mtime).isoformat()
+        previous = {real_file: [_make_sample_dict(real_file, processed_at)]}
+
+        assert is_reusable_process(real_file, previous) is True
+
+
+# ---------------------------------------------------------------------------
+# is_reusable_postprocess
+# ---------------------------------------------------------------------------
+
+
+class TestIsReusablePostprocess:
+    def test_true_when_input_older_than_cached(self):
+        """input_processed_at <= cached processed_at → reusable."""
+        file_path = "/data/doc.pdf"
+        cached_time = "2026-03-01T12:00:00"
+        input_time = "2026-03-01T11:00:00"  # older than cached
+        previous = {file_path: [_make_sample_dict(file_path, cached_time)]}
+
+        assert is_reusable_postprocess(file_path, input_time, previous) is True
+
+    def test_true_when_input_equal_to_cached(self):
+        """input_processed_at == cached processed_at → reusable."""
+        file_path = "/data/doc.pdf"
+        same_time = "2026-03-01T12:00:00"
+        previous = {file_path: [_make_sample_dict(file_path, same_time)]}
+
+        assert is_reusable_postprocess(file_path, same_time, previous) is True
+
+    def test_false_when_input_newer_than_cached(self):
+        """input_processed_at > cached processed_at → not reusable."""
+        file_path = "/data/doc.pdf"
+        cached_time = "2026-03-01T10:00:00"
+        input_time = "2026-03-01T12:00:00"  # newer than cached
+        previous = {file_path: [_make_sample_dict(file_path, cached_time)]}
+
+        assert is_reusable_postprocess(file_path, input_time, previous) is False
+
+    def test_false_when_not_in_previous_results(self):
+        file_path = "/data/doc.pdf"
+        assert is_reusable_postprocess(file_path, "2026-03-01T12:00:00", {}) is False
+
+    def test_uses_max_processed_at_across_cached_samples(self):
+        """Uses the max processed_at from all cached samples for the file."""
+        file_path = "/data/doc.pdf"
+        early = "2026-03-01T08:00:00"
+        late = "2026-03-01T14:00:00"
+        previous = {
+            file_path: [
+                _make_sample_dict(file_path, early),
+                _make_sample_dict(file_path, late),
+            ]
+        }
+
+        # input processed at noon, max cached is 14:00 → noon <= 14:00 → reusable
+        assert (
+            is_reusable_postprocess(file_path, "2026-03-01T12:00:00", previous) is True
+        )
+
+    def test_uses_max_processed_at_all_older_than_input(self):
+        """Even taking the max of cached, it's still older than input → not reusable."""
+        file_path = "/data/doc.pdf"
+        t1 = "2026-03-01T08:00:00"
+        t2 = "2026-03-01T10:00:00"
+        previous = {
+            file_path: [
+                _make_sample_dict(file_path, t1),
+                _make_sample_dict(file_path, t2),
+            ]
+        }
+        # input at noon, max cached is 10:00 → noon > 10:00 → not reusable
+        assert (
+            is_reusable_postprocess(file_path, "2026-03-01T12:00:00", previous) is False
+        )
+
+
+# ---------------------------------------------------------------------------
+# merge_results
+# ---------------------------------------------------------------------------
+
+
+class TestMergeResults:
+    def test_combines_reused_and_new(self):
+        current_files = {"/data/a.pdf", "/data/b.txt"}
+        reused = {
+            "/data/a.pdf": [_make_sample_dict("/data/a.pdf", "2026-01-01T10:00:00")]
+        }
+        new_results = [_make_sample_dict("/data/b.txt", "2026-01-02T10:00:00")]
+
+        result = merge_results(reused, new_results, current_files)
+        assert len(result) == 2
+        file_paths = {r["metadata"]["file_path"] for r in result}
+        assert file_paths == {"/data/a.pdf", "/data/b.txt"}
+
+    def test_drops_deleted_files(self):
+        """Entries whose file_path is not in current_file_paths are excluded."""
+        current_files = {"/data/b.txt"}
+        reused = {
+            "/data/a.pdf": [_make_sample_dict("/data/a.pdf", "2026-01-01T10:00:00")]
+        }
+        new_results = [_make_sample_dict("/data/b.txt", "2026-01-02T10:00:00")]
+
+        result = merge_results(reused, new_results, current_files)
+        assert len(result) == 1
+        assert result[0]["metadata"]["file_path"] == "/data/b.txt"
+
+    def test_empty_reused_returns_only_new(self):
+        current_files = {"/data/b.txt"}
+        new_results = [_make_sample_dict("/data/b.txt", "2026-01-02T10:00:00")]
+
+        result = merge_results({}, new_results, current_files)
+        assert len(result) == 1
+        assert result[0]["metadata"]["file_path"] == "/data/b.txt"
+
+    def test_empty_new_returns_only_reused(self):
+        current_files = {"/data/a.pdf"}
+        reused = {
+            "/data/a.pdf": [_make_sample_dict("/data/a.pdf", "2026-01-01T10:00:00")]
+        }
+
+        result = merge_results(reused, [], current_files)
+        assert len(result) == 1
+        assert result[0]["metadata"]["file_path"] == "/data/a.pdf"
+
+    def test_both_empty_returns_empty_list(self):
+        result = merge_results({}, [], set())
+        assert result == []
+
+    def test_multiple_samples_per_file_included(self):
+        current_files = {"/data/a.pdf"}
+        reused = {
+            "/data/a.pdf": [
+                _make_sample_dict("/data/a.pdf", "2026-01-01T10:00:00"),
+                _make_sample_dict("/data/a.pdf", "2026-01-01T10:00:01"),
+            ]
+        }
+
+        result = merge_results(reused, [], current_files)
+        assert len(result) == 2
+
+    def test_new_results_with_deleted_file_path_dropped(self):
+        """new_results entries whose file_path is not in current_file_paths are also dropped."""
+        current_files = {"/data/a.pdf"}
+        # new_results contains a file that is no longer current
+        new_results = [
+            _make_sample_dict("/data/a.pdf", "2026-01-02T10:00:00"),
+            _make_sample_dict("/data/deleted.pdf", "2026-01-02T11:00:00"),
+        ]
+
+        result = merge_results({}, new_results, current_files)
+        assert len(result) == 1
+        assert result[0]["metadata"]["file_path"] == "/data/a.pdf"
+
+    def test_returns_flat_list(self):
+        """merge_results always returns a flat list of dicts."""
+        current_files = {"/data/a.pdf", "/data/b.txt"}
+        reused = {
+            "/data/a.pdf": [
+                _make_sample_dict("/data/a.pdf", "2026-01-01T10:00:00"),
+                _make_sample_dict("/data/a.pdf", "2026-01-01T10:00:01"),
+            ]
+        }
+        new_results = [
+            _make_sample_dict("/data/b.txt", "2026-01-02T10:00:00"),
+        ]
+
+        result = merge_results(reused, new_results, current_files)
+        assert isinstance(result, list)
+        assert all(isinstance(r, dict) for r in result)
+        assert len(result) == 3

--- a/tests/test_previous_results.py
+++ b/tests/test_previous_results.py
@@ -10,6 +10,7 @@ from mmore.process.previous_results import (
     load_previous_results,
     merge_results,
 )
+from mmore.type import MultimodalSample
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -26,6 +27,11 @@ def _make_sample_dict(file_path: str, processed_at: str) -> dict:
             "processed_at": processed_at,
         },
     }
+
+
+def _make_sample(file_path: str, processed_at: str) -> MultimodalSample:
+    """Build a minimal MultimodalSample for tests."""
+    return MultimodalSample.from_dict(_make_sample_dict(file_path, processed_at))
 
 
 def _write_jsonl(path: str, samples: list[dict]) -> None:
@@ -54,16 +60,16 @@ class TestLoadPreviousResults:
         assert len(result["/data/a.pdf"]) == 2
         assert len(result["/data/b.txt"]) == 1
 
-    def test_sample_dicts_preserved(self, tmp_path):
+    def test_samples_preserved(self, tmp_path):
         jsonl = str(tmp_path / "results.jsonl")
         sample = _make_sample_dict("/data/a.pdf", "2026-01-01T10:00:00")
         _write_jsonl(jsonl, [sample])
 
         result = load_previous_results(jsonl)
-        assert result["/data/a.pdf"][0]["text"] == "content of /data/a.pdf"
+        assert isinstance(result["/data/a.pdf"][0], MultimodalSample)
+        assert result["/data/a.pdf"][0].text == "content of /data/a.pdf"
         assert (
-            result["/data/a.pdf"][0]["metadata"]["processed_at"]
-            == "2026-01-01T10:00:00"
+            result["/data/a.pdf"][0].metadata["processed_at"] == "2026-01-01T10:00:00"
         )
 
     def test_empty_file_returns_empty_dict(self, tmp_path):
@@ -106,7 +112,7 @@ class TestIsReusableProcess:
 
         # processed_at is in the future relative to mtime → reusable
         future = (datetime.now() + timedelta(hours=1)).isoformat()
-        previous = {real_file: [_make_sample_dict(real_file, future)]}
+        previous = {real_file: [_make_sample(real_file, future)]}
 
         assert is_reusable_process(real_file, previous) is True
 
@@ -118,7 +124,7 @@ class TestIsReusableProcess:
 
         # processed_at is in the past relative to mtime → not reusable
         past = (datetime.now() - timedelta(hours=1)).isoformat()
-        previous = {real_file: [_make_sample_dict(real_file, past)]}
+        previous = {real_file: [_make_sample(real_file, past)]}
 
         assert is_reusable_process(real_file, previous) is False
 
@@ -140,8 +146,8 @@ class TestIsReusableProcess:
         future = (datetime.now() + timedelta(hours=2)).isoformat()
         previous = {
             real_file: [
-                _make_sample_dict(real_file, past),
-                _make_sample_dict(real_file, future),
+                _make_sample(real_file, past),
+                _make_sample(real_file, future),
             ]
         }
 
@@ -157,8 +163,8 @@ class TestIsReusableProcess:
         past2 = (datetime.now() - timedelta(hours=1)).isoformat()
         previous = {
             real_file: [
-                _make_sample_dict(real_file, past1),
-                _make_sample_dict(real_file, past2),
+                _make_sample(real_file, past1),
+                _make_sample(real_file, past2),
             ]
         }
 
@@ -173,7 +179,7 @@ class TestIsReusableProcess:
         # Get the actual mtime and use it as processed_at
         mtime = os.path.getmtime(real_file)
         processed_at = datetime.fromtimestamp(mtime).isoformat()
-        previous = {real_file: [_make_sample_dict(real_file, processed_at)]}
+        previous = {real_file: [_make_sample(real_file, processed_at)]}
 
         assert is_reusable_process(real_file, previous) is True
 
@@ -189,7 +195,7 @@ class TestIsReusablePostprocess:
         file_path = "/data/doc.pdf"
         cached_time = "2026-03-01T12:00:00"
         input_time = "2026-03-01T11:00:00"  # older than cached
-        previous = {file_path: [_make_sample_dict(file_path, cached_time)]}
+        previous = {file_path: [_make_sample(file_path, cached_time)]}
 
         assert is_reusable_postprocess(file_path, input_time, previous) is True
 
@@ -197,7 +203,7 @@ class TestIsReusablePostprocess:
         """input_processed_at == cached processed_at → reusable."""
         file_path = "/data/doc.pdf"
         same_time = "2026-03-01T12:00:00"
-        previous = {file_path: [_make_sample_dict(file_path, same_time)]}
+        previous = {file_path: [_make_sample(file_path, same_time)]}
 
         assert is_reusable_postprocess(file_path, same_time, previous) is True
 
@@ -206,7 +212,7 @@ class TestIsReusablePostprocess:
         file_path = "/data/doc.pdf"
         cached_time = "2026-03-01T10:00:00"
         input_time = "2026-03-01T12:00:00"  # newer than cached
-        previous = {file_path: [_make_sample_dict(file_path, cached_time)]}
+        previous = {file_path: [_make_sample(file_path, cached_time)]}
 
         assert is_reusable_postprocess(file_path, input_time, previous) is False
 
@@ -221,8 +227,8 @@ class TestIsReusablePostprocess:
         late = "2026-03-01T14:00:00"
         previous = {
             file_path: [
-                _make_sample_dict(file_path, early),
-                _make_sample_dict(file_path, late),
+                _make_sample(file_path, early),
+                _make_sample(file_path, late),
             ]
         }
 
@@ -238,8 +244,8 @@ class TestIsReusablePostprocess:
         t2 = "2026-03-01T10:00:00"
         previous = {
             file_path: [
-                _make_sample_dict(file_path, t1),
-                _make_sample_dict(file_path, t2),
+                _make_sample(file_path, t1),
+                _make_sample(file_path, t2),
             ]
         }
         # input at noon, max cached is 10:00 → noon > 10:00 → not reusable
@@ -256,45 +262,39 @@ class TestIsReusablePostprocess:
 class TestMergeResults:
     def test_combines_reused_and_new(self):
         current_files = {"/data/a.pdf", "/data/b.txt"}
-        reused = {
-            "/data/a.pdf": [_make_sample_dict("/data/a.pdf", "2026-01-01T10:00:00")]
-        }
-        new_results = [_make_sample_dict("/data/b.txt", "2026-01-02T10:00:00")]
+        reused = {"/data/a.pdf": [_make_sample("/data/a.pdf", "2026-01-01T10:00:00")]}
+        new_results = [_make_sample("/data/b.txt", "2026-01-02T10:00:00")]
 
         result = merge_results(reused, new_results, current_files)
         assert len(result) == 2
-        file_paths = {r["metadata"]["file_path"] for r in result}
+        file_paths = {r.metadata["file_path"] for r in result}
         assert file_paths == {"/data/a.pdf", "/data/b.txt"}
 
     def test_drops_deleted_files(self):
         """Entries whose file_path is not in current_file_paths are excluded."""
         current_files = {"/data/b.txt"}
-        reused = {
-            "/data/a.pdf": [_make_sample_dict("/data/a.pdf", "2026-01-01T10:00:00")]
-        }
-        new_results = [_make_sample_dict("/data/b.txt", "2026-01-02T10:00:00")]
+        reused = {"/data/a.pdf": [_make_sample("/data/a.pdf", "2026-01-01T10:00:00")]}
+        new_results = [_make_sample("/data/b.txt", "2026-01-02T10:00:00")]
 
         result = merge_results(reused, new_results, current_files)
         assert len(result) == 1
-        assert result[0]["metadata"]["file_path"] == "/data/b.txt"
+        assert result[0].metadata["file_path"] == "/data/b.txt"
 
     def test_empty_reused_returns_only_new(self):
         current_files = {"/data/b.txt"}
-        new_results = [_make_sample_dict("/data/b.txt", "2026-01-02T10:00:00")]
+        new_results = [_make_sample("/data/b.txt", "2026-01-02T10:00:00")]
 
         result = merge_results({}, new_results, current_files)
         assert len(result) == 1
-        assert result[0]["metadata"]["file_path"] == "/data/b.txt"
+        assert result[0].metadata["file_path"] == "/data/b.txt"
 
     def test_empty_new_returns_only_reused(self):
         current_files = {"/data/a.pdf"}
-        reused = {
-            "/data/a.pdf": [_make_sample_dict("/data/a.pdf", "2026-01-01T10:00:00")]
-        }
+        reused = {"/data/a.pdf": [_make_sample("/data/a.pdf", "2026-01-01T10:00:00")]}
 
         result = merge_results(reused, [], current_files)
         assert len(result) == 1
-        assert result[0]["metadata"]["file_path"] == "/data/a.pdf"
+        assert result[0].metadata["file_path"] == "/data/a.pdf"
 
     def test_both_empty_returns_empty_list(self):
         result = merge_results({}, [], set())
@@ -304,8 +304,8 @@ class TestMergeResults:
         current_files = {"/data/a.pdf"}
         reused = {
             "/data/a.pdf": [
-                _make_sample_dict("/data/a.pdf", "2026-01-01T10:00:00"),
-                _make_sample_dict("/data/a.pdf", "2026-01-01T10:00:01"),
+                _make_sample("/data/a.pdf", "2026-01-01T10:00:00"),
+                _make_sample("/data/a.pdf", "2026-01-01T10:00:01"),
             ]
         }
 
@@ -317,28 +317,28 @@ class TestMergeResults:
         current_files = {"/data/a.pdf"}
         # new_results contains a file that is no longer current
         new_results = [
-            _make_sample_dict("/data/a.pdf", "2026-01-02T10:00:00"),
-            _make_sample_dict("/data/deleted.pdf", "2026-01-02T11:00:00"),
+            _make_sample("/data/a.pdf", "2026-01-02T10:00:00"),
+            _make_sample("/data/deleted.pdf", "2026-01-02T11:00:00"),
         ]
 
         result = merge_results({}, new_results, current_files)
         assert len(result) == 1
-        assert result[0]["metadata"]["file_path"] == "/data/a.pdf"
+        assert result[0].metadata["file_path"] == "/data/a.pdf"
 
     def test_returns_flat_list(self):
-        """merge_results always returns a flat list of dicts."""
+        """merge_results always returns a flat list of MultimodalSample."""
         current_files = {"/data/a.pdf", "/data/b.txt"}
         reused = {
             "/data/a.pdf": [
-                _make_sample_dict("/data/a.pdf", "2026-01-01T10:00:00"),
-                _make_sample_dict("/data/a.pdf", "2026-01-01T10:00:01"),
+                _make_sample("/data/a.pdf", "2026-01-01T10:00:00"),
+                _make_sample("/data/a.pdf", "2026-01-01T10:00:01"),
             ]
         }
         new_results = [
-            _make_sample_dict("/data/b.txt", "2026-01-02T10:00:00"),
+            _make_sample("/data/b.txt", "2026-01-02T10:00:00"),
         ]
 
         result = merge_results(reused, new_results, current_files)
         assert isinstance(result, list)
-        assert all(isinstance(r, dict) for r in result)
+        assert all(isinstance(r, MultimodalSample) for r in result)
         assert len(result) == 3


### PR DESCRIPTION
## Summary 

Related issue: #244

- Add a way to skip files and documents that have not changed since a previous run, for both the process and post-process pipelines
- New module `incremental.py` with two loaders (one per stage), two reuse-check helpers, and a shared merge function
- Dispatcher now clears each processor's `results.jsonl` before a run, so reruns do not append on top of previous output and end up with duplicate samples                                                                                                                     
- Process stage uses the cached sample's `processed_at` to check if we can reuse it. A file is skipped if the cached `processed_at` of the sample is at least as recent as the file last modified time `mtime`: this can be summarized as `(mtime <= processed_at)`                                  
- Post-process stage uses `min(cached processed_at)` to check if we can reuse previous samples. A file is skipped if the oldest cached chunk is at least as recent as the input's `processed_at`: this can be summarized as `(input_processed_at <= min(cached processed_at))`           
- Process and post-process runs also drop cached results for files that no longer exist                                                                                    
- New `previous_results` parameter in the config YAML files, it can be set to the path of a previous `results.jsonl` (set to null by default)