### PR TITLE
Add workflow for Pyright type check

### DIFF
--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -1,0 +1,29 @@
+name: 📐 Pyright type checks
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  pyright:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv and create venv
+        run: |
+          pipx install uv
+          uv venv .venv
+
+      - name: Install dependencies
+        run: |
+          source .venv/bin/activate
+          uv pip install -e ".[process,index,rag,api,cpu,dev,websearch]"
+
+      - name: Run Pyright
+        continue-on-error: true
+        run: |
+          source .venv/bin/activate
+          pyright

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install uv and create venv
         run: |
           pipx install uv
-          uv venv
+          uv venv .venv
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -12,10 +12,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
       - name: Install uv and create venv
         run: |
           pipx install uv
-          uv venv .venv
+          uv venv
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary

Related issue: #297 
Added a new non blocking workflow to run pyright static type checks. There are three ways to trigger the CI: on push on master, on push to a PR and manually