### PR TITLE
Asynchronous multi-GPU file processing and indexing

### DIFF
--- a/docs/source/developer_documentation/index_api.md
+++ b/docs/source/developer_documentation/index_api.md
@@ -55,6 +55,13 @@ Two config fields tune this:
 - `jobs_per_gpu` (default `1`): jobs processed per GPU at once. Total workers = GPUs * `jobs_per_gpu`.
 - `max_queue_size` (default `null` = `num_gpu` * `jobs_per_gpu` * 10): pending-job cap, uploads beyond it get `503` http error.
 
+GPUs are auto-detected, but you can restrict which (and how many) mmore uses with the `CUDA_VISIBLE_DEVICES` environment variable:
+
+```bash
+# If you want to use only GPUs 0 and 2
+CUDA_VISIBLE_DEVICES=0,2 python3 -m mmore index-api --config-file /path/to/config.yaml --host the_host --port the_port
+```
+
 ```{note}
 For `jobs_per_gpu > 1`, prefer a **Milvus Standalone** server
 (`db.uri: http://localhost:19530`) over Milvus Lite. Milvus Standalone is better

--- a/docs/source/developer_documentation/index_api.md
+++ b/docs/source/developer_documentation/index_api.md
@@ -8,25 +8,26 @@
 
 ## Overview
 
-The **Indexer API** allows users to **upload, update, download, delete, and index documents** into a Milvus vector database for retrieval-augmented generation (RAG) and search applications. 
+The **Indexer API** allows users to **upload, update, download, delete, and index documents** into a Milvus vector database for retrieval-augmented generation (RAG) and search applications.
+
+Uploads are **asynchronous**: the upload endpoints validate the request, queue a background job, and return `202 Accepted` with a `jobId` immediately. Processing and indexing then run in the background, one job per GPU. Clients track progress with the job status endpoints (snapshot or SSE stream).
 
 ## ⚙️ Backend server setup
 
 ### Setup Instructions
 
-#### 1. Optional: set environment variables
+#### 1. Configure the server
 
-If you would like to use a specific database and collection name please set the environment variables using the code below.   
-Otherwise, the following default values will be used:
+The server reads everything from the YAML file passed with `--config-file` (a
+`RetrieverConfig`). The relevant fields, with their defaults:
 
-- Milvus URI = `demo.db`
-- Milvus database name = `my_db`
-- Collection name = `my_documents`
-
-```bash
-export MILVUS_URI="your_milvus_uri"
-export MILVUS_DB="your_database_name"
-export DEFAULT_COLLECTION="your_collection_name"
+```yaml
+db:
+  uri: ./proc_demo.db   # Milvus Lite file, or a Standalone server e.g. http://localhost:19530
+  name: my_db
+collection_name: my_docs
+jobs_per_gpu: 1         # upload jobs processed per GPU at once
+max_queue_size: null    # pending-job cap
 ```
 
 #### 2. Run the server
@@ -46,6 +47,21 @@ This command:
 Keep this terminal window open. The backend runs in the foreground, and closing the terminal will shut it down.
 ```
 
+#### 3. Concurrency and database
+
+Uploads are processed by a background queue, one job per GPU (GPUs are auto-detected).
+Two config fields tune this:
+
+- `jobs_per_gpu` (default `1`): jobs processed per GPU at once. Total workers = GPUs * `jobs_per_gpu`.
+- `max_queue_size` (default `null` = `num_gpu` * `jobs_per_gpu` * 10): pending-job cap, uploads beyond it get `503` http error.
+
+```{note}
+For `jobs_per_gpu > 1`, prefer a **Milvus Standalone** server
+(`db.uri: http://localhost:19530`) over Milvus Lite. Milvus Standalone is better
+suited to a production environment with concurrent load. Lite is fine for small or
+local use. Keep `jobs_per_gpu: 1` with Lite.
+```
+
 
 ## 📂 API Usage
 
@@ -59,18 +75,16 @@ Keep this terminal window open. The backend runs in the foreground, and closing 
 | --- | --- | --- |
 | `fileId` | `str` (form) | Unique identifier for the file |
 | `file` | `UploadFile` (form) | File content to upload |
-- rejects duplicate IDs
-- automatically processes and indexes the file
+- rejects duplicate IDs with `409`
+- queues a background job, returns `202` with a `jobId`
 
-**Response**:
+**Response** (`202 Accepted`):
 
 ```json
 {
-  "status": "success",
-  "message": "File successfully indexed in my_documents collection",
-  "fileId": "example123",
-  "filename": "doc.pdf" }
-
+  "jobId": "a1b2c3d4...",
+  "fileId": "example123"
+}
 ```
 
 
@@ -83,15 +97,16 @@ Keep this terminal window open. The backend runs in the foreground, and closing 
 | `listIds` | `List[str]` (form) | Comma-separated list of file IDs |
 | `files` | `List[UploadFile]` (form) | Files to upload |
 - validates 1-to-1 correspondence between files and IDs
-- processes and indexes each file with its corresponding ID
+- queues **one independent job per file**, a bad file does not fail the batch
 
-**Response**:
+**Response** (`202 Accepted`):
 
 ```json
 {
-  "status": "success",
-  "message": "Successfully processed and indexed 3 documents",
-  "documents": [{"fileId": "doc1", "text": "First 50 characters..."}]
+  "jobs": [
+    {"fileId": "doc1", "jobId": "a1b2c3..."},
+    {"fileId": "doc2", "error": "already exists"}
+  ]
 }
 ```
 
@@ -106,17 +121,15 @@ Keep this terminal window open. The backend runs in the foreground, and closing 
 | --- | --- | --- |
 | `fileId` | `str` (path) | Existing file ID |
 | `file` | `UploadFile` (form) | New file to replace with |
-- deletes the previous vector entry
-- re-indexes new content with the same ID
+- queues a background job, returns `202` with a `jobId`
+- old vectors are replaced only after the new content is processed (no data loss on failure)
 
-**Response**:
+**Response** (`202 Accepted`):
 
 ```json
 {
-  "status": "success",
-  "message": "File successfully updated",
-  "fileId": "doc123",
-  "filename": "new.pdf"
+  "jobId": "a1b2c3d4...",
+  "fileId": "doc123"
 }
 ```
 
@@ -155,16 +168,50 @@ Keep this terminal window open. The backend runs in the foreground, and closing 
 
 Returns the file with binary content.
 
+### 🛰️ Job status endpoints
+
+Uploads return a `jobId`. Track it with either endpoint:
+
+#### 📊 `GET /v1/jobs/{jobId}`
+
+One-shot status snapshot. Returns `404` if the job is unknown (e.g. expired).
+
+```json
+{
+  "jobId": "a1b2c3...", "fileId": "doc1", "filename": "doc.pdf",
+  "status": "done", "device": "cuda:0",
+  "result": {"chunks": 12}, "error": null
+}
+```
+
+`status` is one of `queued`, `processing`, `done`, `failed`.
+
+#### 📡 `GET /v1/jobs/{jobId}/events`
+
+Server-Sent Events stream. The server pushes each status change and closes when
+the job is `done` or `failed`, so the client does not poll. Example with `curl`:
+
+```bash
+curl -N http://host:port/v1/jobs/a1b2c3.../events
+```
+
+```{note}
+Job status is kept in memory and dropped a couple of hours after the job ends
+(and on restart). The durable record of an indexed document is its presence in
+the collection, not the `jobId`.
+```
+
 ---
 
 ## 🔄 How it works
 
-1. **Upload** → the file is saved temporarily
-2. **Process** → the file is processed
+1. **Upload** → bytes are saved, a background job is queued, `202` + `jobId` returns at once
+2. **Process** (on the job's assigned GPU) → the file is processed
    1. **Crawling**: files are parsed using `Crawler`
    2. **Dispatching**: files are dispatched to the proper processor using `Dispatcher`
    3. **Processing**: text, images, and metadata are extracted and returned as a `MultiModalSample`
 3. **Indexing** → dense and sparse vectors are stored in Milvus
+4. The permanent file copy is saved only after indexing succeeds, then the job is marked `done`
 
 ## 🧰 Developer notes
 

--- a/examples/retriever_api/config.yaml
+++ b/examples/retriever_api/config.yaml
@@ -1,5 +1,5 @@
 db:
-  uri: ./proc_demo.db
+  uri: ./proc_demo.db  # http://localhost:19530 if Milvus Standalone server
   name: my_db
 hybrid_search_weight: 0.5
 k: 5

--- a/production-config/retriever_api/config.yaml
+++ b/production-config/retriever_api/config.yaml
@@ -1,6 +1,6 @@
 db:
   uri: http://localhost:19530
-  name: my_db
+  name: default
 hybrid_search_weight: 0.5
 k: 5
 collection_name: my_docs

--- a/production-config/retriever_api/config.yaml
+++ b/production-config/retriever_api/config.yaml
@@ -1,6 +1,8 @@
 db:
-  uri: $ROOT_OUT_DIR/db/proc_demo.db
+  uri: http://localhost:19530
   name: my_db
 hybrid_search_weight: 0.5
 k: 5
 collection_name: my_docs
+jobs_per_gpu: 1
+max_queue_size: null

--- a/src/mmore/index/indexer.py
+++ b/src/mmore/index/indexer.py
@@ -54,17 +54,18 @@ class Indexer:
         dense_model_config: DenseModelConfig,
         sparse_model_config: SparseModelConfig,
         client: MilvusClient,
+        device: Optional[str] = None,
     ):
-        # Load the embedding models
+        # Load the embedding models on the given device
         self.dense_model_config = dense_model_config
-        self.dense_model = DenseModel.from_config(dense_model_config)
+        self.dense_model = DenseModel.from_config(dense_model_config, device=device)
         self.sparse_model_config = sparse_model_config
-        self.sparse_model = SparseModel.from_config(sparse_model_config)
+        self.sparse_model = SparseModel.from_config(sparse_model_config, device=device)
 
         self.client = client
 
     @classmethod
-    def from_config(cls, config: str | IndexerConfig):
+    def from_config(cls, config: str | IndexerConfig, device: Optional[str] = None):
         # Load the config if it's a string
         if isinstance(config, str):
             config_obj = load_config(config, IndexerConfig)
@@ -82,6 +83,7 @@ class Indexer:
             dense_model_config=config_obj.dense_model,
             sparse_model_config=config_obj.sparse_model,
             client=milvus_client,
+            device=device,
         )
 
     @classmethod
@@ -92,8 +94,9 @@ class Indexer:
         collection_name: str = "my_docs",
         partition_name: Optional[str] = None,
         batch_size: int = 64,
+        device: Optional[str] = None,
     ):
-        indexer = Indexer.from_config(config)
+        indexer = Indexer.from_config(config, device=device)
         indexer.index_documents(
             documents,
             collection_name=collection_name,
@@ -229,7 +232,12 @@ class Indexer:
         # Create collection
         if not self.client.has_collection(collection_name):
             logger.info(f"Creating collection {collection_name}")
-            self._create_collection_with_schema(collection_name)
+            try:
+                self._create_collection_with_schema(collection_name)
+            except Exception:
+                if not self.client.has_collection(collection_name):
+                    raise
+                logger.info(f"{collection_name} was created concurrently")
         else:
             logger.info(f"{collection_name} already exists, adding documents to it")
 

--- a/src/mmore/index/indexer.py
+++ b/src/mmore/index/indexer.py
@@ -234,9 +234,9 @@ class Indexer:
             logger.info(f"Creating collection {collection_name}")
             try:
                 self._create_collection_with_schema(collection_name)
-            except Exception:
+            except Exception as e:
                 if not self.client.has_collection(collection_name):
-                    raise
+                    raise e
                 logger.info(f"{collection_name} was created concurrently")
         else:
             logger.info(f"{collection_name} already exists, adding documents to it")

--- a/src/mmore/job_queue.py
+++ b/src/mmore/job_queue.py
@@ -73,7 +73,9 @@ class JobQueue:
     ):
         self.devices = devices or _detect_devices()
         self.n_workers = len(self.devices) * jobs_per_gpu
-        self.max_queue_size = max_queue_size or self.n_workers * 10
+        self.max_queue_size = (
+            max_queue_size if max_queue_size is not None else self.n_workers * 10
+        )
 
         self._device_pool: queue.Queue[str] = queue.Queue()
         for _ in range(jobs_per_gpu):

--- a/src/mmore/job_queue.py
+++ b/src/mmore/job_queue.py
@@ -72,22 +72,22 @@ class JobQueue:
         devices: Optional[list[str]] = None,
     ):
         self.devices = devices or _detect_devices()
-        n_workers = len(self.devices) * jobs_per_gpu
-        self.max_queue_size = max_queue_size or n_workers * 10
+        self.n_workers = len(self.devices) * jobs_per_gpu
+        self.max_queue_size = max_queue_size or self.n_workers * 10
 
         self._device_pool: queue.Queue[str] = queue.Queue()
         for _ in range(jobs_per_gpu):
             for device in self.devices:
                 self._device_pool.put(device)
 
-        self._executor = ThreadPoolExecutor(max_workers=n_workers)
+        self._executor = ThreadPoolExecutor(max_workers=self.n_workers)
         self._jobs: dict[str, Job] = {}
         self._reserved: set[str] = set()
         self._lock = threading.Lock()
 
         logger.info(
             "[JobQueue] ready: %d worker(s) on %s, max_queue=%d",
-            n_workers,
+            self.n_workers,
             self.devices,
             self.max_queue_size,
         )
@@ -111,12 +111,10 @@ class JobQueue:
             self._jobs[job_id] = Job(id=job_id, file_id=file_id, filename=filename)
 
         logger.info(
-            "[JobQueue] job %s queued (file_id=%s, filename=%s), gpus free: %d/%d",
+            "[JobQueue] job %s queued (file_id=%s, filename=%s)",
             job_id,
             file_id,
             filename,
-            self._device_pool.qsize(),
-            len(self.devices),
         )
         self._executor.submit(self._run, job_id, work_fn)
         return job_id
@@ -133,7 +131,13 @@ class JobQueue:
         job.device = device
         job.status = JobStatus.PROCESSING
         job.started_at = time.time()
-        logger.info("[JobQueue] job %s processing (gpu=%s)", job_id, device)
+        logger.info(
+            "[JobQueue] job %s processing (gpu=%s), free slots: %d/%d",
+            job_id,
+            device,
+            self._device_pool.qsize(),
+            self.n_workers,
+        )
 
         result = None
         error = None

--- a/src/mmore/job_queue.py
+++ b/src/mmore/job_queue.py
@@ -27,6 +27,10 @@ class JobStatus(str, Enum):
     DONE = "done"
     FAILED = "failed"
 
+    @property
+    def is_terminal(self) -> bool:
+        return self in (JobStatus.DONE, JobStatus.FAILED)
+
 
 class DuplicateJobError(Exception):
     """A job for this file id is already queued or running."""
@@ -131,25 +135,32 @@ class JobQueue:
         job.status = JobStatus.PROCESSING
         job.started_at = time.time()
         logger.info("job %s processing (gpu=%s)", job_id, device)
+
+        result = None
+        error = None
         try:
-            job.result = work_fn(device)
-            job.status = JobStatus.DONE
-            logger.info("job %s done (gpu=%s, result=%s)", job_id, device, job.result)
+            result = work_fn(device)
         except Exception as e:
-            job.error = str(e)
-            job.status = JobStatus.FAILED
-            logger.exception("job %s failed (gpu=%s): %s", job_id, device, e)
+            error = e
         finally:
-            job.finished_at = time.time()
             self._device_pool.put(device)
             with self._lock:
                 self._reserved.discard(job.file_id)
+            job.finished_at = time.time()
+
+        if error is None:
+            job.result = result
+            job.status = JobStatus.DONE
+            logger.info("job %s done (gpu=%s, result=%s)", job_id, device, result)
+        else:
+            job.error = str(error)
+            job.status = JobStatus.FAILED
+            logger.error(
+                "job %s failed (gpu=%s): %s", job_id, device, error, exc_info=error
+            )
 
     def _pending_count(self) -> int:
-        return sum(
-            j.status in (JobStatus.QUEUED, JobStatus.PROCESSING)
-            for j in self._jobs.values()
-        )
+        return sum(not j.status.is_terminal for j in self._jobs.values())
 
     def _evict_old(self) -> None:
         now = time.time()

--- a/src/mmore/job_queue.py
+++ b/src/mmore/job_queue.py
@@ -1,0 +1,162 @@
+"""In-memory async job runner for the indexer API.
+
+One shared queue, one worker per GPU. Each job checks out a device for its whole
+run so the per-GPU models are never double-booked. State is in-memory only and
+lost on restart, the logs are the durable record.
+"""
+
+import logging
+import queue
+import threading
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+# Keep finished jobs queryable for a while before dropping (2h)
+JOB_RETENTION_SECONDS = 7200
+
+
+class JobStatus(str, Enum):
+    QUEUED = "queued"
+    PROCESSING = "processing"
+    DONE = "done"
+    FAILED = "failed"
+
+
+class DuplicateJobError(Exception):
+    """A job for this file id is already queued or running."""
+
+
+class QueueFullError(Exception):
+    """Too many jobs pending, the upload should be retried later."""
+
+
+@dataclass
+class Job:
+    id: str
+    file_id: str
+    filename: str
+    status: JobStatus = JobStatus.QUEUED
+    device: Optional[str] = None
+    result: Optional[dict] = None
+    error: Optional[str] = None
+    created_at: float = field(default_factory=time.time)
+    started_at: Optional[float] = None
+    finished_at: Optional[float] = None
+
+
+def _detect_devices() -> list[str]:
+    import torch
+
+    if torch.cuda.is_available():
+        return [f"cuda:{i}" for i in range(torch.cuda.device_count())]
+    if getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():
+        return ["mps"]
+    return ["cpu"]
+
+
+class JobQueue:
+    def __init__(
+        self,
+        jobs_per_gpu: int = 1,
+        max_queue_size: Optional[int] = None,
+        devices: Optional[list[str]] = None,
+    ):
+        self.devices = devices or _detect_devices()
+        n_workers = len(self.devices) * jobs_per_gpu
+        self.max_queue_size = max_queue_size or n_workers * 10
+
+        self._device_pool: queue.Queue[str] = queue.Queue()
+        for _ in range(jobs_per_gpu):
+            for device in self.devices:
+                self._device_pool.put(device)
+
+        self._executor = ThreadPoolExecutor(max_workers=n_workers)
+        self._jobs: dict[str, Job] = {}
+        self._reserved: set[str] = set()
+        self._lock = threading.Lock()
+
+        logger.info(
+            "job manager ready: %d worker(s) on %s, max_queue=%d. "
+            "single process only, do not run uvicorn with --workers > 1",
+            n_workers,
+            self.devices,
+            self.max_queue_size,
+        )
+
+    def submit(
+        self, file_id: str, filename: str, work_fn: Callable[[str], dict]
+    ) -> str:
+        """Queue work_fn(device) and return a job id immediately.
+
+        Raises DuplicateJobError if file_id is in flight, QueueFullError if the
+        queue is saturated.
+        """
+        job_id = uuid.uuid4().hex
+        with self._lock:
+            self._evict_old()
+            if file_id in self._reserved:
+                raise DuplicateJobError(file_id)
+            if self._pending_count() >= self.max_queue_size:
+                raise QueueFullError()
+            self._reserved.add(file_id)
+            self._jobs[job_id] = Job(id=job_id, file_id=file_id, filename=filename)
+
+        logger.info(
+            "job %s queued (file_id=%s, filename=%s), gpus free: %d/%d",
+            job_id,
+            file_id,
+            filename,
+            self._device_pool.qsize(),
+            len(self.devices),
+        )
+        self._executor.submit(self._run, job_id, work_fn)
+        return job_id
+
+    def get(self, job_id: str) -> Optional[Job]:
+        return self._jobs.get(job_id)
+
+    def shutdown(self) -> None:
+        self._executor.shutdown(wait=True)
+
+    def _run(self, job_id: str, work_fn: Callable[[str], dict]) -> None:
+        job = self._jobs[job_id]
+        device = self._device_pool.get()
+        job.device = device
+        job.status = JobStatus.PROCESSING
+        job.started_at = time.time()
+        logger.info("job %s processing (gpu=%s)", job_id, device)
+        try:
+            job.result = work_fn(device)
+            job.status = JobStatus.DONE
+            logger.info("job %s done (gpu=%s, result=%s)", job_id, device, job.result)
+        except Exception as e:
+            job.error = str(e)
+            job.status = JobStatus.FAILED
+            logger.exception("job %s failed (gpu=%s): %s", job_id, device, e)
+        finally:
+            job.finished_at = time.time()
+            self._device_pool.put(device)
+            with self._lock:
+                self._reserved.discard(job.file_id)
+
+    def _pending_count(self) -> int:
+        return sum(
+            j.status in (JobStatus.QUEUED, JobStatus.PROCESSING)
+            for j in self._jobs.values()
+        )
+
+    def _evict_old(self) -> None:
+        now = time.time()
+        stale = [
+            j.id
+            for j in self._jobs.values()
+            if j.finished_at and now - j.finished_at > JOB_RETENTION_SECONDS
+        ]
+        for job_id in stale:
+            self._jobs.pop(job_id, None)

--- a/src/mmore/job_queue.py
+++ b/src/mmore/job_queue.py
@@ -86,8 +86,7 @@ class JobQueue:
         self._lock = threading.Lock()
 
         logger.info(
-            "job manager ready: %d worker(s) on %s, max_queue=%d. "
-            "single process only, do not run uvicorn with --workers > 1",
+            "[JobQueue] ready: %d worker(s) on %s, max_queue=%d",
             n_workers,
             self.devices,
             self.max_queue_size,
@@ -112,7 +111,7 @@ class JobQueue:
             self._jobs[job_id] = Job(id=job_id, file_id=file_id, filename=filename)
 
         logger.info(
-            "job %s queued (file_id=%s, filename=%s), gpus free: %d/%d",
+            "[JobQueue] job %s queued (file_id=%s, filename=%s), gpus free: %d/%d",
             job_id,
             file_id,
             filename,
@@ -134,7 +133,7 @@ class JobQueue:
         job.device = device
         job.status = JobStatus.PROCESSING
         job.started_at = time.time()
-        logger.info("job %s processing (gpu=%s)", job_id, device)
+        logger.info("[JobQueue] job %s processing (gpu=%s)", job_id, device)
 
         result = None
         error = None
@@ -151,12 +150,18 @@ class JobQueue:
         if error is None:
             job.result = result
             job.status = JobStatus.DONE
-            logger.info("job %s done (gpu=%s, result=%s)", job_id, device, result)
+            logger.info(
+                "[JobQueue] job %s done (gpu=%s, result=%s)", job_id, device, result
+            )
         else:
             job.error = str(error)
             job.status = JobStatus.FAILED
             logger.error(
-                "job %s failed (gpu=%s): %s", job_id, device, error, exc_info=error
+                "[JobQueue] job %s failed (gpu=%s): %s",
+                job_id,
+                device,
+                error,
+                exc_info=error,
             )
 
     def _pending_count(self) -> int:

--- a/src/mmore/process/dispatcher.py
+++ b/src/mmore/process/dispatcher.py
@@ -136,6 +136,32 @@ class DispatcherConfig:
         )
 
 
+class _LazyPool:
+    """A multiprocessing pool created on first map() call.
+
+    Processors that override process_batch (e.g. PDF, media) never call map(), so a
+    job that only uses them never spawns any worker.
+    """
+
+    def __init__(self, processes: int):
+        self._processes = processes
+        self._pool = None
+
+    def map(self, func, iterable):
+        if self._pool is None:
+            logger.info(f"Initializing shared pool with {self._processes} workers...")
+            self._pool = mp.Pool(processes=self._processes)
+        return self._pool.map(func, iterable)
+
+    def close(self):
+        if self._pool is not None:
+            self._pool.close()
+
+    def join(self):
+        if self._pool is not None:
+            self._pool.join()
+
+
 class Dispatcher:
     """
     Takes a converted crawl result and dispatches it to the appropriate processor.
@@ -185,9 +211,7 @@ class Dispatcher:
 
         instantiated_processors: Dict[Type[Processor], Processor] = {}
 
-        num_workers = os.cpu_count() or 1
-        logger.info(f"🚀 Initializing Shared Global Pool with {num_workers} workers...")
-        global_pool = mp.Pool(processes=num_workers)
+        global_pool = _LazyPool(os.cpu_count() or 1)
 
         try:
             for processor_type, files in task_lists:

--- a/src/mmore/process/dispatcher.py
+++ b/src/mmore/process/dispatcher.py
@@ -74,6 +74,9 @@ class DispatcherConfig:
     process_batch_sizes: Optional[List[Dict[str, float]]] = None
     batch_multiplier: int = 1
     extract_images: bool = False
+    # When set, processing is pinned to this single device (used by the indexer
+    # API to run one job per GPU). None keeps the default behavior.
+    device: Optional[str] = None
 
     def __post_init__(self):
         os.makedirs(self.output_path, exist_ok=True)
@@ -204,6 +207,8 @@ class Dispatcher:
 
                     processor_config["output_path"] = self.config.output_path
                     processor_config["extract_images"] = self.config.extract_images
+                    if self.config.device is not None:
+                        processor_config["device"] = self.config.device
 
                     full_config = ProcessorConfig(
                         custom_config=processor_config,

--- a/src/mmore/process/dispatcher.py
+++ b/src/mmore/process/dispatcher.py
@@ -230,11 +230,11 @@ class Dispatcher:
                         processor_config = {}
 
                     processor_config["output_path"] = self.config.output_path
-                    processor_config["extract_images"] = self.config.extract_images
                     if self.config.device is not None:
                         processor_config["device"] = self.config.device
 
                     full_config = ProcessorConfig(
+                        extract_images=self.config.extract_images,
                         custom_config=processor_config,
                     )
 
@@ -287,13 +287,13 @@ class Dispatcher:
             else:
                 processor_config = {}
             processor_config["output_path"] = self.config.output_path
-            processor_config["extract_images"] = self.config.extract_images
 
             logger.info(
                 f"Dispatching in distributed (to some worker) {len(files)} files to {processor_type.__name__}"
             )
 
             processor_config = ProcessorConfig(
+                extract_images=self.config.extract_images,
                 custom_config=processor_config,
             )
 

--- a/src/mmore/process/execution_state.py
+++ b/src/mmore/process/execution_state.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 from typing import Optional, cast
 
 from dask.distributed import Variable
@@ -21,6 +22,10 @@ class ExecutionState:
     _use_dask: Optional[bool] = None
     _dask_var: Optional[Variable] = None
     _local_state: bool = False
+    # For concurrency: concurrent dispatches share one init, the refcount resets
+    # it only after the last one finishes
+    _lock = threading.Lock()
+    _refcount: int = 0
 
     @staticmethod
     def initialize(distributed_mode=False, client=None):
@@ -29,29 +34,44 @@ class ExecutionState:
         :param distributed_mode: Whether the execution is in distributed mode
         :param client: connection client to the dask cluster
         """
-        if ExecutionState._use_dask is not None:
-            raise Exception("Execution state already initialized")
         assert distributed_mode is not None, (
             "Distributed mode must be set to True or False"
         )
-        ExecutionState._use_dask = distributed_mode
+        with ExecutionState._lock:
+            if ExecutionState._use_dask is not None:
+                if ExecutionState._use_dask != distributed_mode:
+                    raise Exception(
+                        "Execution state already initialized in a different mode"
+                    )
+                ExecutionState._refcount += 1
+                return
 
-        if distributed_mode:
-            assert client is not None, (
-                "You must be in the context of a dask client to use distributed mode"
-            )
-            ExecutionState._dask_var = Variable("should_stop_execution", client=client)
-            ExecutionState._dask_var.set(False)
-            logger.info("Execution state initialized (distributed mode)")
-        else:
-            ExecutionState._local_state = False
-            logger.info("Execution state initialized (local mode)")
+            ExecutionState._use_dask = distributed_mode
+            ExecutionState._refcount = 1
+
+            if distributed_mode:
+                assert client is not None, (
+                    "You must be in the context of a dask client to use distributed mode"
+                )
+                ExecutionState._dask_var = Variable(
+                    "should_stop_execution", client=client
+                )
+                ExecutionState._dask_var.set(False)
+                logger.info("Execution state initialized (distributed mode)")
+            else:
+                ExecutionState._local_state = False
+                logger.info("Execution state initialized (local mode)")
 
     @staticmethod
     def shutdown():
-        ExecutionState._use_dask = None
-        ExecutionState._dask_var = None
-        ExecutionState._local_state = False
+        with ExecutionState._lock:
+            if ExecutionState._refcount > 0:
+                ExecutionState._refcount -= 1
+            if ExecutionState._refcount > 0:
+                return
+            ExecutionState._use_dask = None
+            ExecutionState._dask_var = None
+            ExecutionState._local_state = False
 
     @staticmethod
     def get_should_stop_execution() -> bool:

--- a/src/mmore/process/processors/base.py
+++ b/src/mmore/process/processors/base.py
@@ -21,15 +21,18 @@ class ProcessorConfig:
 
     Attributes:
         attachment_tag (str): Tag used for attachments (default: "<attachment>") - This is what we use for Multimodal Meditron.
+        extract_images (bool): Whether processors should extract embedded images.
         custom_config (Dict[str, Any]): Dictionary of custom configurations.
     """
 
     def __init__(
         self,
         attachement_tag: str = "<attachment>",
+        extract_images: bool = False,
         custom_config: Dict[str, Any] = {},
     ):
         self.attachment_tag = attachement_tag
+        self.extract_images = extract_images
         self.custom_config = custom_config
         self.custom_config["attachment_tag"] = attachement_tag
 

--- a/src/mmore/process/processors/docx_processor.py
+++ b/src/mmore/process/processors/docx_processor.py
@@ -65,7 +65,7 @@ class DOCXProcessor(Processor):
         all_images = []
 
         def _convert_image(image: m_Image) -> Dict[str, Any]:
-            if not self.config.custom_config.get("extract_images", False):
+            if not self.config.extract_images:
                 return {"src": ""}
 
             content_type = cast(Optional[str], image.content_type)

--- a/src/mmore/process/processors/eml_processor.py
+++ b/src/mmore/process/processors/eml_processor.py
@@ -87,7 +87,7 @@ class EMLProcessor(Processor):
 
             # extract images only if passed argument in config is True
             elif part.get_content_type().startswith("image/"):
-                if self.config.custom_config.get("extract_images", True):
+                if self.config.extract_images:
                     try:
                         image_data = part.get_payload(decode=True)
                         if isinstance(image_data, bytes):

--- a/src/mmore/process/processors/html_processor.py
+++ b/src/mmore/process/processors/html_processor.py
@@ -98,14 +98,14 @@ class HTMLProcessor(Processor):
 
         markdown = md(html, heading_style="ATX")
 
-        if self.config.custom_config.get("extract_images", True):
+        if self.config.extract_images:
             embedded_images = _extract_images_from_markdown(markdown)
 
         else:
             embedded_images = []
 
         # If extract_images is enabled, optionally replace image markdown with a placeholder
-        if self.config.custom_config.get("extract_images", True):
+        if self.config.extract_images:
             # Replace all image markdown with the placeholder
             markdown = re.sub(r"!\[.*?\]\(.*?\)", self.config.attachment_tag, markdown)
 

--- a/src/mmore/process/processors/md_processor.py
+++ b/src/mmore/process/processors/md_processor.py
@@ -75,7 +75,7 @@ class MarkdownProcessor(Processor):
                 content,
                 file_path,
                 self.config.attachment_tag,
-                self.config.custom_config.get("extract_images", True),
+                self.config.extract_images,
             )
             return self.create_sample(
                 [all_text], embedded_images, DocumentMetadata(file_path=file_path)

--- a/src/mmore/process/processors/media_processor.py
+++ b/src/mmore/process/processors/media_processor.py
@@ -37,6 +37,8 @@ class MediaProcessor(Processor):
         super().__init__(config=config or ProcessorConfig())
 
     def _device_pipeline(self, device: str, fast_mode: bool = False):
+        # Here fast_mode is not used in the cache indexing key as it won't
+        # change across runs once defined in the configuration files
         cached = MediaProcessor.pipelines_by_device.get(device)
         if cached is not None:
             return cached
@@ -133,7 +135,7 @@ class MediaProcessor(Processor):
 
     def _process_file(self, file_path, pipeline, fast_mode):
         all_text = self._extract_text(file_path, pipeline, fast_mode)
-        if self.config.custom_config.get("extract_images", True):
+        if self.config.extract_images:
             images = self._extract_images(file_path)
         else:
             images = []
@@ -150,11 +152,7 @@ class MediaProcessor(Processor):
 
         pipeline = self.pipelines[0]
         all_text = self._extract_text(file_path, pipeline, fast_mode=fast)
-        images = (
-            self._extract_images(file_path)
-            if self.config.custom_config.get("extract_images", True)
-            else []
-        )
+        images = self._extract_images(file_path) if self.config.extract_images else []
         return self.create_sample(
             [all_text], images, DocumentMetadata(file_path=file_path)
         )

--- a/src/mmore/process/processors/media_processor.py
+++ b/src/mmore/process/processors/media_processor.py
@@ -28,9 +28,28 @@ class MediaProcessor(Processor):
 
     devices = _get_available_devices()
     pipelines = []
+    # One pipeline per device, so several GPUs can transcribe in parallel
+    pipelines_by_device: dict = {}
 
     def __init__(self, config=None):
         super().__init__(config=config or ProcessorConfig())
+
+    def _device_pipeline(self, device: str, fast_mode: bool = False):
+        if device not in MediaProcessor.pipelines_by_device:
+            model_name = (
+                self.config.custom_config.get("fast_model", "openai/whisper-tiny")
+                if fast_mode
+                else self.config.custom_config.get(
+                    "normal_model", "openai/whisper-large-v3-turbo"
+                )
+            )
+            MediaProcessor.pipelines_by_device[device] = pipeline_t(
+                "automatic-speech-recognition",
+                model=model_name,
+                device=torch_device(device),
+                return_timestamps=True,
+            )
+        return MediaProcessor.pipelines_by_device[device]
 
     @classmethod
     def accepts(cls, file: FileDescriptor) -> bool:
@@ -79,6 +98,17 @@ class MediaProcessor(Processor):
     def process_batch(
         self, files_paths: List[str], fast_mode: bool = False, num_workers: int = 1
     ) -> List[MultimodalSample]:
+        device = self.config.custom_config.get("device")
+        if device is not None:
+            pipe = self._device_pipeline(device, fast_mode)
+            results = []
+            for file in files_paths:
+                try:
+                    results.append(self._process_file(file, pipe, fast_mode))
+                except Exception as e:
+                    logger.error(f"Error processing {file}: {e}")
+            return results
+
         if not self.pipelines:
             self.load_models(fast_mode=fast_mode)
 

--- a/src/mmore/process/processors/media_processor.py
+++ b/src/mmore/process/processors/media_processor.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import tempfile
+import threading
 from typing import List
 
 import numpy as np
@@ -30,26 +31,32 @@ class MediaProcessor(Processor):
     pipelines = []
     # One pipeline per device, so several GPUs can transcribe in parallel
     pipelines_by_device: dict = {}
+    _load_lock = threading.Lock()
 
     def __init__(self, config=None):
         super().__init__(config=config or ProcessorConfig())
 
     def _device_pipeline(self, device: str, fast_mode: bool = False):
-        if device not in MediaProcessor.pipelines_by_device:
-            model_name = (
-                self.config.custom_config.get("fast_model", "openai/whisper-tiny")
-                if fast_mode
-                else self.config.custom_config.get(
-                    "normal_model", "openai/whisper-large-v3-turbo"
+        cached = MediaProcessor.pipelines_by_device.get(device)
+        if cached is not None:
+            return cached
+
+        with MediaProcessor._load_lock:
+            if device not in MediaProcessor.pipelines_by_device:
+                model_name = (
+                    self.config.custom_config.get("fast_model", "openai/whisper-tiny")
+                    if fast_mode
+                    else self.config.custom_config.get(
+                        "normal_model", "openai/whisper-large-v3-turbo"
+                    )
                 )
-            )
-            MediaProcessor.pipelines_by_device[device] = pipeline_t(
-                "automatic-speech-recognition",
-                model=model_name,
-                device=torch_device(device),
-                return_timestamps=True,
-            )
-        return MediaProcessor.pipelines_by_device[device]
+                MediaProcessor.pipelines_by_device[device] = pipeline_t(
+                    "automatic-speech-recognition",
+                    model=model_name,
+                    device=torch_device(device),
+                    return_timestamps=True,
+                )
+            return MediaProcessor.pipelines_by_device[device]
 
     @classmethod
     def accepts(cls, file: FileDescriptor) -> bool:

--- a/src/mmore/process/processors/pdf_processor.py
+++ b/src/mmore/process/processors/pdf_processor.py
@@ -34,6 +34,8 @@ class PDFMetadata(DocumentMetadata):
 
 class PDFProcessor(Processor):
     artifact_dict = None
+    # One model set per device, so several GPUs can process in parallel
+    artifacts_by_device: Dict[str, Any] = {}
 
     def __init__(self, config=None):
         super().__init__(config=config or ProcessorConfig())
@@ -44,9 +46,22 @@ class PDFProcessor(Processor):
         return file.file_extension.lower() == ".pdf"
 
     @staticmethod
-    def load_models(disable_image_extraction: bool = False):
-        if PDFProcessor.artifact_dict is None:
-            PDFProcessor.artifact_dict = create_model_dict()
+    def _get_artifacts(device: Optional[str] = None):
+        if device is None:
+            if PDFProcessor.artifact_dict is None:
+                PDFProcessor.artifact_dict = create_model_dict()
+            return PDFProcessor.artifact_dict
+        if device not in PDFProcessor.artifacts_by_device:
+            if str(device).startswith("cuda"):
+                torch.cuda.set_device(torch.device(device))
+            PDFProcessor.artifacts_by_device[device] = create_model_dict()
+        return PDFProcessor.artifacts_by_device[device]
+
+    @staticmethod
+    def load_models(
+        disable_image_extraction: bool = False, device: Optional[str] = None
+    ):
+        artifact_dict = PDFProcessor._get_artifacts(device)
 
         marker_config = {
             "disable_image_extraction": disable_image_extraction,
@@ -55,9 +70,11 @@ class PDFProcessor(Processor):
             "disable_multiprocessing": False,
             "paginate_output": True,
         }
+        if device is not None:
+            marker_config["device"] = str(device)
         config_parser = ConfigParser(marker_config)
         converter = PdfConverter(
-            artifact_dict=PDFProcessor.artifact_dict,
+            artifact_dict=artifact_dict,
             config=config_parser.generate_config_dict(),
         )
 
@@ -69,6 +86,22 @@ class PDFProcessor(Processor):
     def process_batch(
         self, files_paths: List[str], fast_mode: bool = False, num_workers: int = 1
     ) -> List[MultimodalSample]:
+        device = self.config.custom_config.get("device")
+        if device is not None:
+            self.converter = PDFProcessor.load_models(
+                disable_image_extraction=not self.config.custom_config.get(
+                    "extract_images", True
+                ),
+                device=device,
+            )
+            results = []
+            for file_path in files_paths:
+                try:
+                    results.append(self.process(file_path))
+                except Exception as e:
+                    logging.error(f"Failed to process {file_path}: {str(e)}")
+            return results
+
         if fast_mode:  # No GPU available - fallback to default
             return super().process_batch(files_paths, fast_mode, num_workers)
         else:

--- a/src/mmore/process/processors/pdf_processor.py
+++ b/src/mmore/process/processors/pdf_processor.py
@@ -62,9 +62,9 @@ class PDFProcessor(Processor):
                     PDFProcessor.artifact_dict = create_model_dict()
                 return PDFProcessor.artifact_dict
             if device not in PDFProcessor.artifacts_by_device:
-                if str(device).startswith("cuda"):
-                    torch.cuda.set_device(torch.device(device))
-                PDFProcessor.artifacts_by_device[device] = create_model_dict()
+                PDFProcessor.artifacts_by_device[device] = create_model_dict(
+                    device=device
+                )
             return PDFProcessor.artifacts_by_device[device]
 
     @staticmethod
@@ -99,9 +99,7 @@ class PDFProcessor(Processor):
         device = self.config.custom_config.get("device")
         if device is not None:
             self.converter = PDFProcessor.load_models(
-                disable_image_extraction=not self.config.custom_config.get(
-                    "extract_images", True
-                ),
+                disable_image_extraction=not self.config.extract_images,
                 device=device,
             )
             results = []
@@ -160,7 +158,7 @@ class PDFProcessor(Processor):
                         args=(
                             batch,
                             gpu_id,
-                            self.config.custom_config,
+                            self.config.extract_images,
                             output_queue,
                             error_queue,
                         ),
@@ -309,7 +307,7 @@ class PDFProcessor(Processor):
                 all_text_parts.append(text)
                 current_position += len(text)
 
-            if self.config.custom_config.get("extract_images", True):
+            if self.config.extract_images:
                 for img_info in page.get_images(full=False):
                     image = _extract_images(pdf_doc, img_info[0])
                     if image and clean_image(image):
@@ -344,18 +342,16 @@ class PDFProcessor(Processor):
         return batches
 
     def _process_parallel(
-        self, files_paths, gpu_id, config_custom, output_queue, error_queue
+        self, files_paths, gpu_id, extract_images, output_queue, error_queue
     ):
         try:
             torch.cuda.set_device(gpu_id)
 
             if PDFProcessor.artifact_dict is None:
-                PDFProcessor.artifact_dict = create_model_dict()
+                PDFProcessor.artifact_dict = create_model_dict(device=f"cuda:{gpu_id}")
 
             marker_config = {
-                "disable_image_extraction": not config_custom.get(
-                    "extract_images", True
-                ),
+                "disable_image_extraction": not extract_images,
                 "languages": None,
                 "use_llm": False,
                 "disable_multiprocessing": False,

--- a/src/mmore/process/processors/pdf_processor.py
+++ b/src/mmore/process/processors/pdf_processor.py
@@ -1,6 +1,7 @@
 import io
 import logging
 import re
+import threading
 from dataclasses import dataclass, field
 from multiprocessing import Manager, Process, set_start_method
 from typing import Any, Dict, List, Optional, Tuple, cast
@@ -36,6 +37,7 @@ class PDFProcessor(Processor):
     artifact_dict = None
     # One model set per device, so several GPUs can process in parallel
     artifacts_by_device: Dict[str, Any] = {}
+    _load_lock = threading.Lock()
 
     def __init__(self, config=None):
         super().__init__(config=config or ProcessorConfig())
@@ -48,14 +50,22 @@ class PDFProcessor(Processor):
     @staticmethod
     def _get_artifacts(device: Optional[str] = None):
         if device is None:
-            if PDFProcessor.artifact_dict is None:
-                PDFProcessor.artifact_dict = create_model_dict()
-            return PDFProcessor.artifact_dict
-        if device not in PDFProcessor.artifacts_by_device:
-            if str(device).startswith("cuda"):
-                torch.cuda.set_device(torch.device(device))
-            PDFProcessor.artifacts_by_device[device] = create_model_dict()
-        return PDFProcessor.artifacts_by_device[device]
+            cached = PDFProcessor.artifact_dict
+        else:
+            cached = PDFProcessor.artifacts_by_device.get(device)
+        if cached is not None:
+            return cached
+
+        with PDFProcessor._load_lock:
+            if device is None:
+                if PDFProcessor.artifact_dict is None:
+                    PDFProcessor.artifact_dict = create_model_dict()
+                return PDFProcessor.artifact_dict
+            if device not in PDFProcessor.artifacts_by_device:
+                if str(device).startswith("cuda"):
+                    torch.cuda.set_device(torch.device(device))
+                PDFProcessor.artifacts_by_device[device] = create_model_dict()
+            return PDFProcessor.artifacts_by_device[device]
 
     @staticmethod
     def load_models(

--- a/src/mmore/process/processors/pptx_processor.py
+++ b/src/mmore/process/processors/pptx_processor.py
@@ -84,7 +84,7 @@ class PPTXProcessor(Processor):
                             all_text.append(cleaned_text)
 
                     # Extract images from shape
-                    if self.config.custom_config.get("extract_images", True):
+                    if self.config.extract_images:
                         if shape.shape_type == MSO_SHAPE_TYPE.PICTURE:
                             try:
                                 pil_image = Image.open(

--- a/src/mmore/process/processors/spreadsheet_processor.py
+++ b/src/mmore/process/processors/spreadsheet_processor.py
@@ -160,7 +160,7 @@ class SpreadsheetProcessor(Processor):
                 return []
 
         all_text = clean_text(_extract_text(file_path))
-        if self.config.custom_config.get("extract_images", True):
+        if self.config.extract_images:
             embedded_images = _extract_images(file_path)
         else:
             embedded_images = []

--- a/src/mmore/process/processors/url_processor.py
+++ b/src/mmore/process/processors/url_processor.py
@@ -41,7 +41,7 @@ class URLProcessor(Processor):
             # replace all ![] with <attachment>
             all_text = re.sub(r"!\[.*\]\(.*\)", self.config.attachment_tag, result)
 
-            if self.config.custom_config.get("extract_images", True):
+            if self.config.extract_images:
                 images = re.findall(r"!\[.*\]\(.*\)", result)
             else:
                 images = []

--- a/src/mmore/rag/model/dense/base.py
+++ b/src/mmore/rag/model/dense/base.py
@@ -29,15 +29,13 @@ _MISTRAL_MODELS = ["mistral-textembedding-7B-v1", "mistral-textembedding-13B-v1"
 _AWS_MODELS = ["amazon-titan-embedding-xlarge", "amazon-titan-embedding-light"]
 
 
+# HF is handled in from_config (it takes a device), the rest are remote APIs.
 loaders = {
     "OPENAI": OpenAIEmbeddings,
     # 'GOOGLE': VertexAIEmbeddings,
     "COHERE": CohereEmbeddings,
     "MISTRAL": MistralAIEmbeddings,
     "AWS": BedrockEmbeddings,
-    "HF": lambda model, **kwargs: HuggingFaceEmbeddings(
-        model_name=model, model_kwargs={"trust_remote_code": True}, **kwargs
-    ),
     "FAKE": lambda **kwargs: FakeEmbeddings(
         size=2048
     ),  # For testing purposes, don't use in production
@@ -69,8 +67,16 @@ class DenseModelConfig:
 
 class DenseModel(Embeddings):
     @classmethod
-    def from_config(cls, config: DenseModelConfig) -> Embeddings:
-        if config.organization == "HF" and config.is_multimodal:
-            return MultimodalEmbeddings(model_name=config.model_name)
-        else:
+    def from_config(
+        cls, config: DenseModelConfig, device: str | None = None
+    ) -> Embeddings:
+        if config.organization != "HF":
             return loaders[config.organization](model=config.model_name)
+        if config.is_multimodal:
+            return MultimodalEmbeddings(model_name=config.model_name)
+        model_kwargs: dict = {"trust_remote_code": True}
+        if device:
+            model_kwargs["device"] = str(device)
+        return HuggingFaceEmbeddings(
+            model_name=config.model_name, model_kwargs=model_kwargs
+        )

--- a/src/mmore/rag/model/sparse/base.py
+++ b/src/mmore/rag/model/sparse/base.py
@@ -28,7 +28,9 @@ class SparseModelConfig:
 
 class SparseModel(BaseSparseEmbedding):
     @classmethod
-    def from_config(cls, config: SparseModelConfig) -> BaseSparseEmbedding:
+    def from_config(
+        cls, config: SparseModelConfig, device: str | None = None
+    ) -> BaseSparseEmbedding:
         return loaders.get(config.model_type, SpladeSparseEmbedding)(
-            model_name=config.model_name
+            model_name=config.model_name, device=device
         )

--- a/src/mmore/rag/model/sparse/splade.py
+++ b/src/mmore/rag/model/sparse/splade.py
@@ -15,16 +15,22 @@ class SpladeSparseEmbedding(BaseSparseEmbedding):
     https://milvus.io/docs/embed-with-splade.md
     """
 
-    def __init__(self, model_name: str = "naver/splade-cocondenser-selfdistil"):
+    def __init__(
+        self,
+        model_name: str = "naver/splade-cocondenser-selfdistil",
+        device: str | None = None,
+    ):
         from pymilvus.model.sparse import SpladeEmbeddingFunction  # type: ignore
 
-        self.device = (
-            "cuda"
-            if torch.cuda.is_available()
-            else "mps"
-            if torch.backends.mps.is_available()
-            else "cpu"
-        )
+        if device is None:
+            device = (
+                "cuda"
+                if torch.cuda.is_available()
+                else "mps"
+                if torch.backends.mps.is_available()
+                else "cpu"
+            )
+        self.device = device
         self.splade = SpladeEmbeddingFunction(model_name=model_name, device=self.device)
 
     def embed_query(self, query: str) -> Dict[int, float]:

--- a/src/mmore/rag/retriever.py
+++ b/src/mmore/rag/retriever.py
@@ -36,6 +36,7 @@ class RetrieverConfig:
     use_web: bool = False
     reranker_model_name: Optional[str] = "BAAI/bge-reranker-base"
     jobs_per_gpu: int = 1
+    # None below gives by default a queue size of num_gpu * jobs_per_gpu * 10
     max_queue_size: Optional[int] = None
 
 

--- a/src/mmore/rag/retriever.py
+++ b/src/mmore/rag/retriever.py
@@ -35,6 +35,8 @@ class RetrieverConfig:
     collection_name: str = "my_docs"
     use_web: bool = False
     reranker_model_name: Optional[str] = "BAAI/bge-reranker-base"
+    jobs_per_gpu: int = 1
+    max_queue_size: Optional[int] = None
 
 
 class Retriever(BaseRetriever):

--- a/src/mmore/run_index_api.py
+++ b/src/mmore/run_index_api.py
@@ -3,8 +3,9 @@ import logging
 import os
 import shutil
 import tempfile
+import threading
 from pathlib import Path as FilePath
-from typing import List
+from typing import Callable, List
 
 import uvicorn
 from fastapi import APIRouter, FastAPI, File, Form, HTTPException, Path, UploadFile
@@ -21,6 +22,7 @@ logging.basicConfig(
 
 from mmore.profiler import enable_profiling_from_env
 
+from .job_queue import DuplicateJobError, JobQueue, QueueFullError
 from .process.processors import register_all_processors
 from .rag.retriever import RetrieverConfig
 from .type import MultimodalSample
@@ -60,6 +62,67 @@ def make_router(config_path: str) -> APIRouter:
     get_indexer(COLLECTION_NAME, MILVUS_URI, MILVUS_DB)
     register_all_processors(preload=True)
 
+    jobs = JobQueue(
+        jobs_per_gpu=getattr(config, "jobs_per_gpu", 1),
+        max_queue_size=getattr(config, "max_queue_size", None),
+    )
+
+    db_lock = threading.Lock()
+
+    def _stage_upload(file: UploadFile, filename: str) -> tuple[str, str]:
+        """Save the uploaded bytes now, while the request is alive.
+
+        Returns (job_dir, input_dir). The worker removes job_dir when done.
+        """
+        job_dir = tempfile.mkdtemp(prefix="index_job_")
+        input_dir = os.path.join(job_dir, "input")
+        os.makedirs(input_dir)
+        with open(os.path.join(input_dir, filename), "wb") as buffer:
+            shutil.copyfileobj(file.file, buffer)
+        return job_dir, input_dir
+
+    def _make_ingest_job(
+        job_dir: str,
+        input_dir: str,
+        file_id: str,
+        filename: str,
+        replace: bool,
+    ) -> Callable[[str], dict]:
+        extension = FilePath(filename).suffix.lower()
+
+        def ingest(device: str) -> dict:
+            try:
+                documents = process_files_default(
+                    input_dir,
+                    COLLECTION_NAME,
+                    [extension],
+                    device=device,
+                    output_path=os.path.join(job_dir, "out"),
+                )
+                _apply_uploaded_file_metadata(documents, file_id, filename)
+
+                indexer = get_indexer(COLLECTION_NAME, MILVUS_URI, MILVUS_DB)
+                with db_lock:
+                    if replace:
+                        indexer.client.delete(
+                            collection_name=COLLECTION_NAME,
+                            filter=f"document_id == '{file_id}'",
+                        )
+                    indexer.index_documents(
+                        documents=documents, collection_name=COLLECTION_NAME
+                    )
+                    indexer.client.flush(COLLECTION_NAME)
+
+                # Persist the permanent copy only on success
+                dest = FilePath(UPLOAD_DIR) / file_id
+                os.makedirs(os.path.dirname(dest), exist_ok=True)
+                shutil.copy2(os.path.join(input_dir, filename), dest)
+                return {"chunks": len(documents)}
+            finally:
+                shutil.rmtree(job_dir, ignore_errors=True)
+
+        return ingest
+
     @router.get("/")
     async def root():
         return {
@@ -67,317 +130,131 @@ def make_router(config_path: str) -> APIRouter:
         }
 
     # SINGLE FILE UPLOAD ENDPOINT
-    @router.post("/v1/files", status_code=201, tags=["File Operations"])
+    @router.post("/v1/files", status_code=202, tags=["File Operations"])
     async def upload_file(
         fileId: str = Form(..., description="Unique identifier for the file"),
         file: UploadFile = File(..., description="The file content"),
     ):
         """
-        Upload a new file with a unique identifier.
+        Queue a new file for processing and indexing.
 
-        Requirements:
-        - Unique fileId
+        Returns a jobId immediately, the work runs in the background.
         """
+        if file.filename is None:
+            raise HTTPException(
+                status_code=422, detail="Provided file should have a filename"
+            )
+        if (FilePath(UPLOAD_DIR) / fileId).exists():
+            raise HTTPException(
+                status_code=409, detail=f"File with ID {fileId} already exists"
+            )
+
+        job_dir, input_dir = _stage_upload(file, file.filename)
+        await file.close()
+        ingest = _make_ingest_job(
+            job_dir, input_dir, fileId, file.filename, replace=False
+        )
         try:
-            # Check if file with this ID already exists
-            # pdb.set_trace()
-            file_storage_path = FilePath(UPLOAD_DIR) / fileId
-            if file_storage_path.exists():
-                raise HTTPException(
-                    status_code=400, detail=f"File with ID {fileId} already exists"
-                )
+            job_id = jobs.submit(fileId, file.filename, ingest)
+        except DuplicateJobError:
+            shutil.rmtree(job_dir, ignore_errors=True)
+            raise HTTPException(
+                status_code=409,
+                detail=f"File with ID {fileId} is already being processed",
+            )
+        except QueueFullError:
+            shutil.rmtree(job_dir, ignore_errors=True)
+            raise HTTPException(status_code=503, detail="Server busy, retry later")
 
-            if file.filename is None:
-                raise HTTPException(
-                    status_code=422, detail="Provided file should have a filename"
-                )
+        return {"jobId": job_id, "fileId": fileId}
 
-            # Use a temporary directory for processing so that we only process the incoming docs
-            with tempfile.TemporaryDirectory() as temp_dir:
-                temp_file_path = FilePath(temp_dir) / file.filename
-                with temp_file_path.open("wb") as buffer:
-                    shutil.copyfileobj(file.file, buffer)
-
-                await file.close()
-
-                # Process and index the file
-                file_extension = FilePath(file.filename).suffix.lower()
-                try:
-                    documents = process_files_default(
-                        temp_dir, COLLECTION_NAME, [file_extension]
-                    )
-                except KeyError as e:
-                    logger.warning(
-                        "Could not process file '%s' with extension '%s'",
-                        file.filename,
-                        file_extension,
-                        exc_info=True,
-                    )
-                    raise HTTPException(
-                        status_code=422,
-                        detail=f"Could not process file '{file.filename}'",
-                    ) from e
-
-                # Save a permanent copy for later retrieval
-                os.makedirs(os.path.dirname(file_storage_path), exist_ok=True)
-                shutil.copy2(temp_file_path, file_storage_path)
-
-                _apply_uploaded_file_metadata(documents, fileId, file.filename)
-
-                # Get indexer and index the document
-                try:
-                    indexer = get_indexer(COLLECTION_NAME, MILVUS_URI, MILVUS_DB)
-                except Exception as e:
-                    raise HTTPException(status_code=500, detail=str(e))
-
-                indexer.index_documents(
-                    documents=documents, collection_name=COLLECTION_NAME
-                )
-                indexer.client.flush(COLLECTION_NAME)
-
-                return {
-                    "status": "success",
-                    "message": f"File successfully indexed in {COLLECTION_NAME} collection",
-                    "fileId": fileId,
-                    "filename": file.filename,
-                }
-
-        except HTTPException:
-            raise
-
-        except Exception as e:
-            logger.error(f"Error uploading file: {str(e)}", exc_info=True)
-            raise HTTPException(status_code=500, detail=str(e))
-
-    @router.post("/v1/files/bulk", status_code=201, tags=["File Operations"])
+    @router.post("/v1/files/bulk", status_code=202, tags=["File Operations"])
     async def upload_files(
         listIds: List[str] = Form(..., description="List of IDs for the files"),
         files: List[UploadFile] = File(..., description="Files to upload"),
     ):
         """
-        Upload multiple files with custom IDs and index them.
+        Queue multiple files, one independent job per file.
+
+        Returns a per-file outcome (jobId or error), so one bad file does not
+        fail the whole batch.
         """
-        try:
-            listIds = [
-                file_id.strip()
-                for ids in listIds
-                for file_id in ids.split(",")
-                if file_id.strip()
-            ]
-            # Check if IDs and files match in number
-            if len(listIds) != len(files):
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"Number of IDs ({len(listIds)}) doesn't match number of files ({len(files)})",
-                )
+        listIds = [
+            file_id.strip()
+            for ids in listIds
+            for file_id in ids.split(",")
+            if file_id.strip()
+        ]
+        if len(listIds) != len(files):
+            raise HTTPException(
+                status_code=400,
+                detail=f"Number of IDs ({len(listIds)}) doesn't match number of files ({len(files)})",
+            )
 
-            with tempfile.TemporaryDirectory() as temp_dir:
-                logging.info(f"Starting to process {len(files)} files with custom IDs")
+        results = []
+        for file, file_id in zip(files, listIds):
+            if file.filename is None:
+                results.append({"fileId": file_id, "error": "missing filename"})
+                continue
+            if (FilePath(UPLOAD_DIR) / file_id).exists():
+                results.append({"fileId": file_id, "error": "already exists"})
+                continue
 
-                uploaded_files: list[dict[str, str]] = []
-                file_info_by_temp_path = {}
-                for index, (file, file_id) in enumerate(zip(files, listIds)):
-                    if file.filename is None:
-                        raise HTTPException(
-                            status_code=422,
-                            detail=f"File {file_id} does not have a filename",
-                        )
-                    filename = file.filename
+            job_dir, input_dir = _stage_upload(file, file.filename)
+            await file.close()
+            ingest = _make_ingest_job(
+                job_dir, input_dir, file_id, file.filename, replace=False
+            )
+            try:
+                job_id = jobs.submit(file_id, file.filename, ingest)
+                results.append({"fileId": file_id, "jobId": job_id})
+            except DuplicateJobError:
+                shutil.rmtree(job_dir, ignore_errors=True)
+                results.append({"fileId": file_id, "error": "already being processed"})
+            except QueueFullError:
+                shutil.rmtree(job_dir, ignore_errors=True)
+                results.append({"fileId": file_id, "error": "queue full"})
 
-                    # Check if file with this ID already exists
-                    file_storage_path = FilePath(UPLOAD_DIR) / file_id
-                    if file_storage_path.exists():
-                        raise HTTPException(
-                            status_code=400,
-                            detail=f"File with ID {file_id} already exists",
-                        )
+        return {"jobs": results}
 
-                    # Save to temp directory
-                    temp_file_path = (
-                        FilePath(temp_dir) / f"{index}{FilePath(filename).suffix}"
-                    )
-                    file_info = {
-                        "fileId": file_id,
-                        "filename": filename,
-                        "temp_path": str(temp_file_path.resolve()),
-                    }
-                    uploaded_files.append(file_info)
-                    file_info_by_temp_path[file_info["temp_path"]] = file_info
-
-                    with temp_file_path.open("wb") as buffer:
-                        shutil.copyfileobj(file.file, buffer)
-
-                    # Close the file
-                    await file.close()
-
-                logging.info(f"Files saved to temporary directory: {temp_dir}")
-
-                # Process the documents
-                file_extensions = [
-                    FilePath(file_info["temp_path"]).suffix.lower()
-                    for file_info in uploaded_files
-                ]
-                try:
-                    documents = process_files_default(
-                        temp_dir, COLLECTION_NAME, file_extensions
-                    )
-                except KeyError as e:
-                    logger.warning(
-                        "Could not process one of the uploaded files with extensions %s",
-                        file_extensions,
-                        exc_info=True,
-                    )
-                    raise HTTPException(
-                        status_code=422,
-                        detail="Could not process one of the uploaded files",
-                    ) from e
-
-                # Save permanent copies
-                for file_info in uploaded_files:
-                    file_storage_path = FilePath(UPLOAD_DIR) / file_info["fileId"]
-                    shutil.copy2(file_info["temp_path"], file_storage_path)
-
-                # Change the IDs to match the ones from the client
-                modified_documents = []
-                text_by_file_id = {}
-                chunks_by_file_id = {
-                    file_info["fileId"]: 0 for file_info in uploaded_files
-                }
-                for doc_index, doc in enumerate(documents):
-                    doc_temp_path = str(FilePath(doc.metadata.file_path).resolve())
-                    file_info = file_info_by_temp_path.get(doc_temp_path)
-                    if file_info is None:
-                        if doc_index >= len(uploaded_files):
-                            raise HTTPException(
-                                status_code=500,
-                                detail=(
-                                    "Could not match processed document "
-                                    f"{doc.metadata.file_path} to an uploaded file"
-                                ),
-                            )
-                        # Fallback for processors/tests that return file paths outside temp_dir.
-                        file_info = uploaded_files[doc_index]
-                    doc_id = file_info["fileId"]
-                    _apply_uploaded_file_metadata([doc], doc_id, file_info["filename"])
-                    text_by_file_id.setdefault(doc_id, doc.text)
-                    chunks_by_file_id[doc_id] += 1
-                    modified_documents.append(doc)
-
-                logging.info("Indexing the files")
-
-                try:
-                    indexer = get_indexer(COLLECTION_NAME, MILVUS_URI, MILVUS_DB)
-                except Exception as e:
-                    raise HTTPException(status_code=500, detail=str(e))
-
-                indexer.index_documents(
-                    documents=modified_documents, collection_name=COLLECTION_NAME
-                )
-                indexer.client.flush(COLLECTION_NAME)
-
-                return {
-                    "status": "success",
-                    "message": f"Successfully processed and indexed {len(uploaded_files)} files",
-                    "documents": [
-                        {
-                            "fileId": file_info["fileId"],
-                            "filename": file_info["filename"],
-                            "text": text_by_file_id.get(file_info["fileId"], "")[:50]
-                            + "...",
-                            "chunks": chunks_by_file_id[file_info["fileId"]],
-                        }
-                        for file_info in uploaded_files
-                    ],
-                }
-
-        except HTTPException:
-            raise
-
-        except Exception as e:
-            raise HTTPException(status_code=500, detail=str(e))
-
-    @router.put("/v1/files/{fileId}", tags=["File Operations"])
+    @router.put("/v1/files/{fileId}", status_code=202, tags=["File Operations"])
     async def update_file(
         fileId: str = Path(..., description="ID of the file to update"),
         file: UploadFile = File(..., description="The new file content"),
     ):
         """
-        Replace an existing file with a new version.
+        Queue a replacement for an existing file and re-index it.
+
+        The old vectors are deleted and the new ones inserted only after
+        processing succeeds, so a failure leaves the existing document intact.
         """
+        if not (FilePath(UPLOAD_DIR) / fileId).exists():
+            raise HTTPException(
+                status_code=404, detail=f"File with ID {fileId} not found"
+            )
+        if file.filename is None:
+            raise HTTPException(
+                status_code=422, detail="Provided file should have a filename"
+            )
+
+        job_dir, input_dir = _stage_upload(file, file.filename)
+        await file.close()
+        ingest = _make_ingest_job(
+            job_dir, input_dir, fileId, file.filename, replace=True
+        )
         try:
-            # Check if file exists
-            file_storage_path = FilePath(UPLOAD_DIR) / fileId
-            if not file_storage_path.exists():
-                raise HTTPException(
-                    status_code=404, detail=f"File with ID {fileId} not found"
-                )
+            job_id = jobs.submit(fileId, file.filename, ingest)
+        except DuplicateJobError:
+            shutil.rmtree(job_dir, ignore_errors=True)
+            raise HTTPException(
+                status_code=409,
+                detail=f"File with ID {fileId} is already being processed",
+            )
+        except QueueFullError:
+            shutil.rmtree(job_dir, ignore_errors=True)
+            raise HTTPException(status_code=503, detail="Server busy, retry later")
 
-            if file.filename is None:
-                raise HTTPException(
-                    status_code=422, detail="Provided file should have a filename"
-                )
-
-            with tempfile.TemporaryDirectory() as temp_dir:
-                # Save the file temporarily for processing
-                temp_file_path = FilePath(temp_dir) / file.filename
-                with temp_file_path.open("wb") as buffer:
-                    shutil.copyfileobj(file.file, buffer)
-
-                await file.close()
-
-                # Replace the existing file
-                os.remove(file_storage_path)
-                shutil.copy2(temp_file_path, file_storage_path)
-
-                # Process and index the file
-                file_extension = FilePath(file.filename).suffix.lower()
-                documents = process_files_default(
-                    temp_dir, COLLECTION_NAME, [file_extension]
-                )
-
-                # Set the custom ID and preserve the original upload filename
-                _apply_uploaded_file_metadata(documents, fileId, file.filename)
-
-                # Get indexer and reindex the document
-                try:
-                    indexer = get_indexer(COLLECTION_NAME, MILVUS_URI, MILVUS_DB)
-                except Exception as e:
-                    raise HTTPException(status_code=500, detail=str(e))
-
-                # First delete the existing document
-                try:
-                    # Delete existing document with this ID from collection
-                    client = MilvusClient(
-                        uri=MILVUS_URI, db_name=MILVUS_DB, enable_sparse=True
-                    )
-                    client.delete(
-                        collection_name=COLLECTION_NAME,
-                        filter=f"document_id == '{fileId}'",
-                    )
-                except Exception as delete_error:
-                    logger.warning(
-                        f"Error deleting existing document (may not exist): {str(delete_error)}"
-                    )
-
-                # Index the new document
-                indexer.index_documents(
-                    documents=documents, collection_name=COLLECTION_NAME
-                )
-                indexer.client.flush(COLLECTION_NAME)
-
-                return {
-                    "status": "success",
-                    "message": "File successfully updated",
-                    "fileId": fileId,
-                    "filename": file.filename,
-                }
-
-        except HTTPException as e:
-            raise e
-
-        except Exception as e:
-            logger.error(f"Error updating file: {str(e)}", exc_info=True)
-            raise HTTPException(status_code=500, detail=str(e))
+        return {"jobId": job_id, "fileId": fileId}
 
     @router.delete("/v1/files/{fileId}", tags=["File Operations"])
     async def delete_file(

--- a/src/mmore/run_index_api.py
+++ b/src/mmore/run_index_api.py
@@ -173,14 +173,34 @@ def make_router(config_path: str) -> APIRouter:
 
         return ingest
 
-    @router.get("/")
+    @router.get("/", tags=["Health"], summary="Health check")
     async def root():
         return {
             "message": "Indexer API is running (what are you doing here...go catch it!)"
         }
 
     # SINGLE FILE UPLOAD ENDPOINT
-    @router.post("/v1/files", status_code=202, tags=["File Operations"])
+    @router.post(
+        "/v1/files",
+        status_code=202,
+        tags=["File Operations"],
+        summary="Upload a single file",
+        responses={
+            202: {
+                "description": "Job queued",
+                "content": {
+                    "application/json": {
+                        "example": {"jobId": "a1b2c3d4...", "fileId": "example123"}
+                    }
+                },
+            },
+            409: {
+                "description": "File ID already exists or is already being processed"
+            },
+            422: {"description": "Uploaded file has no filename"},
+            503: {"description": "Job queue is full, retry later"},
+        },
+    )
     async def upload_file(
         fileId: str = Form(..., description="Unique identifier for the file"),
         file: UploadFile = File(..., description="The file content"),
@@ -218,7 +238,28 @@ def make_router(config_path: str) -> APIRouter:
 
         return {"jobId": job_id, "fileId": fileId}
 
-    @router.post("/v1/files/bulk", status_code=202, tags=["File Operations"])
+    @router.post(
+        "/v1/files/bulk",
+        status_code=202,
+        tags=["File Operations"],
+        summary="Upload multiple files with IDs",
+        responses={
+            202: {
+                "description": "Per-file outcome (jobId or error)",
+                "content": {
+                    "application/json": {
+                        "example": {
+                            "jobs": [
+                                {"fileId": "doc1", "jobId": "a1b2c3..."},
+                                {"fileId": "doc2", "error": "already exists"},
+                            ]
+                        }
+                    }
+                },
+            },
+            400: {"description": "Number of IDs does not match number of files"},
+        },
+    )
     async def upload_files(
         listIds: List[str] = Form(..., description="List of IDs for the files"),
         files: List[UploadFile] = File(..., description="Files to upload"),
@@ -267,7 +308,26 @@ def make_router(config_path: str) -> APIRouter:
 
         return {"jobs": results}
 
-    @router.put("/v1/files/{fileId}", status_code=202, tags=["File Operations"])
+    @router.put(
+        "/v1/files/{fileId}",
+        status_code=202,
+        tags=["File Operations"],
+        summary="Replace an existing file and re-index",
+        responses={
+            202: {
+                "description": "Replacement job queued",
+                "content": {
+                    "application/json": {
+                        "example": {"jobId": "a1b2c3d4...", "fileId": "doc123"}
+                    }
+                },
+            },
+            404: {"description": "File not found"},
+            409: {"description": "File is already being processed"},
+            422: {"description": "Uploaded file has no filename"},
+            503: {"description": "Job queue is full, retry later"},
+        },
+    )
     async def update_file(
         fileId: str = Path(..., description="ID of the file to update"),
         file: UploadFile = File(..., description="The new file content"),
@@ -306,7 +366,27 @@ def make_router(config_path: str) -> APIRouter:
 
         return {"jobId": job_id, "fileId": fileId}
 
-    @router.delete("/v1/files/{fileId}", tags=["File Operations"])
+    @router.delete(
+        "/v1/files/{fileId}",
+        tags=["File Operations"],
+        summary="Delete a file and remove its vector entry",
+        responses={
+            200: {
+                "description": "File deleted",
+                "content": {
+                    "application/json": {
+                        "example": {
+                            "status": "success",
+                            "message": "File successfully deleted",
+                            "fileId": "doc123",
+                        }
+                    }
+                },
+            },
+            404: {"description": "File not found"},
+            500: {"description": "Internal error while deleting the file"},
+        },
+    )
     async def delete_file(
         fileId: str = Path(..., description="ID of the file to delete"),
     ):
@@ -352,7 +432,20 @@ def make_router(config_path: str) -> APIRouter:
             logger.error(f"Error deleting file: {str(e)}", exc_info=True)
             raise HTTPException(status_code=500, detail=str(e))
 
-    @router.get("/v1/files/{fileId}", tags=["File Operations"])
+    @router.get(
+        "/v1/files/{fileId}",
+        tags=["File Operations"],
+        summary="Download a file by its ID",
+        response_class=FileResponse,
+        responses={
+            200: {
+                "description": "Binary file content",
+                "content": {"application/octet-stream": {}},
+            },
+            404: {"description": "File not found"},
+            500: {"description": "Internal error while retrieving the file"},
+        },
+    )
     async def download_file(
         fileId: str = Path(..., description="ID of the file to download"),
     ):
@@ -406,7 +499,30 @@ def make_router(config_path: str) -> APIRouter:
             logger.error(f"Error downloading file: {str(e)}", exc_info=True)
             raise HTTPException(status_code=500, detail=str(e))
 
-    @router.get("/v1/jobs/{jobId}", tags=["Jobs"])
+    @router.get(
+        "/v1/jobs/{jobId}",
+        tags=["Jobs"],
+        summary="Get a one-shot job status snapshot",
+        responses={
+            200: {
+                "description": "Job status snapshot",
+                "content": {
+                    "application/json": {
+                        "example": {
+                            "jobId": "a1b2c3...",
+                            "fileId": "doc1",
+                            "filename": "doc.pdf",
+                            "status": "done",
+                            "device": "cuda:0",
+                            "result": {"chunks": 12},
+                            "error": None,
+                        }
+                    }
+                },
+            },
+            404: {"description": "Unknown or expired job"},
+        },
+    )
     async def get_job(jobId: str = Path(..., description="ID of the job")):
         """One-shot job status snapshot, fallback for when the SSE stream drops."""
         job = jobs.get(jobId)
@@ -414,7 +530,19 @@ def make_router(config_path: str) -> APIRouter:
             raise HTTPException(status_code=404, detail=f"Unknown job {jobId}")
         return _job_payload(job)
 
-    @router.get("/v1/jobs/{jobId}/events", tags=["Jobs"])
+    @router.get(
+        "/v1/jobs/{jobId}/events",
+        tags=["Jobs"],
+        summary="Stream job status updates over SSE",
+        response_class=StreamingResponse,
+        responses={
+            200: {
+                "description": "Server-Sent Events stream of job status changes, "
+                "closed when the job is done or failed",
+                "content": {"text/event-stream": {}},
+            },
+        },
+    )
     async def stream_job_events(jobId: str = Path(..., description="ID of the job")):
         """Push job status updates to the client over SSE until the job ends."""
 

--- a/src/mmore/run_index_api.py
+++ b/src/mmore/run_index_api.py
@@ -6,7 +6,6 @@ import multiprocessing
 import os
 import shutil
 import tempfile
-import threading
 from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path as FilePath
 from typing import Callable, List, Optional
@@ -115,8 +114,6 @@ def make_router(config_path: str) -> APIRouter:
 
     router.add_event_handler("shutdown", _shutdown)
 
-    db_lock = threading.Lock()
-
     def _stage_upload(file: UploadFile, filename: str) -> tuple[str, str]:
         """Save the uploaded bytes now, while the request is alive.
 
@@ -151,19 +148,20 @@ def make_router(config_path: str) -> APIRouter:
                 )
                 _apply_uploaded_file_metadata(documents, file_id, filename)
 
-                indexer = get_indexer(COLLECTION_NAME, MILVUS_URI, MILVUS_DB)
-                with db_lock:
-                    if torch.cuda.is_available():
-                        torch.cuda.set_device(0)
-                    if replace:
-                        indexer.client.delete(
-                            collection_name=COLLECTION_NAME,
-                            filter=f"document_id == '{file_id}'",
-                        )
-                    indexer.index_documents(
-                        documents=documents, collection_name=COLLECTION_NAME
+                indexer = get_indexer(
+                    COLLECTION_NAME, MILVUS_URI, MILVUS_DB, device=device
+                )
+                if str(device).startswith("cuda"):
+                    torch.cuda.set_device(torch.device(device))
+                if replace:
+                    indexer.client.delete(
+                        collection_name=COLLECTION_NAME,
+                        filter=f"document_id == '{file_id}'",
                     )
-                    indexer.client.flush(COLLECTION_NAME)
+                indexer.index_documents(
+                    documents=documents, collection_name=COLLECTION_NAME
+                )
+                indexer.client.flush(COLLECTION_NAME)
 
                 # Persist the permanent copy only on success
                 dest = FilePath(UPLOAD_DIR) / file_id

--- a/src/mmore/run_index_api.py
+++ b/src/mmore/run_index_api.py
@@ -122,12 +122,6 @@ def make_router(config_path: str) -> APIRouter:
                 os.makedirs(os.path.dirname(file_storage_path), exist_ok=True)
                 shutil.copy2(temp_file_path, file_storage_path)
 
-                # Process and index the file
-                file_extension = FilePath(file.filename).suffix.lower()
-                documents = process_files_default(
-                    temp_dir, COLLECTION_NAME, [file_extension]
-                )
-
                 _apply_uploaded_file_metadata(documents, fileId, file.filename)
 
                 # Get indexer and index the document

--- a/src/mmore/run_index_api.py
+++ b/src/mmore/run_index_api.py
@@ -9,6 +9,7 @@ import threading
 from pathlib import Path as FilePath
 from typing import Callable, List, Optional
 
+import torch
 import uvicorn
 from fastapi import APIRouter, FastAPI, File, Form, HTTPException, Path, UploadFile
 from fastapi.responses import FileResponse, StreamingResponse
@@ -124,6 +125,8 @@ def make_router(config_path: str) -> APIRouter:
 
                 indexer = get_indexer(COLLECTION_NAME, MILVUS_URI, MILVUS_DB)
                 with db_lock:
+                    if torch.cuda.is_available():
+                        torch.cuda.set_device(0)
                     if replace:
                         indexer.client.delete(
                             collection_name=COLLECTION_NAME,

--- a/src/mmore/run_index_api.py
+++ b/src/mmore/run_index_api.py
@@ -81,9 +81,12 @@ def make_router(config_path: str) -> APIRouter:
     register_all_processors(preload=True)
 
     jobs = JobQueue(
-        jobs_per_gpu=getattr(config, "jobs_per_gpu", 1),
-        max_queue_size=getattr(config, "max_queue_size", None),
+        jobs_per_gpu=config.jobs_per_gpu,
+        max_queue_size=config.max_queue_size,
     )
+
+    # Clear jobs before exiting
+    router.add_event_handler("shutdown", jobs.shutdown)
 
     db_lock = threading.Lock()
 

--- a/src/mmore/run_index_api.py
+++ b/src/mmore/run_index_api.py
@@ -2,10 +2,12 @@ import argparse
 import asyncio
 import json
 import logging
+import multiprocessing
 import os
 import shutil
 import tempfile
 import threading
+from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path as FilePath
 from typing import Callable, List, Optional
 
@@ -42,6 +44,18 @@ logger = logging.getLogger(__name__)
 
 POLL_INTERVAL = 2.0
 HEARTBEAT_SECONDS = 15
+
+
+def _process_files(pool, input_dir, collection_name, extensions, device, output_path):
+    """Run processing in the device's subprocess."""
+    return pool.submit(
+        process_files_default,
+        input_dir,
+        collection_name,
+        extensions,
+        device=device,
+        output_path=output_path,
+    ).result()
 
 
 def _job_payload(job: Job) -> dict:
@@ -86,8 +100,20 @@ def make_router(config_path: str) -> APIRouter:
         max_queue_size=config.max_queue_size,
     )
 
-    # Clear jobs before exiting
-    router.add_event_handler("shutdown", jobs.shutdown)
+    mp_context = multiprocessing.get_context("spawn")
+    process_pools = {
+        device: ProcessPoolExecutor(
+            max_workers=config.jobs_per_gpu, mp_context=mp_context
+        )
+        for device in jobs.devices
+    }
+
+    def _shutdown():
+        jobs.shutdown()
+        for pool in process_pools.values():
+            pool.shutdown(wait=True)
+
+    router.add_event_handler("shutdown", _shutdown)
 
     db_lock = threading.Lock()
 
@@ -114,12 +140,14 @@ def make_router(config_path: str) -> APIRouter:
 
         def ingest(device: str) -> dict:
             try:
-                documents = process_files_default(
+                # Processing runs in the device's subprocess
+                documents = _process_files(
+                    process_pools[device],
                     input_dir,
                     COLLECTION_NAME,
                     [extension],
-                    device=device,
-                    output_path=os.path.join(job_dir, "out"),
+                    device,
+                    os.path.join(job_dir, "out"),
                 )
                 _apply_uploaded_file_metadata(documents, file_id, filename)
 

--- a/src/mmore/run_index_api.py
+++ b/src/mmore/run_index_api.py
@@ -122,7 +122,10 @@ def make_router(config_path: str) -> APIRouter:
         job_dir = tempfile.mkdtemp(prefix="index_job_")
         input_dir = os.path.join(job_dir, "input")
         os.makedirs(input_dir)
-        with open(os.path.join(input_dir, filename), "wb") as buffer:
+        target = os.path.realpath(os.path.join(input_dir, os.path.basename(filename)))
+        if os.path.dirname(target) != os.path.realpath(input_dir):
+            raise HTTPException(status_code=422, detail="Invalid filename")
+        with open(target, "wb") as buffer:
             shutil.copyfileobj(file.file, buffer)
         return job_dir, input_dir
 
@@ -156,7 +159,7 @@ def make_router(config_path: str) -> APIRouter:
                 if replace:
                     indexer.client.delete(
                         collection_name=COLLECTION_NAME,
-                        filter=f"document_id == '{file_id}'",
+                        filter=f"document_id == {json.dumps(file_id)}",
                     )
                 indexer.index_documents(
                     documents=documents, collection_name=COLLECTION_NAME
@@ -285,9 +288,11 @@ def make_router(config_path: str) -> APIRouter:
         results = []
         for file, file_id in zip(files, listIds):
             if file.filename is None:
+                await file.close()
                 results.append({"fileId": file_id, "error": "missing filename"})
                 continue
             if (FilePath(UPLOAD_DIR) / file_id).exists():
+                await file.close()
                 results.append({"fileId": file_id, "error": "already exists"})
                 continue
 
@@ -411,7 +416,8 @@ def make_router(config_path: str) -> APIRouter:
                     uri=MILVUS_URI, db_name=MILVUS_DB, enable_sparse=True
                 )
                 delete_result = client.delete(
-                    collection_name=COLLECTION_NAME, filter=f"document_id == '{fileId}'"
+                    collection_name=COLLECTION_NAME,
+                    filter=f"document_id == {json.dumps(fileId)}",
                 )
                 logger.info(f"Deleted document from vector DB: {delete_result}")
             except Exception as db_error:
@@ -467,7 +473,7 @@ def make_router(config_path: str) -> APIRouter:
                 )
                 file_paths = client.query(
                     collection_name=COLLECTION_NAME,
-                    filter=f"document_id == '{fileId}'",
+                    filter=f"document_id == {json.dumps(fileId)}",
                     output_fields=["file_path"],
                 )
 

--- a/src/mmore/run_index_api.py
+++ b/src/mmore/run_index_api.py
@@ -1,15 +1,17 @@
 import argparse
+import asyncio
+import json
 import logging
 import os
 import shutil
 import tempfile
 import threading
 from pathlib import Path as FilePath
-from typing import Callable, List
+from typing import Callable, List, Optional
 
 import uvicorn
 from fastapi import APIRouter, FastAPI, File, Form, HTTPException, Path, UploadFile
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, StreamingResponse
 from pymilvus import MilvusClient
 
 logger = logging.getLogger(__name__)
@@ -22,7 +24,7 @@ logging.basicConfig(
 
 from mmore.profiler import enable_profiling_from_env
 
-from .job_queue import DuplicateJobError, JobQueue, QueueFullError
+from .job_queue import DuplicateJobError, Job, JobQueue, QueueFullError
 from .process.processors import register_all_processors
 from .rag.retriever import RetrieverConfig
 from .type import MultimodalSample
@@ -35,6 +37,22 @@ os.makedirs(UPLOAD_DIR, exist_ok=True)
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+
+POLL_INTERVAL = 2.0
+HEARTBEAT_SECONDS = 15
+
+
+def _job_payload(job: Job) -> dict:
+    return {
+        "jobId": job.id,
+        "fileId": job.file_id,
+        "filename": job.filename,
+        "status": job.status.value,
+        "device": job.device,
+        "result": job.result,
+        "error": job.error,
+    }
 
 
 def _apply_uploaded_file_metadata(
@@ -355,6 +373,46 @@ def make_router(config_path: str) -> APIRouter:
         except Exception as e:
             logger.error(f"Error downloading file: {str(e)}", exc_info=True)
             raise HTTPException(status_code=500, detail=str(e))
+
+    @router.get("/v1/jobs/{jobId}", tags=["Jobs"])
+    async def get_job(jobId: str = Path(..., description="ID of the job")):
+        """One-shot job status snapshot, fallback for when the SSE stream drops."""
+        job = jobs.get(jobId)
+        if job is None:
+            raise HTTPException(status_code=404, detail=f"Unknown job {jobId}")
+        return _job_payload(job)
+
+    @router.get("/v1/jobs/{jobId}/events", tags=["Jobs"])
+    async def stream_job_events(jobId: str = Path(..., description="ID of the job")):
+        """Push job status updates to the client over SSE until the job ends."""
+
+        async def event_stream():
+            last: Optional[str] = None
+            idle = 0.0
+            while True:
+                job = jobs.get(jobId)
+                status = job.status.value if job else "unknown"
+                if status != last:
+                    last = status
+                    idle = 0.0
+                    payload = (
+                        _job_payload(job) if job else {"jobId": jobId, "status": status}
+                    )
+                    yield f"data: {json.dumps(payload)}\n\n"
+                    if job is None or job.status.is_terminal:
+                        return
+                else:
+                    idle += POLL_INTERVAL
+                    if idle >= HEARTBEAT_SECONDS:
+                        idle = 0.0
+                        yield ": keepalive\n\n"
+                await asyncio.sleep(POLL_INTERVAL)
+
+        return StreamingResponse(
+            event_stream(),
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        )
 
     return router
 

--- a/src/mmore/run_retriever.py
+++ b/src/mmore/run_retriever.py
@@ -140,14 +140,56 @@ def make_router(config_file: str) -> APIRouter:
     retriever_obj = Retriever.from_config(config)
     logger.info("Retriever loaded!")
 
-    @router.get("/list_files", tags=["Files"])
+    @router.get(
+        "/list_files",
+        tags=["Files"],
+        summary="List files in a collection",
+        responses={
+            200: {
+                "description": "Files currently stored in the collection",
+                "content": {
+                    "application/json": {
+                        "example": [
+                            {"id": "doc1", "filename": "report.pdf"},
+                            {"id": "doc2", "filename": "notes.md"},
+                        ]
+                    }
+                },
+            },
+        },
+    )
     def list_files(
         collection_name: str, limit: int = Query(default=16000, ge=1, le=100000)
     ):
         """List all files currently in the database."""
         return retriever_obj.list_files(collection_name=collection_name, limit=limit)
 
-    @router.post("/v1/retrieve", tags=["Retrieval"])
+    @router.post(
+        "/v1/retrieve",
+        tags=["Retrieval"],
+        summary="Retrieve the most similar chunks for a query",
+        responses={
+            200: {
+                "description": "Matching chunks ordered by similarity",
+                "content": {
+                    "application/json": {
+                        "example": [
+                            {
+                                "fileId": "doc1",
+                                "chunkId": "3",
+                                "content": "the matched passage...",
+                                "similarity": 0.87,
+                                "metadata": {
+                                    "first": {"page": 0, "paragraph": 2},
+                                    "last": {"page": 0, "paragraph": 2},
+                                },
+                            }
+                        ]
+                    }
+                },
+            },
+        },
+    )
     def retriever(query: RetrieverQuery):
         """Query the retriever"""
 
@@ -180,7 +222,32 @@ def make_router(config_file: str) -> APIRouter:
 
         return docs_info
 
-    @router.get("/v1/chunks/{fileId}/{chunkId}", tags=["Retrieval"])
+    @router.get(
+        "/v1/chunks/{fileId}/{chunkId}",
+        tags=["Retrieval"],
+        summary="Fetch a chunk's content and metadata by reference",
+        responses={
+            200: {
+                "description": "Chunk content and positional metadata",
+                "content": {
+                    "application/json": {
+                        "example": {
+                            "fileId": "doc1",
+                            "chunkId": "3",
+                            "filename": "report.pdf",
+                            "content": "the chunk text...",
+                            "metadata": {
+                                "first": {"page": 0, "paragraph": 2},
+                                "last": {"page": 1, "paragraph": 0},
+                            },
+                        }
+                    }
+                },
+            },
+            400: {"description": "fileId or chunkId contains a forbidden character ('+' or '\"')"},
+            404: {"description": "Chunk not found for the given file"},
+        },
+    )
     def get_chunk(fileId: str, chunkId: str):
         """Fetch a chunk's content and positional metadata by reference."""
         if not _ID_PATTERN.match(fileId) or not _ID_PATTERN.match(chunkId):

--- a/src/mmore/utils.py
+++ b/src/mmore/utils.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import TYPE_CHECKING, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Dict, List, Optional, Type, TypeVar, Union, cast
 
 import yaml
 from dacite import from_dict
@@ -205,6 +205,7 @@ def process_files_default(
         ".htm",
         ".html",
     ],
+    device: Optional[str] = None,
 ) -> List["MultimodalSample"]:
     from .process.crawler import Crawler, CrawlerConfig
     from .process.dispatcher import Dispatcher, DispatcherConfig
@@ -224,7 +225,10 @@ def process_files_default(
 
     # dispatching the processing
     dispatcher_config = DispatcherConfig(
-        output_path=output_path, use_fast_processors=False, extract_images=True
+        output_path=output_path,
+        use_fast_processors=False,
+        extract_images=True,
+        device=device,
     )
 
     dispatcher = Dispatcher(result=crawl_result, config=dispatcher_config)

--- a/src/mmore/utils.py
+++ b/src/mmore/utils.py
@@ -224,7 +224,8 @@ def process_files_default(
     from .process.dispatcher import Dispatcher, DispatcherConfig
     from .process.post_processor.pipeline import PPPipeline, PPPipelineConfig
 
-    # Per-job output_path keeps concurrent jobs from overwriting each other
+    # Per-job output_path keeps concurrent jobs from overwriting each
+    # other if enforced by the caller
     output_path = output_path or f"./tmp/{collection_name}"
 
     # crawling

--- a/src/mmore/utils.py
+++ b/src/mmore/utils.py
@@ -206,12 +206,14 @@ def process_files_default(
         ".html",
     ],
     device: Optional[str] = None,
+    output_path: Optional[str] = None,
 ) -> List["MultimodalSample"]:
     from .process.crawler import Crawler, CrawlerConfig
     from .process.dispatcher import Dispatcher, DispatcherConfig
     from .process.post_processor.pipeline import PPPipeline, PPPipelineConfig
 
-    output_path = f"./tmp/{collection_name}"
+    # Per-job output_path keeps concurrent jobs from overwriting each other
+    output_path = output_path or f"./tmp/{collection_name}"
 
     # crawling
     crawler_config = CrawlerConfig(

--- a/src/mmore/utils.py
+++ b/src/mmore/utils.py
@@ -60,7 +60,9 @@ indexers = {}
 retrievers = {}
 
 
-def create_new_indexer(collection_name: str, uri: str, db_name: str) -> "Indexer":
+def create_new_indexer(
+    collection_name: str, uri: str, db_name: str, device: Optional[str] = None
+) -> "Indexer":
     """Create a new indexer with default configuration"""
 
     from .index.indexer import DBConfig, Indexer, IndexerConfig
@@ -87,11 +89,14 @@ def create_new_indexer(collection_name: str, uri: str, db_name: str) -> "Indexer
 
         # Create indexer from documents (this will create the collection)
         indexer = Indexer.from_documents(
-            config=config, documents=empty_docs, collection_name=collection_name
+            config=config,
+            documents=empty_docs,
+            collection_name=collection_name,
+            device=device,
         )
 
         # Store in cache
-        indexers[collection_name] = indexer
+        indexers[(collection_name, device)] = indexer
 
         logging.info(
             f"Successfully created new indexer for collection: {collection_name}"
@@ -101,15 +106,21 @@ def create_new_indexer(collection_name: str, uri: str, db_name: str) -> "Indexer
         raise Exception(f"Unable to create a new indexer: {str(e)}")
 
 
-def get_indexer(collection_name: str, uri: str, db_name: str) -> "Indexer":
-    """Get an existing indexer in cached Dict or load from the collection"""
+def get_indexer(
+    collection_name: str, uri: str, db_name: str, device: Optional[str] = None
+) -> "Indexer":
+    """Get an existing indexer in cached Dict or load from the collection.
+
+    Cached per (collection, device) so each GPU gets its own embedding replica.
+    """
 
     from .index.indexer import Indexer, get_model_from_index
     from .rag.model.dense.base import DenseModelConfig
     from .rag.model.sparse.base import SparseModelConfig
 
-    if collection_name in indexers:
-        return indexers[collection_name]
+    key = (collection_name, device)
+    if key in indexers:
+        return indexers[key]
 
     try:
         from pymilvus import MilvusClient
@@ -119,7 +130,7 @@ def get_indexer(collection_name: str, uri: str, db_name: str) -> "Indexer":
         collections = cast(List[str], client.list_collections())
 
         if collection_name not in collections:
-            return create_new_indexer(collection_name, uri, db_name)
+            return create_new_indexer(collection_name, uri, db_name, device=device)
 
         # Get model configs from the collection
         dense_config = cast(
@@ -136,9 +147,10 @@ def get_indexer(collection_name: str, uri: str, db_name: str) -> "Indexer":
             dense_model_config=dense_config,
             sparse_model_config=sparse_config,
             client=client,
+            device=device,
         )
 
-        indexers[collection_name] = indexer
+        indexers[key] = indexer
 
         return indexer
     except Exception as e:

--- a/tests/test_job_queue.py
+++ b/tests/test_job_queue.py
@@ -1,0 +1,86 @@
+import threading
+import time
+
+import pytest
+
+from mmore.job_queue import DuplicateJobError, JobQueue, QueueFullError
+
+
+def _wait_for(manager, job_id, status, timeout=5.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        job = manager.get(job_id)
+        if job and job.status == status:
+            return job
+        time.sleep(0.01)
+    raise AssertionError(f"job {job_id} did not reach {status}")
+
+
+def test_submit_runs_to_done():
+    manager = JobQueue(devices=["cpu"])
+    job_id = manager.submit("f1", "a.pdf", lambda device: {"device": device, "n": 1})
+    job = _wait_for(manager, job_id, "done")
+    assert job.result == {"device": "cpu", "n": 1}
+    manager.shutdown()
+
+
+def test_failure_marks_failed():
+    manager = JobQueue(devices=["cpu"])
+
+    def boom(device):
+        raise ValueError("error")
+
+    job_id = manager.submit("f1", "a.pdf", boom)
+    job = _wait_for(manager, job_id, "failed")
+    assert job.error == "error"
+    manager.shutdown()
+
+
+def test_duplicate_file_id_while_in_flight():
+    manager = JobQueue(devices=["cpu"])
+    release = threading.Event()
+
+    job_id = manager.submit("same", "a.pdf", lambda device: release.wait())
+    _wait_for(manager, job_id, "processing")
+    with pytest.raises(DuplicateJobError):
+        manager.submit("same", "b.pdf", lambda device: {})
+
+    release.set()
+    _wait_for(manager, job_id, "done")
+    manager.shutdown()
+
+
+def test_queue_full():
+    manager = JobQueue(devices=["cpu"], max_queue_size=1)
+    release = threading.Event()
+
+    job_id = manager.submit("f1", "a.pdf", lambda device: release.wait())
+    _wait_for(manager, job_id, "processing")
+    with pytest.raises(QueueFullError):
+        manager.submit("f2", "b.pdf", lambda device: {})
+
+    release.set()
+    manager.shutdown()
+
+
+def test_single_device_serializes():
+    manager = JobQueue(devices=["cpu"])
+    running = []
+    max_seen = []
+    lock = threading.Lock()
+
+    def work(device):
+        with lock:
+            running.append(1)
+            max_seen.append(len(running))
+        time.sleep(0.05)
+        with lock:
+            running.pop()
+        return {}
+
+    ids = [manager.submit(f"f{i}", "a.pdf", work) for i in range(4)]
+    for job_id in ids:
+        _wait_for(manager, job_id, "done")
+
+    assert max(max_seen) == 1
+    manager.shutdown()

--- a/tests/test_job_queue.py
+++ b/tests/test_job_queue.py
@@ -40,7 +40,11 @@ def test_duplicate_file_id_while_in_flight():
     manager = JobQueue(devices=["cpu"])
     release = threading.Event()
 
-    job_id = manager.submit("same", "a.pdf", lambda device: release.wait())
+    def block(device):
+        release.wait()
+        return {}
+
+    job_id = manager.submit("same", "a.pdf", block)
     _wait_for(manager, job_id, "processing")
     with pytest.raises(DuplicateJobError):
         manager.submit("same", "b.pdf", lambda device: {})
@@ -54,7 +58,11 @@ def test_queue_full():
     manager = JobQueue(devices=["cpu"], max_queue_size=1)
     release = threading.Event()
 
-    job_id = manager.submit("f1", "a.pdf", lambda device: release.wait())
+    def block(device):
+        release.wait()
+        return {}
+
+    job_id = manager.submit("f1", "a.pdf", block)
     _wait_for(manager, job_id, "processing")
     with pytest.raises(QueueFullError):
         manager.submit("f2", "b.pdf", lambda device: {})

--- a/tests/test_live_retriever_api.py
+++ b/tests/test_live_retriever_api.py
@@ -414,7 +414,7 @@ def test_upload_file_success(indexer_client):
     fake_path = str(Path(upload_dir) / "new-doc.txt")
 
     with patch(
-        "mmore.run_index_api.process_files_default",
+        "mmore.run_index_api._process_files",
         return_value=[_fake_doc(fake_path)],
     ):
         response = tc.post(
@@ -474,7 +474,7 @@ def test_uploaded_file_has_filename_in_list_files(tmp_path):
         uploaded_path = str(upload_dir / "listed-doc.txt")
         stack.enter_context(
             patch(
-                "mmore.run_index_api.process_files_default",
+                "mmore.run_index_api._process_files",
                 return_value=[_fake_doc(uploaded_path)],
             )
         )
@@ -510,7 +510,7 @@ def test_upload_duplicate_file_returns_400(indexer_client):
     tc, upload_dir, _ = indexer_client
     duplicate_id = "duplicate-doc"
     Path(upload_dir, duplicate_id).write_bytes(b"Existing content.")
-    with patch("mmore.run_index_api.process_files_default", return_value=[]):
+    with patch("mmore.run_index_api._process_files", return_value=[]):
         response = tc.post(
             "/v1/files",
             data={"fileId": duplicate_id},
@@ -525,9 +525,7 @@ def test_upload_failed_processing_does_not_consume_id(indexer_client):
     file_id = "id"
 
     # Processing now fails in the background, the upload still returns 202
-    with patch(
-        "mmore.run_index_api.process_files_default", side_effect=KeyError("xyz")
-    ):
+    with patch("mmore.run_index_api._process_files", side_effect=KeyError("xyz")):
         response = tc.post(
             "/v1/files",
             data={"fileId": file_id},
@@ -541,7 +539,7 @@ def test_upload_failed_processing_does_not_consume_id(indexer_client):
     # A failed job releases the id, so it can be reused
     fake_path = str(Path(upload_dir) / "good.txt")
     with patch(
-        "mmore.run_index_api.process_files_default",
+        "mmore.run_index_api._process_files",
         return_value=[_fake_doc(fake_path, file_id)],
     ):
         response = tc.post(
@@ -562,14 +560,14 @@ def test_upload_failed_processing_does_not_consume_id(indexer_client):
 def test_upload_bulk_files_success(indexer_client):
     tc, *_ = indexer_client
 
-    def fake_process(temp_dir, collection_name, extensions, **kwargs):
+    def fake_process(pool, input_dir, collection_name, extensions, device, output_path):
         # Each job processes a single file
-        path = next(p for p in Path(temp_dir).iterdir() if p.is_file())
+        path = next(p for p in Path(input_dir).iterdir() if p.is_file())
         count = 2 if path.name.startswith("bulk-1") else 1
         return [_fake_doc(str(path)) for _ in range(count)]
 
     with patch(
-        "mmore.run_index_api.process_files_default",
+        "mmore.run_index_api._process_files",
         side_effect=fake_process,
     ):
         response = tc.post(
@@ -594,12 +592,12 @@ def test_upload_bulk_files_success(indexer_client):
 def test_upload_bulk_files_allows_duplicate_uploaded_filenames(indexer_client):
     tc, upload_dir, _ = indexer_client
 
-    def fake_process(temp_dir, collection_name, extensions, **kwargs):
-        path = next(p for p in Path(temp_dir).iterdir() if p.is_file())
+    def fake_process(pool, input_dir, collection_name, extensions, device, output_path):
+        path = next(p for p in Path(input_dir).iterdir() if p.is_file())
         return [_fake_doc(str(path))]
 
     with patch(
-        "mmore.run_index_api.process_files_default",
+        "mmore.run_index_api._process_files",
         side_effect=fake_process,
     ):
         response = tc.post(
@@ -622,7 +620,7 @@ def test_upload_bulk_files_allows_duplicate_uploaded_filenames(indexer_client):
 
 def test_upload_bulk_mismatched_ids_returns_400(indexer_client):
     tc, *_ = indexer_client
-    with patch("mmore.run_index_api.process_files_default", return_value=[]):
+    with patch("mmore.run_index_api._process_files", return_value=[]):
         response = tc.post(
             "/v1/files/bulk",
             data={"listIds": "only-one-id"},
@@ -639,9 +637,7 @@ def test_upload_bulk_failed_processing_does_not_consume_ids(indexer_client):
     tc, upload_dir, _ = indexer_client
     ids = ["id-1", "id-2"]
 
-    with patch(
-        "mmore.run_index_api.process_files_default", side_effect=KeyError("xyz")
-    ):
+    with patch("mmore.run_index_api._process_files", side_effect=KeyError("xyz")):
         response = tc.post(
             "/v1/files/bulk",
             data={"listIds": ",".join(ids)},
@@ -656,12 +652,12 @@ def test_upload_bulk_failed_processing_does_not_consume_ids(indexer_client):
     for file_id in ids:
         assert not Path(upload_dir, file_id).exists()
 
-    def fake_process(temp_dir, collection_name, extensions, **kwargs):
-        path = next(p for p in Path(temp_dir).iterdir() if p.is_file())
+    def fake_process(pool, input_dir, collection_name, extensions, device, output_path):
+        path = next(p for p in Path(input_dir).iterdir() if p.is_file())
         return [_fake_doc(str(path))]
 
     with patch(
-        "mmore.run_index_api.process_files_default",
+        "mmore.run_index_api._process_files",
         side_effect=fake_process,
     ):
         response = tc.post(
@@ -691,7 +687,7 @@ def test_update_existing_file_success(indexer_client):
 
     fake_path = str(Path(upload_dir) / "update-doc.txt")
     with patch(
-        "mmore.run_index_api.process_files_default",
+        "mmore.run_index_api._process_files",
         return_value=[_fake_doc(fake_path, update_id)],
     ):
         response = tc.put(
@@ -707,7 +703,7 @@ def test_update_existing_file_success(indexer_client):
 
 def test_update_nonexistent_file_returns_404(indexer_client):
     tc, *_ = indexer_client
-    with patch("mmore.run_index_api.process_files_default", return_value=[]):
+    with patch("mmore.run_index_api._process_files", return_value=[]):
         response = tc.put(
             "/v1/files/does-not-exist",
             files={"file": ("x.txt", b"content", "text/plain")},
@@ -766,7 +762,7 @@ def test_job_events_stream_reaches_done(indexer_client):
     tc, upload_dir, _ = indexer_client
     fake_path = str(Path(upload_dir) / "sse-doc.txt")
     with patch(
-        "mmore.run_index_api.process_files_default",
+        "mmore.run_index_api._process_files",
         return_value=[_fake_doc(fake_path)],
     ):
         response = tc.post(

--- a/tests/test_live_retriever_api.py
+++ b/tests/test_live_retriever_api.py
@@ -5,6 +5,7 @@ Integration tests for the live retrieval API using a Milvus DB:
 """
 
 import json
+import time
 from contextlib import ExitStack
 from pathlib import Path
 from unittest.mock import patch
@@ -312,6 +313,17 @@ def _fake_doc(file_path: str, document_id: str = "doc") -> MultimodalSample:
     )
 
 
+def _wait_job(tc, job_id: str, timeout: float = 15.0) -> dict:
+    """Poll the job status endpoint until the background job is terminal."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        resp = tc.get(f"/v1/jobs/{job_id}")
+        if resp.status_code == 200 and resp.json()["status"] in ("done", "failed"):
+            return resp.json()
+        time.sleep(0.02)
+    raise AssertionError(f"job {job_id} did not finish in time")
+
+
 def test_apply_uploaded_file_metadata_preserves_chunk_suffix():
     doc = _fake_doc("/tmp/original-name.txt", document_id="default-doc")
     doc.id = "processor-generated-id+7"
@@ -410,10 +422,11 @@ def test_upload_file_success(indexer_client):
             data={"fileId": "new-doc"},
             files={"file": ("new-doc.txt", b"Hello world", "text/plain")},
         )
+        assert response.status_code == 202
+        job_id = response.json()["jobId"]
+        job = _wait_job(tc, job_id)
 
-    assert response.status_code == 201
-    data = response.json()
-    assert data["fileId"] == "new-doc"
+    assert job["status"] == "done"
     assert Path(upload_dir, "new-doc").exists()
 
 
@@ -470,7 +483,8 @@ def test_uploaded_file_has_filename_in_list_files(tmp_path):
             data={"fileId": "listed-doc"},
             files={"file": ("listed-doc.txt", b"Hello list files", "text/plain")},
         )
-        assert response.status_code == 201
+        assert response.status_code == 202
+        assert _wait_job(index_client, response.json()["jobId"])["status"] == "done"
 
         stack.enter_context(
             patch(
@@ -502,7 +516,7 @@ def test_upload_duplicate_file_returns_400(indexer_client):
             data={"fileId": duplicate_id},
             files={"file": ("duplicate-doc.txt", b"Hello again", "text/plain")},
         )
-    assert response.status_code == 400
+    assert response.status_code == 409
     assert "already exists" in response.json()["detail"]
 
 
@@ -510,14 +524,21 @@ def test_upload_failed_processing_does_not_consume_id(indexer_client):
     tc, upload_dir, _ = indexer_client
     file_id = "id"
 
-    response = tc.post(
-        "/v1/files",
-        data={"fileId": file_id},
-        files={"file": ("file.xyz", b"bad", "application/octet-stream")},
-    )
-    assert response.status_code == 422
+    # Processing now fails in the background, the upload still returns 202
+    with patch(
+        "mmore.run_index_api.process_files_default", side_effect=KeyError("xyz")
+    ):
+        response = tc.post(
+            "/v1/files",
+            data={"fileId": file_id},
+            files={"file": ("file.xyz", b"bad", "application/octet-stream")},
+        )
+        assert response.status_code == 202
+        job = _wait_job(tc, response.json()["jobId"])
+    assert job["status"] == "failed"
     assert not Path(upload_dir, file_id).exists()
 
+    # A failed job releases the id, so it can be reused
     fake_path = str(Path(upload_dir) / "good.txt")
     with patch(
         "mmore.run_index_api.process_files_default",
@@ -528,7 +549,8 @@ def test_upload_failed_processing_does_not_consume_id(indexer_client):
             data={"fileId": file_id},
             files={"file": ("file.txt", b"good", "text/plain")},
         )
-    assert response.status_code == 201
+        assert response.status_code == 202
+        assert _wait_job(tc, response.json()["jobId"])["status"] == "done"
     assert Path(upload_dir, file_id).read_bytes() == b"good"
 
 
@@ -540,19 +562,11 @@ def test_upload_failed_processing_does_not_consume_id(indexer_client):
 def test_upload_bulk_files_success(indexer_client):
     tc, *_ = indexer_client
 
-    def fake_process(temp_dir, collection_name, extensions):
-        first_path, second_path = sorted(Path(temp_dir).iterdir())
-        return [
-            _fake_doc(str(first_path), "bulk-1"),
-            MultimodalSample(
-                id="bulk-1+1",
-                document_id="bulk-1",
-                text="Second chunk from the first bulk document.",
-                modalities=[],
-                metadata=DocumentMetadata(file_path=str(first_path)),
-            ),
-            _fake_doc(str(second_path), "bulk-2"),
-        ]
+    def fake_process(temp_dir, collection_name, extensions, **kwargs):
+        # Each job processes a single file
+        path = next(p for p in Path(temp_dir).iterdir() if p.is_file())
+        count = 2 if path.name.startswith("bulk-1") else 1
+        return [_fake_doc(str(path)) for _ in range(count)]
 
     with patch(
         "mmore.run_index_api.process_files_default",
@@ -566,25 +580,23 @@ def test_upload_bulk_files_success(indexer_client):
                 ("files", ("bulk-2.txt", b"Bulk content 2", "text/plain")),
             ],
         )
+        assert response.status_code == 202
+        jobs_by_id = {j["fileId"]: j for j in response.json()["jobs"]}
+        assert set(jobs_by_id) == {"bulk-1", "bulk-2"}
+        results = {fid: _wait_job(tc, job["jobId"]) for fid, job in jobs_by_id.items()}
 
-    assert response.status_code == 201
-    data = response.json()
-    documents_by_id = {doc["fileId"]: doc for doc in data["documents"]}
-    assert set(documents_by_id) == {"bulk-1", "bulk-2"}
-    assert documents_by_id["bulk-1"]["filename"] == "bulk-1.txt"
-    assert documents_by_id["bulk-1"]["chunks"] == 2
-    assert documents_by_id["bulk-2"]["filename"] == "bulk-2.txt"
-    assert documents_by_id["bulk-2"]["chunks"] == 1
+    assert results["bulk-1"]["status"] == "done"
+    assert results["bulk-1"]["result"]["chunks"] == 2
+    assert results["bulk-2"]["status"] == "done"
+    assert results["bulk-2"]["result"]["chunks"] == 1
 
 
 def test_upload_bulk_files_allows_duplicate_uploaded_filenames(indexer_client):
     tc, upload_dir, _ = indexer_client
 
-    def fake_process(temp_dir, collection_name, extensions):
-        return [
-            _fake_doc(str(path), f"processed-{path.stem}")
-            for path in sorted(Path(temp_dir).iterdir())
-        ]
+    def fake_process(temp_dir, collection_name, extensions, **kwargs):
+        path = next(p for p in Path(temp_dir).iterdir() if p.is_file())
+        return [_fake_doc(str(path))]
 
     with patch(
         "mmore.run_index_api.process_files_default",
@@ -598,15 +610,12 @@ def test_upload_bulk_files_allows_duplicate_uploaded_filenames(indexer_client):
                 ("files", ("same.txt", b"Second content", "text/plain")),
             ],
         )
+        assert response.status_code == 202
+        jobs_by_id = {j["fileId"]: j for j in response.json()["jobs"]}
+        assert set(jobs_by_id) == {"same-name-1", "same-name-2"}
+        for job in jobs_by_id.values():
+            assert _wait_job(tc, job["jobId"])["status"] == "done"
 
-    assert response.status_code == 201
-    data = response.json()
-    documents_by_id = {doc["fileId"]: doc for doc in data["documents"]}
-    assert set(documents_by_id) == {"same-name-1", "same-name-2"}
-    assert documents_by_id["same-name-1"]["filename"] == "same.txt"
-    assert documents_by_id["same-name-1"]["chunks"] == 1
-    assert documents_by_id["same-name-2"]["filename"] == "same.txt"
-    assert documents_by_id["same-name-2"]["chunks"] == 1
     assert Path(upload_dir, "same-name-1").exists()
     assert Path(upload_dir, "same-name-2").exists()
 
@@ -630,22 +639,30 @@ def test_upload_bulk_failed_processing_does_not_consume_ids(indexer_client):
     tc, upload_dir, _ = indexer_client
     ids = ["id-1", "id-2"]
 
-    response = tc.post(
-        "/v1/files/bulk",
-        data={"listIds": ",".join(ids)},
-        files=[
-            ("files", ("file.xyz", b"bad A", "application/octet-stream")),
-            ("files", ("file.xyz", b"bad B", "application/octet-stream")),
-        ],
-    )
-    assert response.status_code == 422
+    with patch(
+        "mmore.run_index_api.process_files_default", side_effect=KeyError("xyz")
+    ):
+        response = tc.post(
+            "/v1/files/bulk",
+            data={"listIds": ",".join(ids)},
+            files=[
+                ("files", ("file.xyz", b"bad A", "application/octet-stream")),
+                ("files", ("file.xyz", b"bad B", "application/octet-stream")),
+            ],
+        )
+        assert response.status_code == 202
+        for job in response.json()["jobs"]:
+            assert _wait_job(tc, job["jobId"])["status"] == "failed"
     for file_id in ids:
         assert not Path(upload_dir, file_id).exists()
 
-    fake_paths = [str(Path(upload_dir) / f"{i}_file.txt") for i in ids]
+    def fake_process(temp_dir, collection_name, extensions, **kwargs):
+        path = next(p for p in Path(temp_dir).iterdir() if p.is_file())
+        return [_fake_doc(str(path))]
+
     with patch(
         "mmore.run_index_api.process_files_default",
-        return_value=[_fake_doc(p, i) for p, i in zip(fake_paths, ids)],
+        side_effect=fake_process,
     ):
         response = tc.post(
             "/v1/files/bulk",
@@ -655,7 +672,9 @@ def test_upload_bulk_failed_processing_does_not_consume_ids(indexer_client):
                 ("files", ("file.txt", b"good B", "text/plain")),
             ],
         )
-    assert response.status_code == 201
+        assert response.status_code == 202
+        for job in response.json()["jobs"]:
+            assert _wait_job(tc, job["jobId"])["status"] == "done"
     assert Path(upload_dir, ids[0]).read_bytes() == b"good A"
     assert Path(upload_dir, ids[1]).read_bytes() == b"good B"
 
@@ -679,9 +698,11 @@ def test_update_existing_file_success(indexer_client):
             f"/v1/files/{update_id}",
             files={"file": ("update-doc.txt", b"Updated content.", "text/plain")},
         )
+        assert response.status_code == 202
+        assert response.json()["fileId"] == update_id
+        assert _wait_job(tc, response.json()["jobId"])["status"] == "done"
 
-    assert response.status_code == 200
-    assert response.json()["fileId"] == update_id
+    assert Path(upload_dir, update_id).read_bytes() == b"Updated content."
 
 
 def test_update_nonexistent_file_returns_404(indexer_client):
@@ -728,3 +749,35 @@ def test_download_nonexistent_file_returns_404(indexer_client):
     tc, *_ = indexer_client
     response = tc.get("/v1/files/does-not-exist")
     assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/jobs/{jobId} and /v1/jobs/{jobId}/events
+# ---------------------------------------------------------------------------
+
+
+def test_get_unknown_job_returns_404(indexer_client):
+    tc, *_ = indexer_client
+    response = tc.get("/v1/jobs/does-not-exist")
+    assert response.status_code == 404
+
+
+def test_job_events_stream_reaches_done(indexer_client):
+    tc, upload_dir, _ = indexer_client
+    fake_path = str(Path(upload_dir) / "sse-doc.txt")
+    with patch(
+        "mmore.run_index_api.process_files_default",
+        return_value=[_fake_doc(fake_path)],
+    ):
+        response = tc.post(
+            "/v1/files",
+            data={"fileId": "sse-doc"},
+            files={"file": ("sse-doc.txt", b"stream me", "text/plain")},
+        )
+        job_id = response.json()["jobId"]
+        with tc.stream("GET", f"/v1/jobs/{job_id}/events") as stream:
+            body = "".join(stream.iter_text())
+
+    # The stream stays open until the job is terminal, so "done" is always sent
+    assert "data:" in body
+    assert "done" in body

--- a/tests/test_processors_local.py
+++ b/tests/test_processors_local.py
@@ -46,11 +46,11 @@ def test_docx_no_image_extraction():
 
     # Disable image extraction by setting "extract_images" to False.
     config = ProcessorConfig(
+        extract_images=False,
         custom_config={
             "output_path": "tmp",
-            "extract_images": False,
             "attachment_tag": "<attachment>",
-        }
+        },
     )
     processor = DOCXProcessor(config=config)
 
@@ -131,9 +131,7 @@ def test_md_image_extraction():
     assert os.path.exists(sample_file), f"Sample file not found: {sample_file}"
     custom_attachment_tag = "<attachment>"
     # Set extract images to True explicitly
-    config = ProcessorConfig(
-        custom_config={"output_path": "tmp", "extract_images": True}
-    )
+    config = ProcessorConfig(extract_images=True, custom_config={"output_path": "tmp"})
     processor = MarkdownProcessor(config=config)
     # Process file
     result = processor.process(sample_file)
@@ -256,9 +254,7 @@ def test_spreadsheet_multi_sheet_content():
     sample_file = os.path.join(SAMPLES_DIR, "spreadsheet", "survey.xlsx")
     assert os.path.exists(sample_file), f"Sample file not found: {sample_file}"
 
-    config = ProcessorConfig(
-        custom_config={"extract_images": True, "output_path": "tmp"}
-    )
+    config = ProcessorConfig(extract_images=True, custom_config={"output_path": "tmp"})
     processor = SpreadsheetProcessor(config=config)
 
     result = processor.process(sample_file)
@@ -300,11 +296,11 @@ def test_pdf_process_standard():
     # Assert that the file exists beforre attempting to process it
     assert os.path.exists(sample_file), f"Sample file not found {sample_file}"
     config = ProcessorConfig(
+        extract_images=True,
         custom_config={
-            "extract_images": True,
             "attachment_tag": "<attachment>",
             "output_path": "tmp",
-        }
+        },
     )
     processor = PDFProcessor(config=config)
     processor.converter = (  # pyright: ignore[reportAttributeAccessIssue]
@@ -325,11 +321,11 @@ def test_pdf_process_fast():
     # Assert that the file exists beforre attempting to process it
     assert os.path.exists(sample_file), f"Sample file not found {sample_file}"
     config = ProcessorConfig(
+        extract_images=True,
         custom_config={
-            "extract_images": True,
             "attachment_tag": "<attachment>",
             "output_path": "tmp",
-        }
+        },
     )
     processor = PDFProcessor(config=config)
     processor.converter = (  # pyright: ignore[reportAttributeAccessIssue]
@@ -361,11 +357,11 @@ def test_text_process_standard():
 def test_url_process_standard():
     sample_url = "http://example.com"
     config = ProcessorConfig(
+        extract_images=False,
         custom_config={
-            "extract_images": False,
             "output_path": "tmp",
             "attachment_tag": "<attachment>",
-        }
+        },
     )
     processor = URLProcessor(config=config)
     result = processor.process(sample_url)
@@ -382,11 +378,11 @@ def test_url_process_standard():
 def test_url_process_invalid():
     sample_url = "http://thisurldoesnotexist.tld"
     config = ProcessorConfig(
+        extract_images=False,
         custom_config={
-            "extract_images": False,
             "output_path": "tmp",
             "attachment_tag": "<attachment>",
-        }
+        },
     )
     processor = URLProcessor(config=config)
     result = processor.process(sample_url)


### PR DESCRIPTION
## Summary
Related issues: #324, #326 

In production the live-retrieval API processed uploads synchronously, so a single user uploading a document blocked every other request until it finished. This PR makes the processing and indexing pipelines asynchronous and parallel across GPUs: uploads now return immediately with a job id, and documents are processed and indexed concurrently thanks to a queue. To handle concurrent updates on the Milvus database, its version was changed from Lite to Standalone.

## Changes
- Fixed a bug where files uploaded through the API were processed twice
- Added an`JobQueue` (`src/mmore/job_queue.py`) that schedule jobs on GPUs with size limit and eviction of finished jobs
- Made file upload asynchronous: `POST /v1/files`, `POST /v1/files/bulk` and `PUT /v1/files/{fileId}` endpoints now return `202 Accepted` with a `jobId` instead of blocking. Duplicate ids are rejected (`409`), a saturated queue returns `503`
- Added job status endpoints: `GET /v1/jobs/{jobId}` for a one-time status and `GET /v1/jobs/{jobId}/events` for a server-pushed status stream over Server-Sent Events (SSE)
- Parallelized processing and indexing across GPUs: per-device model copies in the PDF and media processors (`artifacts_by_device` / `pipelines_by_device`), and per-device embedding models (dense + splade)
- Updated configs (`jobs_per_gpu`, `max_queue_size`, Milvus Standalone uri) and the API documentation
- Added new tests for the job queue and the changed endpoints

## Improvements
- Non-blocking API: one user's upload no longer stalls everyone else, the request returns instantly with a job id
- Multi-GPU: documents are processed and indexed in parallel across all available GPUs instead of one at a time
- Observability: logs report the queue state and per-job progress, and clients can either poll `GET /v1/jobs/{jobId}` or subscribe to the SSE stream
- Configurable concurrency: `jobs_per_gpu` (defaults to 1) lets you overlap CPU and GPU work for higher utilization but each replica loads its own models (needs some tuning wrt VRAM)

## Milvus Standalone server
- Concurrent writes require a real Milvus Standalone server (the production config now points at `http://localhost:19530`), not Milvus Lite which is single-process

To create it:

```bash
wget https://github.com/milvus-io/milvus/releases/download/v2.5.4/milvus-standalone-docker-compose.yml -O docker-compose.yml
docker compose up -d
```

Alternatively:
```bash
curl -sfL https://raw.githubusercontent.com/milvus-io/milvus/master/scripts/standalone_embed.sh -o standalone_embed.sh
bash standalone_embed.sh start
```

The port exposed by default is `19530`

---

## DEMO

The experiment runs on a server with 4 NVIDIA Tesla V100 32 GB GPUs, of which only CUDA devices 1, 2 and 3 are available to the indexer (device 0 is reserved for other containers). The workload is a single HTTP request to the bulk-upload endpoint carrying 4 large PDFs (18 MB, 450 pages each), one per available GPU

https://github.com/user-attachments/assets/4f493ca9-1048-49c0-a94f-10f0b2aa29c0

Notes:
- To restrict the API to devices 1-3, it was started with env variable `CUDA_VISIBLE_DEVICES=1,2,3`. Inside the process these are then re-indexed as `cuda:0,1,2` and `_detect_devices()` sees 3 GPUs
- As GPUs are working in parallel, the API logs get quite often overwritten, explaining the behavior in the video
- With `jobs_per_gpu=1` and 3 visible GPUs, the 4th PDF queues until one of the first three finishes, then runs