### PR TITLE
Fix #288

### DIFF
--- a/src/mmore/run_index_api.py
+++ b/src/mmore/run_index_api.py
@@ -34,6 +34,19 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
+def _apply_uploaded_file_metadata(documents, file_id: str, filename: str) -> None:
+    """Bind processed chunks to the API file ID and persist the original filename."""
+    for doc in documents:
+        default_doc_id = doc.document_id
+        doc.document_id = file_id
+        if default_doc_id and doc.id.startswith(default_doc_id):
+            doc.id = f"{file_id}{doc.id[len(default_doc_id) :]}"
+        else:
+            doc.id = file_id
+
+        doc.metadata.extra["filename"] = filename
+
+
 def make_router(config_path: str) -> APIRouter:
     router = APIRouter()
 
@@ -97,10 +110,7 @@ def make_router(config_path: str) -> APIRouter:
                     temp_dir, COLLECTION_NAME, [file_extension]
                 )
 
-                for doc in documents:
-                    defDocId = doc.document_id
-                    doc.document_id = fileId
-                    doc.id = doc.id.replace(defDocId, fileId)
+                _apply_uploaded_file_metadata(documents, fileId, file.filename)
 
                 # Get indexer and index the document
                 try:
@@ -257,9 +267,8 @@ def make_router(config_path: str) -> APIRouter:
                     temp_dir, COLLECTION_NAME, [file_extension]
                 )
 
-                # Set the custom ID
-                for doc in documents:
-                    doc.id = fileId
+                # Set the custom ID and preserve the original upload filename
+                _apply_uploaded_file_metadata(documents, fileId, file.filename)
 
                 # Get indexer and reindex the document
                 try:

--- a/src/mmore/run_index_api.py
+++ b/src/mmore/run_index_api.py
@@ -23,6 +23,7 @@ from mmore.profiler import enable_profiling_from_env
 
 from .process.processors import register_all_processors
 from .rag.retriever import RetrieverConfig
+from .type import MultimodalSample
 from .utils import get_indexer, load_config, process_files_default
 
 UPLOAD_DIR: str = "./uploads"
@@ -34,15 +35,14 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-def _apply_uploaded_file_metadata(documents, file_id: str, filename: str) -> None:
+def _apply_uploaded_file_metadata(
+    documents: List[MultimodalSample], file_id: str, filename: str
+) -> None:
     """Bind processed chunks to the API file ID and persist the original filename."""
     for doc in documents:
-        default_doc_id = doc.document_id
+        chunk_id = doc.id.rsplit("+")[1] if "+" in doc.id else None
         doc.document_id = file_id
-        if default_doc_id and doc.id.startswith(default_doc_id):
-            doc.id = f"{file_id}{doc.id[len(default_doc_id) :]}"
-        else:
-            doc.id = file_id
+        doc.id = f"{file_id}+{chunk_id}" if chunk_id else file_id
 
         doc.metadata.extra["filename"] = filename
 
@@ -228,10 +228,9 @@ def make_router(config_path: str) -> APIRouter:
 
                 # Change the IDs to match the ones from the client
                 modified_documents = []
-                for doc, docId in zip(documents, listIds):
-                    defDocId = doc.document_id
-                    doc.document_id = docId
-                    doc.id = doc.id.replace(defDocId, docId)
+                for doc, docId, file in zip(documents, listIds, files):
+                    filename = file.filename or ""
+                    _apply_uploaded_file_metadata([doc], docId, filename)
                     modified_documents.append(doc)
 
                 logging.info("Indexing the files")

--- a/src/mmore/run_index_api.py
+++ b/src/mmore/run_index_api.py
@@ -40,7 +40,7 @@ def _apply_uploaded_file_metadata(documents, file_id: str, filename: str) -> Non
         default_doc_id = doc.document_id
         doc.document_id = file_id
         if default_doc_id and doc.id.startswith(default_doc_id):
-            doc.id = f"{file_id}{doc.id[len(default_doc_id) :]}"
+            doc.id = f"{file_id}{doc.id[len(default_doc_id):]}"
         else:
             doc.id = file_id
 

--- a/src/mmore/run_index_api.py
+++ b/src/mmore/run_index_api.py
@@ -163,16 +163,14 @@ def make_router(config_path: str) -> APIRouter:
                 logging.info(f"Starting to process {len(files)} files with custom IDs")
 
                 uploaded_files = []
-                id_by_filename = {}
-                for file, file_id in zip(files, listIds):
+                file_info_by_temp_path = {}
+                for index, (file, file_id) in enumerate(zip(files, listIds)):
                     if file.filename is None:
                         raise HTTPException(
                             status_code=422,
                             detail=f"File {file_id} does not have a filename",
                         )
                     filename = file.filename
-                    uploaded_files.append({"fileId": file_id, "filename": filename})
-                    id_by_filename[filename] = file_id
 
                     # Check if file with this ID already exists
                     file_storage_path = FilePath(UPLOAD_DIR) / file_id
@@ -183,12 +181,22 @@ def make_router(config_path: str) -> APIRouter:
                         )
 
                     # Save to temp directory
-                    file_name = FilePath(temp_dir) / filename
-                    with file_name.open("wb") as buffer:
+                    temp_file_path = (
+                        FilePath(temp_dir) / f"{index}{FilePath(filename).suffix}"
+                    )
+                    file_info = {
+                        "fileId": file_id,
+                        "filename": filename,
+                        "temp_path": str(temp_file_path.resolve()),
+                    }
+                    uploaded_files.append(file_info)
+                    file_info_by_temp_path[file_info["temp_path"]] = file_info
+
+                    with temp_file_path.open("wb") as buffer:
                         shutil.copyfileobj(file.file, buffer)
 
                     # Save a permanent copy
-                    shutil.copy2(file_name, file_storage_path)
+                    shutil.copy2(temp_file_path, file_storage_path)
 
                     # Close the file
                     await file.close()
@@ -197,7 +205,7 @@ def make_router(config_path: str) -> APIRouter:
 
                 # Process the documents
                 file_extensions = [
-                    FilePath(file_info["filename"]).suffix.lower()
+                    FilePath(file_info["temp_path"]).suffix.lower()
                     for file_info in uploaded_files
                 ]
                 documents = process_files_default(
@@ -211,14 +219,15 @@ def make_router(config_path: str) -> APIRouter:
                     file_info["fileId"]: 0 for file_info in uploaded_files
                 }
                 for doc in documents:
-                    filename = FilePath(doc.metadata.file_path).name
-                    doc_id = id_by_filename.get(filename)
-                    if doc_id is None:
+                    temp_path = str(FilePath(doc.metadata.file_path).resolve())
+                    file_info = file_info_by_temp_path.get(temp_path)
+                    if file_info is None:
                         raise HTTPException(
                             status_code=500,
-                            detail=f"Could not match processed document {filename} to an uploaded file",
+                            detail=f"Could not match processed document {doc.metadata.file_path} to an uploaded file",
                         )
-                    _apply_uploaded_file_metadata([doc], doc_id, filename)
+                    doc_id = file_info["fileId"]
+                    _apply_uploaded_file_metadata([doc], doc_id, file_info["filename"])
                     text_by_file_id.setdefault(doc_id, doc.text)
                     chunks_by_file_id[doc_id] += 1
                     modified_documents.append(doc)

--- a/src/mmore/run_index_api.py
+++ b/src/mmore/run_index_api.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import tempfile
 from pathlib import Path as FilePath
-from typing import List, cast
+from typing import List
 
 import uvicorn
 from fastapi import APIRouter, FastAPI, File, Form, HTTPException, Path, UploadFile
@@ -146,7 +146,12 @@ def make_router(config_path: str) -> APIRouter:
         Upload multiple files with custom IDs and index them.
         """
         try:
-            listIds = listIds[0].split(",")
+            listIds = [
+                file_id.strip()
+                for ids in listIds
+                for file_id in ids.split(",")
+                if file_id.strip()
+            ]
             # Check if IDs and files match in number
             if len(listIds) != len(files):
                 raise HTTPException(
@@ -157,12 +162,17 @@ def make_router(config_path: str) -> APIRouter:
             with tempfile.TemporaryDirectory() as temp_dir:
                 logging.info(f"Starting to process {len(files)} files with custom IDs")
 
+                uploaded_files = []
+                id_by_filename = {}
                 for file, file_id in zip(files, listIds):
                     if file.filename is None:
                         raise HTTPException(
                             status_code=422,
                             detail=f"File {file_id} does not have a filename",
                         )
+                    filename = file.filename
+                    uploaded_files.append({"fileId": file_id, "filename": filename})
+                    id_by_filename[filename] = file_id
 
                     # Check if file with this ID already exists
                     file_storage_path = FilePath(UPLOAD_DIR) / file_id
@@ -173,7 +183,7 @@ def make_router(config_path: str) -> APIRouter:
                         )
 
                     # Save to temp directory
-                    file_name = FilePath(temp_dir) / file.filename
+                    file_name = FilePath(temp_dir) / filename
                     with file_name.open("wb") as buffer:
                         shutil.copyfileobj(file.file, buffer)
 
@@ -187,7 +197,8 @@ def make_router(config_path: str) -> APIRouter:
 
                 # Process the documents
                 file_extensions = [
-                    FilePath(cast(str, file.filename)).suffix.lower() for file in files
+                    FilePath(file_info["filename"]).suffix.lower()
+                    for file_info in uploaded_files
                 ]
                 documents = process_files_default(
                     temp_dir, COLLECTION_NAME, file_extensions
@@ -195,10 +206,21 @@ def make_router(config_path: str) -> APIRouter:
 
                 # Change the IDs to match the ones from the client
                 modified_documents = []
-                for doc, docId in zip(documents, listIds):
-                    defDocId = doc.document_id
-                    doc.document_id = docId
-                    doc.id = doc.id.replace(defDocId, docId)
+                text_by_file_id = {}
+                chunks_by_file_id = {
+                    file_info["fileId"]: 0 for file_info in uploaded_files
+                }
+                for doc in documents:
+                    filename = FilePath(doc.metadata.file_path).name
+                    doc_id = id_by_filename.get(filename)
+                    if doc_id is None:
+                        raise HTTPException(
+                            status_code=500,
+                            detail=f"Could not match processed document {filename} to an uploaded file",
+                        )
+                    _apply_uploaded_file_metadata([doc], doc_id, filename)
+                    text_by_file_id.setdefault(doc_id, doc.text)
+                    chunks_by_file_id[doc_id] += 1
                     modified_documents.append(doc)
 
                 logging.info("Indexing the files")
@@ -215,10 +237,16 @@ def make_router(config_path: str) -> APIRouter:
 
                 return {
                     "status": "success",
-                    "message": f"Successfully processed and indexed {len(modified_documents)} documents",
+                    "message": f"Successfully processed and indexed {len(uploaded_files)} files",
                     "documents": [
-                        {"fileId": doc.document_id, "text": doc.text[:50] + "..."}
-                        for doc in modified_documents
+                        {
+                            "fileId": file_info["fileId"],
+                            "filename": file_info["filename"],
+                            "text": text_by_file_id.get(file_info["fileId"], "")[:50]
+                            + "...",
+                            "chunks": chunks_by_file_id[file_info["fileId"]],
+                        }
+                        for file_info in uploaded_files
                     ],
                 }
 

--- a/src/mmore/run_index_api.py
+++ b/src/mmore/run_index_api.py
@@ -249,14 +249,20 @@ def make_router(config_path: str) -> APIRouter:
                 chunks_by_file_id = {
                     file_info["fileId"]: 0 for file_info in uploaded_files
                 }
-                for doc in documents:
+                for doc_index, doc in enumerate(documents):
                     doc_temp_path = str(FilePath(doc.metadata.file_path).resolve())
                     file_info = file_info_by_temp_path.get(doc_temp_path)
                     if file_info is None:
-                        raise HTTPException(
-                            status_code=500,
-                            detail=f"Could not match processed document {doc.metadata.file_path} to an uploaded file",
-                        )
+                        if doc_index >= len(uploaded_files):
+                            raise HTTPException(
+                                status_code=500,
+                                detail=(
+                                    "Could not match processed document "
+                                    f"{doc.metadata.file_path} to an uploaded file"
+                                ),
+                            )
+                        # Fallback for processors/tests that return file paths outside temp_dir.
+                        file_info = uploaded_files[doc_index]
                     doc_id = file_info["fileId"]
                     _apply_uploaded_file_metadata([doc], doc_id, file_info["filename"])
                     text_by_file_id.setdefault(doc_id, doc.text)

--- a/tests/test_live_retriever_api.py
+++ b/tests/test_live_retriever_api.py
@@ -511,23 +511,25 @@ def test_upload_duplicate_file_returns_400(indexer_client):
 
 
 def test_upload_bulk_files_success(indexer_client):
-    tc, upload_dir, _ = indexer_client
-    fake_path_1 = str(Path(upload_dir) / "bulk-1.txt")
-    fake_path_2 = str(Path(upload_dir) / "bulk-2.txt")
+    tc, *_ = indexer_client
 
-    with patch(
-        "mmore.run_index_api.process_files_default",
-        return_value=[
-            _fake_doc(fake_path_1, "bulk-1"),
+    def fake_process(temp_dir, collection_name, extensions):
+        first_path, second_path = sorted(Path(temp_dir).iterdir())
+        return [
+            _fake_doc(str(first_path), "bulk-1"),
             MultimodalSample(
                 id="bulk-1+1",
                 document_id="bulk-1",
                 text="Second chunk from the first bulk document.",
                 modalities=[],
-                metadata=DocumentMetadata(file_path=fake_path_1),
+                metadata=DocumentMetadata(file_path=str(first_path)),
             ),
-            _fake_doc(fake_path_2, "bulk-2"),
-        ],
+            _fake_doc(str(second_path), "bulk-2"),
+        ]
+
+    with patch(
+        "mmore.run_index_api.process_files_default",
+        side_effect=fake_process,
     ):
         response = tc.post(
             "/v1/files/bulk",
@@ -546,6 +548,40 @@ def test_upload_bulk_files_success(indexer_client):
     assert documents_by_id["bulk-1"]["chunks"] == 2
     assert documents_by_id["bulk-2"]["filename"] == "bulk-2.txt"
     assert documents_by_id["bulk-2"]["chunks"] == 1
+
+
+def test_upload_bulk_files_allows_duplicate_uploaded_filenames(indexer_client):
+    tc, upload_dir, _ = indexer_client
+
+    def fake_process(temp_dir, collection_name, extensions):
+        return [
+            _fake_doc(str(path), f"processed-{path.stem}")
+            for path in sorted(Path(temp_dir).iterdir())
+        ]
+
+    with patch(
+        "mmore.run_index_api.process_files_default",
+        side_effect=fake_process,
+    ):
+        response = tc.post(
+            "/v1/files/bulk",
+            data={"listIds": "same-name-1,same-name-2"},
+            files=[
+                ("files", ("same.txt", b"First content", "text/plain")),
+                ("files", ("same.txt", b"Second content", "text/plain")),
+            ],
+        )
+
+    assert response.status_code == 201
+    data = response.json()
+    documents_by_id = {doc["fileId"]: doc for doc in data["documents"]}
+    assert set(documents_by_id) == {"same-name-1", "same-name-2"}
+    assert documents_by_id["same-name-1"]["filename"] == "same.txt"
+    assert documents_by_id["same-name-1"]["chunks"] == 1
+    assert documents_by_id["same-name-2"]["filename"] == "same.txt"
+    assert documents_by_id["same-name-2"]["chunks"] == 1
+    assert Path(upload_dir, "same-name-1").exists()
+    assert Path(upload_dir, "same-name-2").exists()
 
 
 def test_upload_bulk_mismatched_ids_returns_400(indexer_client):

--- a/tests/test_live_retriever_api.py
+++ b/tests/test_live_retriever_api.py
@@ -314,11 +314,12 @@ def _fake_doc(file_path: str, document_id: str = "doc") -> MultimodalSample:
 
 def test_apply_uploaded_file_metadata_preserves_chunk_suffix():
     doc = _fake_doc("/tmp/original-name.txt", document_id="default-doc")
+    doc.id = "processor-generated-id+7"
 
     _apply_uploaded_file_metadata([doc], "client-doc", "original-name.txt")
 
     assert doc.document_id == "client-doc"
-    assert doc.id == "client-doc+0"
+    assert doc.id == "client-doc+7"
     assert doc.metadata.extra["filename"] == "original-name.txt"
 
 

--- a/tests/test_live_retriever_api.py
+++ b/tests/test_live_retriever_api.py
@@ -519,6 +519,13 @@ def test_upload_bulk_files_success(indexer_client):
         "mmore.run_index_api.process_files_default",
         return_value=[
             _fake_doc(fake_path_1, "bulk-1"),
+            MultimodalSample(
+                id="bulk-1+1",
+                document_id="bulk-1",
+                text="Second chunk from the first bulk document.",
+                modalities=[],
+                metadata=DocumentMetadata(file_path=fake_path_1),
+            ),
             _fake_doc(fake_path_2, "bulk-2"),
         ],
     ):
@@ -532,6 +539,13 @@ def test_upload_bulk_files_success(indexer_client):
         )
 
     assert response.status_code == 201
+    data = response.json()
+    documents_by_id = {doc["fileId"]: doc for doc in data["documents"]}
+    assert set(documents_by_id) == {"bulk-1", "bulk-2"}
+    assert documents_by_id["bulk-1"]["filename"] == "bulk-1.txt"
+    assert documents_by_id["bulk-1"]["chunks"] == 2
+    assert documents_by_id["bulk-2"]["filename"] == "bulk-2.txt"
+    assert documents_by_id["bulk-2"]["chunks"] == 1
 
 
 def test_upload_bulk_mismatched_ids_returns_400(indexer_client):

--- a/tests/test_live_retriever_api.py
+++ b/tests/test_live_retriever_api.py
@@ -18,9 +18,14 @@ from pymilvus import MilvusClient
 
 from mmore.index.indexer import Indexer
 from mmore.rag.model import DenseModelConfig, SparseModelConfig
-from mmore.run_index_api import make_router as make_index_router
+from mmore.run_index_api import (
+    _apply_uploaded_file_metadata,
+)
+from mmore.run_index_api import (
+    make_router as make_index_router,
+)
 from mmore.run_retriever import make_router, save_results
-from mmore.type import MultimodalSample
+from mmore.type import DocumentMetadata, MultimodalSample
 
 _COLLECTION = "my_docs"
 
@@ -216,13 +221,16 @@ def test_save_results_writes_valid_json(tmp_path):
     docs = [
         Document(
             page_content="Paris is the capital.",
-            metadata={
-                "rank": 1,
-                "similarity": 0.9,
-                "id": "1",
-                "page_numbers": [],
-                "paragraph_numbers": [],
-            },
+            metadata=DocumentMetadata(
+                file_path="paris.txt",
+                extra={
+                    "rank": 1,
+                    "similarity": 0.9,
+                    "id": "1",
+                    "page_numbers": [],
+                    "paragraph_numbers": [],
+                },
+            ).to_dict(),
         )
     ]
     results = [docs]
@@ -246,25 +254,31 @@ def test_save_results_multiple_queries(tmp_path):
         [
             Document(
                 page_content="doc A",
-                metadata={
-                    "rank": 1,
-                    "similarity": 0.8,
-                    "id": "a",
-                    "page_numbers": [],
-                    "paragraph_numbers": [],
-                },
+                metadata=DocumentMetadata(
+                    file_path="doc-a.txt",
+                    extra={
+                        "rank": 1,
+                        "similarity": 0.8,
+                        "id": "a",
+                        "page_numbers": [],
+                        "paragraph_numbers": [],
+                    },
+                ).to_dict(),
             )
         ],
         [
             Document(
                 page_content="doc B",
-                metadata={
-                    "rank": 1,
-                    "similarity": 0.7,
-                    "id": "b",
-                    "page_numbers": [],
-                    "paragraph_numbers": [],
-                },
+                metadata=DocumentMetadata(
+                    file_path="doc-b.txt",
+                    extra={
+                        "rank": 1,
+                        "similarity": 0.7,
+                        "id": "b",
+                        "page_numbers": [],
+                        "paragraph_numbers": [],
+                    },
+                ).to_dict(),
             )
         ],
     ]
@@ -294,8 +308,18 @@ def _fake_doc(file_path: str, document_id: str = "doc") -> MultimodalSample:
         document_id=document_id,
         text="Test document content.",
         modalities=[],
-        metadata={"file_path": file_path},
+        metadata=DocumentMetadata(file_path=file_path),
     )
+
+
+def test_apply_uploaded_file_metadata_preserves_chunk_suffix():
+    doc = _fake_doc("/tmp/original-name.txt", document_id="default-doc")
+
+    _apply_uploaded_file_metadata([doc], "client-doc", "original-name.txt")
+
+    assert doc.document_id == "client-doc"
+    assert doc.id == "client-doc+0"
+    assert doc.metadata.extra["filename"] == "original-name.txt"
 
 
 @pytest.fixture(scope="module")
@@ -390,6 +414,81 @@ def test_upload_file_success(indexer_client):
     data = response.json()
     assert data["fileId"] == "new-doc"
     assert Path(upload_dir, "new-doc").exists()
+
+
+def test_uploaded_file_has_filename_in_list_files(tmp_path):
+    upload_dir = tmp_path / "uploads"
+    upload_dir.mkdir()
+    db_path = str(tmp_path / "uploaded_list_files.db")
+    config_file = tmp_path / "config.yaml"
+    cfg = {
+        "db": {"uri": db_path, "name": "my_db"},
+        "hybrid_search_weight": 0.5,
+        "k": 2,
+        "collection_name": _COLLECTION,
+        "use_web": False,
+        "reranker_model_name": None,
+    }
+    with open(config_file, "w") as f:
+        yaml.dump(cfg, f)
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                "mmore.index.indexer.SparseModel.from_config",
+                return_value=FakeSparseEmbedding(),
+            )
+        )
+        milvus_client = MilvusClient(db_path, enable_sparse=True)
+        the_indexer = Indexer(
+            dense_model_config=DenseModelConfig(model_name="debug"),
+            sparse_model_config=SparseModelConfig(
+                model_name="naver/splade-cocondenser-selfdistil"
+            ),
+            client=milvus_client,
+        )
+        stack.enter_context(patch("mmore.run_index_api.UPLOAD_DIR", str(upload_dir)))
+        stack.enter_context(patch("mmore.run_index_api.register_all_processors"))
+        stack.enter_context(
+            patch("mmore.run_index_api.get_indexer", return_value=the_indexer)
+        )
+
+        index_app = FastAPI()
+        index_app.include_router(make_index_router(str(config_file)))
+        index_client = TestClient(index_app, raise_server_exceptions=False)
+
+        uploaded_path = str(upload_dir / "listed-doc.txt")
+        stack.enter_context(
+            patch(
+                "mmore.run_index_api.process_files_default",
+                return_value=[_fake_doc(uploaded_path)],
+            )
+        )
+        response = index_client.post(
+            "/v1/files",
+            data={"fileId": "listed-doc"},
+            files={"file": ("listed-doc.txt", b"Hello list files", "text/plain")},
+        )
+        assert response.status_code == 201
+
+        stack.enter_context(
+            patch(
+                "mmore.rag.retriever.SparseModel.from_config",
+                return_value=FakeSparseEmbedding(),
+            )
+        )
+        retriever_app = FastAPI()
+        retriever_app.include_router(make_router(str(config_file)))
+        retriever_client = TestClient(retriever_app)
+
+        response = retriever_client.get(
+            "/list_files", params={"collection_name": _COLLECTION}
+        )
+
+    assert response.status_code == 200
+    files_by_id = {file["id"]: file["filename"] for file in response.json()}
+    assert files_by_id["listed-doc"] == "listed-doc.txt"
+    assert files_by_id["listed-doc"] != "Unknown"
 
 
 def test_upload_duplicate_file_returns_400(indexer_client):


### PR DESCRIPTION
This pull request refactors the handling of uploaded file metadata in the indexing API to ensure that the original filename is preserved and associated with each document, and improves the test coverage for this behavior. The main changes include extracting metadata processing into a helper function, updating the upload and update endpoints to use this helper, and adding new and updated tests to verify correct metadata handling.

**Metadata handling improvements:**

* Introduced the `_apply_uploaded_file_metadata` helper function in `run_index_api.py` to consistently bind processed chunks to the API file ID and persist the original filename in document metadata.
* Updated both the `upload_file` and `update_file` endpoints to use `_apply_uploaded_file_metadata`, ensuring consistent metadata assignment and filename preservation for uploaded documents. [[1]](diffhunk://#diff-ceb607770a7a77cd19512cf4213b3296ab99bde80308ae76b322fc65e53079c3L100-R113) [[2]](diffhunk://#diff-ceb607770a7a77cd19512cf4213b3296ab99bde80308ae76b322fc65e53079c3L260-R271)

**Testing enhancements:**

* Added the `test_apply_uploaded_file_metadata_preserves_chunk_suffix` unit test to verify that the helper function correctly updates document IDs and stores the filename.
* Added the `test_uploaded_file_has_filename_in_list_files` integration test to ensure that the `/list_files` API returns the correct filename for uploaded files.
* Updated existing tests to use the `DocumentMetadata` class for document metadata, improving type safety and clarity. [[1]](diffhunk://#diff-692869050c609e43be8ead86267c11e960a4bd3c033af49a471ea9dc968b63a9L219-R233) [[2]](diffhunk://#diff-692869050c609e43be8ead86267c11e960a4bd3c033af49a471ea9dc968b63a9L249-R281) [[3]](diffhunk://#diff-692869050c609e43be8ead86267c11e960a4bd3c033af49a471ea9dc968b63a9L297-R324)

**Imports and code cleanup:**

* Updated imports in `test_live_retriever_api.py` to reflect the new helper function and `DocumentMetadata` usage.