### PR TITLE
Fix consumed file ID when upload fails

### DIFF
--- a/src/mmore/run_index_api.py
+++ b/src/mmore/run_index_api.py
@@ -93,11 +93,17 @@ def make_router(config_path: str) -> APIRouter:
                     documents = process_files_default(
                         temp_dir, COLLECTION_NAME, [file_extension]
                     )
-                except Exception:
+                except KeyError as e:
+                    logger.warning(
+                        "Could not process file '%s' with extension '%s'",
+                        file.filename,
+                        file_extension,
+                        exc_info=True,
+                    )
                     raise HTTPException(
                         status_code=422,
                         detail=f"Could not process file '{file.filename}'",
-                    )
+                    ) from e
 
                 # Save a permanent copy for later retrieval
                 os.makedirs(os.path.dirname(file_storage_path), exist_ok=True)
@@ -188,11 +194,16 @@ def make_router(config_path: str) -> APIRouter:
                     documents = process_files_default(
                         temp_dir, COLLECTION_NAME, file_extensions
                     )
-                except Exception:
+                except KeyError as e:
+                    logger.warning(
+                        "Could not process one of the uploaded files with extensions %s",
+                        file_extensions,
+                        exc_info=True,
+                    )
                     raise HTTPException(
                         status_code=422,
                         detail="Could not process one of the uploaded files",
-                    )
+                    ) from e
 
                 # Save permanent copies
                 for temp_path, file_id in zip(temp_paths, listIds):

--- a/src/mmore/run_index_api.py
+++ b/src/mmore/run_index_api.py
@@ -176,7 +176,7 @@ def make_router(config_path: str) -> APIRouter:
                         )
 
                     # Save to temp directory
-                    file_name = FilePath(temp_dir) / file.filename
+                    file_name = FilePath(temp_dir) / f"{file_id}_{file.filename}"
                     with file_name.open("wb") as buffer:
                         shutil.copyfileobj(file.file, buffer)
                     temp_paths.append(file_name)

--- a/src/mmore/run_index_api.py
+++ b/src/mmore/run_index_api.py
@@ -87,15 +87,21 @@ def make_router(config_path: str) -> APIRouter:
 
                 await file.close()
 
+                # Process and index the file
+                file_extension = FilePath(file.filename).suffix.lower()
+                try:
+                    documents = process_files_default(
+                        temp_dir, COLLECTION_NAME, [file_extension]
+                    )
+                except Exception:
+                    raise HTTPException(
+                        status_code=422,
+                        detail=f"Could not process file '{file.filename}'",
+                    )
+
                 # Save a permanent copy for later retrieval
                 os.makedirs(os.path.dirname(file_storage_path), exist_ok=True)
                 shutil.copy2(temp_file_path, file_storage_path)
-
-                # Process and index the file
-                file_extension = FilePath(file.filename).suffix.lower()
-                documents = process_files_default(
-                    temp_dir, COLLECTION_NAME, [file_extension]
-                )
 
                 for doc in documents:
                     defDocId = doc.document_id
@@ -147,6 +153,7 @@ def make_router(config_path: str) -> APIRouter:
             with tempfile.TemporaryDirectory() as temp_dir:
                 logging.info(f"Starting to process {len(files)} files with custom IDs")
 
+                temp_paths: List[FilePath] = []
                 for file, file_id in zip(files, listIds):
                     if file.filename is None:
                         raise HTTPException(
@@ -166,9 +173,7 @@ def make_router(config_path: str) -> APIRouter:
                     file_name = FilePath(temp_dir) / file.filename
                     with file_name.open("wb") as buffer:
                         shutil.copyfileobj(file.file, buffer)
-
-                    # Save a permanent copy
-                    shutil.copy2(file_name, file_storage_path)
+                    temp_paths.append(file_name)
 
                     # Close the file
                     await file.close()
@@ -179,9 +184,20 @@ def make_router(config_path: str) -> APIRouter:
                 file_extensions = [
                     FilePath(cast(str, file.filename)).suffix.lower() for file in files
                 ]
-                documents = process_files_default(
-                    temp_dir, COLLECTION_NAME, file_extensions
-                )
+                try:
+                    documents = process_files_default(
+                        temp_dir, COLLECTION_NAME, file_extensions
+                    )
+                except Exception:
+                    raise HTTPException(
+                        status_code=422,
+                        detail="Could not process one of the uploaded files",
+                    )
+
+                # Save permanent copies
+                for temp_path, file_id in zip(temp_paths, listIds):
+                    file_storage_path = FilePath(UPLOAD_DIR) / file_id
+                    shutil.copy2(temp_path, file_storage_path)
 
                 # Change the IDs to match the ones from the client
                 modified_documents = []

--- a/tests/test_live_retriever_api.py
+++ b/tests/test_live_retriever_api.py
@@ -406,6 +406,32 @@ def test_upload_duplicate_file_returns_400(indexer_client):
     assert "already exists" in response.json()["detail"]
 
 
+def test_upload_failed_processing_does_not_consume_id(indexer_client):
+    tc, upload_dir, _ = indexer_client
+    file_id = "id"
+
+    response = tc.post(
+        "/v1/files",
+        data={"fileId": file_id},
+        files={"file": ("file.xyz", b"bad", "application/octet-stream")},
+    )
+    assert response.status_code == 422
+    assert not Path(upload_dir, file_id).exists()
+
+    fake_path = str(Path(upload_dir) / "good.txt")
+    with patch(
+        "mmore.run_index_api.process_files_default",
+        return_value=[_fake_doc(fake_path, file_id)],
+    ):
+        response = tc.post(
+            "/v1/files",
+            data={"fileId": file_id},
+            files={"file": ("file.txt", b"good", "text/plain")},
+        )
+    assert response.status_code == 201
+    assert Path(upload_dir, file_id).read_bytes() == b"good"
+
+
 # ---------------------------------------------------------------------------
 # POST /v1/files/bulk
 # ---------------------------------------------------------------------------
@@ -448,6 +474,40 @@ def test_upload_bulk_mismatched_ids_returns_400(indexer_client):
         )
     assert response.status_code == 400
     assert "doesn't match" in response.json()["detail"]
+
+
+def test_upload_bulk_failed_processing_does_not_consume_ids(indexer_client):
+    tc, upload_dir, _ = indexer_client
+    ids = ["id-1", "id-2"]
+
+    response = tc.post(
+        "/v1/files/bulk",
+        data={"listIds": ",".join(ids)},
+        files=[
+            ("files", ("file.xyz", b"bad A", "application/octet-stream")),
+            ("files", ("file.xyz", b"bad B", "application/octet-stream")),
+        ],
+    )
+    assert response.status_code == 422
+    for file_id in ids:
+        assert not Path(upload_dir, file_id).exists()
+
+    fake_paths = [str(Path(upload_dir) / f"{i}_file.txt") for i in ids]
+    with patch(
+        "mmore.run_index_api.process_files_default",
+        return_value=[_fake_doc(p, i) for p, i in zip(fake_paths, ids)],
+    ):
+        response = tc.post(
+            "/v1/files/bulk",
+            data={"listIds": ",".join(ids)},
+            files=[
+                ("files", ("file.txt", b"good A", "text/plain")),
+                ("files", ("file.txt", b"good B", "text/plain")),
+            ],
+        )
+    assert response.status_code == 201
+    assert Path(upload_dir, ids[0]).read_bytes() == b"good A"
+    assert Path(upload_dir, ids[1]).read_bytes() == b"good B"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Related issue: #290 
- `POST /v1/files`: Files are now saved to disk only _after_ processing succeeds, this way when the upload fails the id is not reserved
- Unsupported files return 422 HTTP error instead of a 500 crash
- `POST /v1/files/bulk`: fixed similarly when one of the uploaded files fails

## Demo

When uploading twice an invalid file with the same ID:
```bash
# The command below is run twice
curl http://localhost:8000/v1/files --form "fileId=id" --form file=@/dev/null
```

The http response is now `{"detail":"Could not process file 'null'"}`.

And the API logs are the following:
```bash
INFO:     Started server process [12988]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
[INDEX API 🗂️ -- 2026-05-11 11:46:19] Found 1 files/URLs to process.
[INDEX API 🗂️ -- 2026-05-11 11:46:19] No registered processor found for file <mmore.type.FileDescriptor object at 0x345e68cd0>
[INDEX API 🗂️ -- 2026-05-11 11:46:19] Could not process file 'null' with extension ''
Traceback (most recent call last):
  File "/Users/chaverot/dev/thesis/mmore-index-api-consuming-id-on-error/src/mmore/run_index_api.py", line 93, in upload_file
    documents = process_files_default(
                ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chaverot/dev/thesis/mmore-index-api-consuming-id-on-error/src/mmore/utils.py", line 231, in process_files_default
    raw_documents = sum(list(dispatcher()), [])
                             ^^^^^^^^^^^^
  File "/Users/chaverot/dev/thesis/mmore-index-api-consuming-id-on-error/src/mmore/process/dispatcher.py", line 407, in __call__
    return self.dispatch()
           ^^^^^^^^^^^^^^^
  File "/Users/chaverot/dev/thesis/mmore-index-api-consuming-id-on-error/src/mmore/process/dispatcher.py", line 381, in dispatch
    self._bucket_files()
  File "/Users/chaverot/dev/thesis/mmore-index-api-consuming-id-on-error/src/mmore/process/dispatcher.py", line 167, in _bucket_files
    processor_map[processor].append(file)
    ~~~~~~~~~~~~~^^^^^^^^^^^
KeyError: None
INFO:     127.0.0.1:51776 - "POST /v1/files HTTP/1.1" 422 Unprocessable Entity
[INDEX API 🗂️ -- 2026-05-11 11:46:20] Found 1 files/URLs to process.
[INDEX API 🗂️ -- 2026-05-11 11:46:20] No registered processor found for file <mmore.type.FileDescriptor object at 0x345e68a10>
[INDEX API 🗂️ -- 2026-05-11 11:46:20] Could not process file 'null' with extension ''
Traceback (most recent call last):
  File "/Users/chaverot/dev/thesis/mmore-index-api-consuming-id-on-error/src/mmore/run_index_api.py", line 93, in upload_file
    documents = process_files_default(
                ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chaverot/dev/thesis/mmore-index-api-consuming-id-on-error/src/mmore/utils.py", line 231, in process_files_default
    raw_documents = sum(list(dispatcher()), [])
                             ^^^^^^^^^^^^
  File "/Users/chaverot/dev/thesis/mmore-index-api-consuming-id-on-error/src/mmore/process/dispatcher.py", line 407, in __call__
    return self.dispatch()
           ^^^^^^^^^^^^^^^
  File "/Users/chaverot/dev/thesis/mmore-index-api-consuming-id-on-error/src/mmore/process/dispatcher.py", line 381, in dispatch
    self._bucket_files()
  File "/Users/chaverot/dev/thesis/mmore-index-api-consuming-id-on-error/src/mmore/process/dispatcher.py", line 167, in _bucket_files
    processor_map[processor].append(file)
    ~~~~~~~~~~~~~^^^^^^^^^^^
KeyError: None
INFO:     127.0.0.1:51778 - "POST /v1/files HTTP/1.1" 422 Unprocessable Entity
```

And the same goes for the bulk endpoint