### PR TITLE
Quick fix of an issue for saving temporarily

### DIFF
--- a/src/mmore/process/post_processor/pipeline.py
+++ b/src/mmore/process/post_processor/pipeline.py
@@ -131,7 +131,9 @@ class PPPipeline:
         """Run processors only on samples from new/changed source documents."""
         output_dir = os.path.dirname(self.output_config.output_path) or "."
 
-        assert self.previous_results_path is not None
+        assert self.previous_results_path is not None and os.path.exists(
+            self.previous_results_path
+        ), f"Previous results file not found: {self.previous_results_path}"
         previous = load_previous_postprocess_results(self.previous_results_path)
 
         # Group input samples by file_path

--- a/src/mmore/process/post_processor/pipeline.py
+++ b/src/mmore/process/post_processor/pipeline.py
@@ -35,6 +35,12 @@ class PPPipelineConfig:
     previous_results: Optional[str] = None
 
 
+def _jsonl_path(path: str, filename: str = "final.jsonl") -> str:
+    if path.endswith(".jsonl"):
+        return path
+    return f"{path}/{filename}"
+
+
 class PPPipeline:
     def __init__(
         self,
@@ -116,9 +122,7 @@ class PPPipeline:
         for sample in samples:
             sample.metadata["processed_at"] = processed_at
 
-        save_samples(
-            samples, os.path.join(self.output_config.output_path, "final.jsonl")
-        )
+        save_samples(samples, _jsonl_path(self.output_config.output_path))
         return samples
 
     def _run_incremental(
@@ -164,7 +168,7 @@ class PPPipeline:
             merged_samples = merge_results(reused, [], current_file_paths)
             save_samples(
                 merged_samples,
-                os.path.join(self.output_config.output_path, "final.jsonl"),
+                _jsonl_path(self.output_config.output_path),
             )
             return merged_samples
 
@@ -192,7 +196,5 @@ class PPPipeline:
             sample.metadata["processed_at"] = processed_at
 
         merged_samples = merge_results(reused, processed, current_file_paths)
-        save_samples(
-            merged_samples, os.path.join(self.output_config.output_path, "final.jsonl")
-        )
+        save_samples(merged_samples, _jsonl_path(self.output_config.output_path))
         return merged_samples

--- a/src/mmore/process/post_processor/pipeline.py
+++ b/src/mmore/process/post_processor/pipeline.py
@@ -38,7 +38,7 @@ class PPPipelineConfig:
 def _jsonl_path(path: str, filename: str = "final.jsonl") -> str:
     if path.endswith(".jsonl"):
         return path
-    return f"{path}/{filename}"
+    return os.path.normpath(os.path.join(path, filename))
 
 
 class PPPipeline:

--- a/src/mmore/process/post_processor/pipeline.py
+++ b/src/mmore/process/post_processor/pipeline.py
@@ -116,7 +116,9 @@ class PPPipeline:
         for sample in samples:
             sample.metadata["processed_at"] = processed_at
 
-        save_samples(samples, self.output_config.output_path)
+        save_samples(
+            samples, os.path.join(self.output_config.output_path, "final.jsonl")
+        )
         return samples
 
     def _run_incremental(
@@ -125,6 +127,7 @@ class PPPipeline:
         """Run processors only on samples from new/changed source documents."""
         output_dir = os.path.dirname(self.output_config.output_path) or "."
 
+        assert self.previous_results_path is not None
         previous = load_previous_postprocess_results(self.previous_results_path)
 
         # Group input samples by file_path
@@ -159,7 +162,10 @@ class PPPipeline:
 
         if not to_process_file_paths:
             merged_samples = merge_results(reused, [], current_file_paths)
-            save_samples(merged_samples, self.output_config.output_path)
+            save_samples(
+                merged_samples,
+                os.path.join(self.output_config.output_path, "final.jsonl"),
+            )
             return merged_samples
 
         # Collect samples to process
@@ -186,5 +192,7 @@ class PPPipeline:
             sample.metadata["processed_at"] = processed_at
 
         merged_samples = merge_results(reused, processed, current_file_paths)
-        save_samples(merged_samples, self.output_config.output_path)
+        save_samples(
+            merged_samples, os.path.join(self.output_config.output_path, "final.jsonl")
+        )
         return merged_samples

--- a/src/mmore/process/post_processor/pipeline.py
+++ b/src/mmore/process/post_processor/pipeline.py
@@ -10,7 +10,7 @@ from ..incremental import (
     load_previous_postprocess_results,
     merge_results,
 )
-from ..utils import save_samples
+from ..utils import _jsonl_path, save_samples
 from . import BasePostProcessor, BasePostProcessorConfig, load_postprocessor
 
 logger = logging.getLogger(__name__)
@@ -33,12 +33,6 @@ class PPPipelineConfig:
     pp_modules: List[BasePostProcessorConfig]
     output: OutputConfig
     previous_results: Optional[str] = None
-
-
-def _jsonl_path(path: str, filename: str = "final.jsonl") -> str:
-    if path.endswith(".jsonl"):
-        return path
-    return os.path.normpath(os.path.join(path, filename))
 
 
 class PPPipeline:

--- a/src/mmore/process/post_processor/pipeline.py
+++ b/src/mmore/process/post_processor/pipeline.py
@@ -10,7 +10,7 @@ from ..incremental import (
     load_previous_postprocess_results,
     merge_results,
 )
-from ..utils import _jsonl_path, save_samples
+from ..utils import jsonl_path, save_samples
 from . import BasePostProcessor, BasePostProcessorConfig, load_postprocessor
 
 logger = logging.getLogger(__name__)
@@ -116,7 +116,7 @@ class PPPipeline:
         for sample in samples:
             sample.metadata["processed_at"] = processed_at
 
-        save_samples(samples, _jsonl_path(self.output_config.output_path))
+        save_samples(samples, jsonl_path(self.output_config.output_path))
         return samples
 
     def _run_incremental(
@@ -164,7 +164,7 @@ class PPPipeline:
             merged_samples = merge_results(reused, [], current_file_paths)
             save_samples(
                 merged_samples,
-                _jsonl_path(self.output_config.output_path),
+                jsonl_path(self.output_config.output_path),
             )
             return merged_samples
 
@@ -192,5 +192,5 @@ class PPPipeline:
             sample.metadata["processed_at"] = processed_at
 
         merged_samples = merge_results(reused, processed, current_file_paths)
-        save_samples(merged_samples, _jsonl_path(self.output_config.output_path))
+        save_samples(merged_samples, jsonl_path(self.output_config.output_path))
         return merged_samples

--- a/src/mmore/process/utils.py
+++ b/src/mmore/process/utils.py
@@ -18,6 +18,12 @@ from ..type import MultimodalSample
 logger = logging.getLogger(__name__)
 
 
+def _jsonl_path(path: str, filename: str = "final.jsonl") -> str:
+    if path.endswith(".jsonl"):
+        return path
+    return os.path.normpath(os.path.join(path, filename))
+
+
 def clean_text(text: str) -> str:
     """
     Clean a given text using `cleantext` library. https://pypi.org/project/clean-text/

--- a/src/mmore/process/utils.py
+++ b/src/mmore/process/utils.py
@@ -6,6 +6,7 @@ cleaning, splitting, and aggregation.
 
 import json
 import logging
+import os
 from typing import List
 
 import numpy as np
@@ -98,6 +99,7 @@ def save_samples(
     """
     try:
         mode = "a" if append_mode else "w"
+        os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, mode) as f:
             for result in samples:
                 f.write(json.dumps(result.to_dict()) + "\n")

--- a/src/mmore/process/utils.py
+++ b/src/mmore/process/utils.py
@@ -18,7 +18,7 @@ from ..type import MultimodalSample
 logger = logging.getLogger(__name__)
 
 
-def _jsonl_path(path: str, filename: str = "final.jsonl") -> str:
+def jsonl_path(path: str, filename: str = "final.jsonl") -> str:
     if path.endswith(".jsonl"):
         return path
     return os.path.normpath(os.path.join(path, filename))

--- a/src/mmore/process/utils.py
+++ b/src/mmore/process/utils.py
@@ -99,7 +99,10 @@ def save_samples(
     """
     try:
         mode = "a" if append_mode else "w"
-        os.makedirs(os.path.dirname(path), exist_ok=True)
+        directory = os.path.dirname(path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
+
         with open(path, mode) as f:
             for result in samples:
                 f.write(json.dumps(result.to_dict()) + "\n")


### PR DESCRIPTION
This pull request updates the post-processing pipeline to consistently write output results to a `final.jsonl` file inside the specified output directory, instead of directly to the directory path. It also adds a safety check to ensure the previous results path is set when running incremental processing, and improves robustness when saving output files.

Key output path changes:

* Updated both full and incremental processing methods in `pipeline.py` to save output samples to `final.jsonl` within the output directory, rather than directly to the directory path. [[1]](diffhunk://#diff-d7b15b72f72bdb270bbd1b3f2319884eda554590d8e05938cea2f9ee6e658d49L119-R121) [[2]](diffhunk://#diff-d7b15b72f72bdb270bbd1b3f2319884eda554590d8e05938cea2f9ee6e658d49L162-R168) [[3]](diffhunk://#diff-d7b15b72f72bdb270bbd1b3f2319884eda554590d8e05938cea2f9ee6e658d49L189-R197)

Robustness and safety improvements:

* Added an assertion to ensure `previous_results_path` is not `None` before loading previous results in incremental processing.
* Modified `save_samples` in `utils.py` to create the parent directory for the output file if it does not exist, preventing errors when saving.
* Added an import for `os` in `utils.py` to support directory creation.