### PR TITLE
 [Multi-Agent Privacy] Add Adversarial agent with initial pipeline

### DIFF
--- a/src/mmore/privacy/agents/__init__.py
+++ b/src/mmore/privacy/agents/__init__.py
@@ -1,3 +1,4 @@
+from .adversary import AdversarialAgent
 from .base import AgentState, BaseAgent, clear_llm_cache
 from .checkpointer import build_checkpointer, open_checkpointer
 from .config import AgentConfig
@@ -13,6 +14,7 @@ __all__ = [
     "AgentConfig",
     "AgentState",
     "BaseAgent",
+    "AdversarialAgent",
     "ToolNotRegisteredError",
     "build_checkpointer",
     "open_checkpointer",

--- a/src/mmore/privacy/agents/__init__.py
+++ b/src/mmore/privacy/agents/__init__.py
@@ -2,6 +2,7 @@ from .adversary import AdversarialAgent
 from .base import AgentState, BaseAgent, clear_llm_cache
 from .checkpointer import build_checkpointer, open_checkpointer
 from .config import AgentConfig
+from .gate import HITLGateAgent, build_gate_summary
 from .registry import (
     ToolNotRegisteredError,
     list_tools,
@@ -15,8 +16,10 @@ __all__ = [
     "AgentState",
     "BaseAgent",
     "AdversarialAgent",
+    "HITLGateAgent",
     "ToolNotRegisteredError",
     "build_checkpointer",
+    "build_gate_summary",
     "open_checkpointer",
     "clear_llm_cache",
     "list_tools",

--- a/src/mmore/privacy/agents/adversary.py
+++ b/src/mmore/privacy/agents/adversary.py
@@ -1,0 +1,222 @@
+"""Pre-cloud Leakage Adversary.
+
+Pipeline:  analyzer -> detector -> sanitizer -> [leakage_adversary] -> gate
+Reads:     policy, sanitized_chunks
+Writes:    verdict, safe
+
+The trust-boundary probe: it attacks the sanitized context for residual PII and
+quasi-identifiers before anything leaves for the cloud answer model. It runs one
+adversarial probe per configured attack vector, keeps the strongest signal, and
+treats a probe whose confidence reaches the threashold as a leak.
+"""
+
+import logging
+from typing import List, Optional, Union
+
+import dspy
+from langgraph.checkpoint.base import BaseCheckpointSaver
+from typing_extensions import Self
+
+from ...rag.llm import LLMConfig
+from ...utils import load_config
+from ..config import AttackVector, PrivacyConfig
+from ..dspy_llm import build_dspy_lm
+from ..leakage import LeakageVerdict
+from ..policy import PrivacyPolicy
+from .base import BaseAgent
+from .state import PrivacyState
+
+logger = logging.getLogger(__name__)
+
+
+# ========================================================================
+# Attack taxonomy (Guan et al. 2025 Section 3.2.3)
+# ========================================================================
+
+_VECTOR_GUIDANCE = {
+    AttackVector.RESIDUAL_SPAN: (
+        "Residual-span extraction: scan for any protected identifier the "
+        "sanitizer left verbatim or only partially masked (a name, number, "
+        "email, date, or location still readable in the clear)."
+    ),
+    AttackVector.QUASI_IDENTIFIER: (
+        "Quasi-identifier synthesis: combine individually non-identifying "
+        "attributes (a rare attribute + a location + a date) that together "
+        "single out one person even though no direct identifier remains."
+    ),
+    AttackVector.STRUCTURAL_REID: (
+        "Structural re-identification: exploit the uniqueness of a record's "
+        "structure (an unusual combination of fields or an outlier value) to "
+        "pick out a specific individual from the population."
+    ),
+    AttackVector.CONTEXT_RECONSTRUCTION: (
+        "Context reconstruction: infer what a redacted or masked span must "
+        "have been from the retained surrounding text (e.g. a placeholder "
+        "that the remaining context uniquely determines)."
+    ),
+    AttackVector.MEMBERSHIP_INFERENCE: (
+        "Membership inference: decide whether a specific, nameable individual "
+        "is present in this context from the retained details, even without "
+        "recovering a direct identifier."
+    ),
+}
+
+
+# ========================================================================
+# DSPy signature
+# ========================================================================
+
+_CONTEXT_DESC = "the sanitized retrieved context to attack"
+_ENTITIES_DESC = "entity types that must not be recoverable from the context"
+_ATTACK_DESC = "the attack vector to attempt and how it works"
+_LEAKED_DESC = "true if the attack recovers or infers a protected identifier"
+_ENTITY_TYPE_DESC = "the entity type that leaks, or NONE if the attack fails"
+_EVIDENCE_DESC = (
+    "brief justification for the verdict, citing the residual signal without "
+    "restating any raw personal value"
+)
+_CONFIDENCE_DESC = "0.0-1.0 likelihood that the attack succeeds"
+
+_PROBE_INSTRUCTION = (
+    "You are a privacy red-team adversary. Attempt the described attack "
+    "against the sanitized context and report whether a protected identifier "
+    "can be recovered or inferred. Be strict: a residual or reconstructable "
+    "identifier is a leak. Do not echo raw personal values in your evidence."
+)
+
+
+class _LeakageProbeSignature(dspy.Signature):
+    context: str = dspy.InputField(desc=_CONTEXT_DESC)
+    sensitive_entities: List[str] = dspy.InputField(desc=_ENTITIES_DESC)
+    attack: str = dspy.InputField(desc=_ATTACK_DESC)
+    leaked: bool = dspy.OutputField(desc=_LEAKED_DESC)
+    entity_type: str = dspy.OutputField(desc=_ENTITY_TYPE_DESC)
+    evidence: str = dspy.OutputField(desc=_EVIDENCE_DESC)
+    confidence: float = dspy.OutputField(desc=_CONFIDENCE_DESC)
+
+
+def _build_probe_predictor() -> dspy.Predict:
+    return dspy.Predict(_LeakageProbeSignature.with_instructions(_PROBE_INSTRUCTION))
+
+
+def _clamp_confidence(value: object) -> float:
+    """Coerce a model-provided confidence into ``[0.0, 1.0]``, 0.0 on failure."""
+    if isinstance(value, (int, float)):
+        return max(0.0, min(1.0, float(value)))
+    try:
+        return max(0.0, min(1.0, float(str(value))))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+_SAFE_VERDICT = LeakageVerdict(
+    leaked=False, vector="none", entity_type="NONE", evidence="", confidence=0.0
+)
+
+
+# ========================================================================
+# Agent
+# ========================================================================
+
+
+class AdversarialAgent(BaseAgent):
+    """Adversarially probes the sanitized context for residual leakage."""
+
+    state_schema = PrivacyState
+    node_name = "leakage_adversary"
+
+    def __init__(
+        self,
+        config: PrivacyConfig,
+        llm_config: Optional[LLMConfig] = None,
+        checkpointer: Optional[BaseCheckpointSaver] = None,
+    ):
+        self._dspy_lm: Optional[dspy.BaseLM] = None
+        self._adversary_cfg = config.leakage_adversary
+        super().__init__(config, llm_config=llm_config, checkpointer=checkpointer)
+
+    @classmethod
+    def from_config(
+        cls,
+        config: Union[PrivacyConfig, str, dict],
+        checkpointer: Optional[BaseCheckpointSaver] = None,
+    ) -> Self:
+        if not isinstance(config, PrivacyConfig):
+            config = load_config(config, PrivacyConfig)
+        llm_config = config.leakage_adversary.llm
+        return cls(config, llm_config, checkpointer=checkpointer)
+
+    @property
+    def strategies(self) -> List[AttackVector]:
+        return list(self._adversary_cfg.strategies)
+
+    @property
+    def leakage_threshold(self) -> float:
+        return self._adversary_cfg.leakage_threshold
+
+    def _ensure_dspy_lm(self) -> dspy.BaseLM:
+        if self._dspy_lm is None:
+            if self._llm_config is None:
+                raise ValueError("Leakage adversary requires an LLM to probe leakage.")
+            self._dspy_lm = build_dspy_lm(self._llm_config)
+        return self._dspy_lm
+
+    def _probe_vector(
+        self,
+        predictor: dspy.Predict,
+        context: str,
+        entities: List[str],
+        vector: AttackVector,
+    ) -> LeakageVerdict:
+        """Run one attack vector; confidence 0.0 if the probe errors out."""
+        try:
+            with dspy.context(lm=self._ensure_dspy_lm()):
+                prediction = predictor(
+                    context=context,
+                    sensitive_entities=entities,
+                    attack=_VECTOR_GUIDANCE[vector],
+                )
+        except Exception as e:
+            logger.warning(
+                "Leakage probe '%s' failed (%s); treating as no leak", vector.value, e
+            )
+            return LeakageVerdict(
+                leaked=False,
+                vector=vector.value,
+                entity_type="NONE",
+                evidence="",
+                confidence=0.0,
+            )
+        confidence = _clamp_confidence(getattr(prediction, "confidence", 0.0))
+        return LeakageVerdict(
+            leaked=confidence >= self.leakage_threshold,
+            vector=vector.value,
+            entity_type=str(getattr(prediction, "entity_type", "NONE")).strip()
+            or "NONE",
+            evidence=str(getattr(prediction, "evidence", "")).strip(),
+            confidence=confidence,
+        )
+
+    def probe(
+        self, policy: PrivacyPolicy, sanitized_chunks: List[str]
+    ) -> LeakageVerdict:
+        """Attack the sanitized context and return the strongest leakage signal."""
+        context = "\n\n".join(c for c in sanitized_chunks if c).strip()
+        if not context or not self.strategies:
+            return _SAFE_VERDICT
+
+        predictor = _build_probe_predictor()
+        entities = list(policy.sensitive_entities)
+        verdicts = [
+            self._probe_vector(predictor, context, entities, vector)
+            for vector in self.strategies
+        ]
+        return max(verdicts, key=lambda v: v.confidence)
+
+    def _node(self, state: PrivacyState) -> PrivacyState:
+        """Graph node: write the leakage verdict and the safety flag to state."""
+        policy = state.get("policy")
+        if policy is None:
+            raise ValueError("AdversarialAgent requires 'policy' in the state.")
+        verdict = self.probe(policy, list(state.get("sanitized_chunks", [])))
+        return PrivacyState(verdict=verdict, safe=not verdict.leaked)

--- a/src/mmore/privacy/agents/adversary.py
+++ b/src/mmore/privacy/agents/adversary.py
@@ -21,7 +21,7 @@ from ...rag.llm import LLMConfig
 from ...utils import load_config
 from ..config import AttackVector, PrivacyConfig
 from ..dspy_llm import build_dspy_lm
-from ..leakage import LeakageVerdict
+from ..leakage import SAFE_VERDICT, LeakageVerdict
 from ..policy import PrivacyPolicy
 from .base import BaseAgent
 from .state import PrivacyState
@@ -109,11 +109,6 @@ def _clamp_confidence(value: object) -> float:
         return 0.0
 
 
-_SAFE_VERDICT = LeakageVerdict(
-    leaked=False, vector="none", entity_type="NONE", evidence="", confidence=0.0
-)
-
-
 # ========================================================================
 # Agent
 # ========================================================================
@@ -182,17 +177,17 @@ class AdversarialAgent(BaseAgent):
             )
             return LeakageVerdict(
                 leaked=False,
-                vector=vector.value,
-                entity_type="NONE",
+                vector=vector,
+                entity_type=None,
                 evidence="",
                 confidence=0.0,
             )
         confidence = _clamp_confidence(getattr(prediction, "confidence", 0.0))
+        entity = str(getattr(prediction, "entity_type", "")).strip()
         return LeakageVerdict(
             leaked=confidence >= self.leakage_threshold,
-            vector=vector.value,
-            entity_type=str(getattr(prediction, "entity_type", "NONE")).strip()
-            or "NONE",
+            vector=vector,
+            entity_type=entity if entity and entity.upper() != "NONE" else None,
             evidence=str(getattr(prediction, "evidence", "")).strip(),
             confidence=confidence,
         )
@@ -203,7 +198,7 @@ class AdversarialAgent(BaseAgent):
         """Attack the sanitized context and return the strongest leakage signal."""
         context = "\n\n".join(c for c in sanitized_chunks if c).strip()
         if not context or not self.strategies:
-            return _SAFE_VERDICT
+            return SAFE_VERDICT
 
         predictor = _build_probe_predictor()
         entities = list(policy.sensitive_entities)

--- a/src/mmore/privacy/agents/adversary.py
+++ b/src/mmore/privacy/agents/adversary.py
@@ -7,10 +7,13 @@ Writes:    verdict, safe
 The trust-boundary probe: it attacks the sanitized context for residual PII and
 quasi-identifiers before anything leaves for the cloud answer model. It runs one
 adversarial probe per configured attack vector, keeps the strongest signal, and
-treats a probe whose confidence reaches the threshold as a leak.
+treats a probe whose confidence reaches the threshold as a leak. On a leak it
+also emits a PII-free remediation report the analyzer applies like human gate
+feedback: which engine, strategy, threshold, or entity labels to change.
 """
 
 import logging
+from dataclasses import replace
 from typing import List, Optional, Union
 
 import dspy
@@ -20,9 +23,11 @@ from typing_extensions import Self
 from ...rag.llm import LLMConfig
 from ...utils import load_config
 from ..config import AttackVector, PrivacyConfig
+from ..detection.constants import DETECTION_GUIDANCE, DETECTION_PARAM_GUIDANCE
 from ..dspy_llm import build_dspy_lm
 from ..leakage import SAFE_VERDICT, LeakageVerdict
 from ..policy import PrivacyPolicy
+from ..sanitization.constants import SANITIZATION_GUIDANCE
 from .base import BaseAgent
 from .state import PrivacyState
 
@@ -97,6 +102,73 @@ class _LeakageProbeSignature(dspy.Signature):
 
 def _build_probe_predictor() -> dspy.Predict:
     return dspy.Predict(_LeakageProbeSignature.with_instructions(_PROBE_INSTRUCTION))
+
+
+# ========================================================================
+# Remediation report (emitted on a leak, applied by the analyzer)
+# ========================================================================
+
+_CURRENT_POLICY_DESC = (
+    "the policy the leaking pass ran under: detection engine, sanitization "
+    "strategy, confidence threshold, and sensitive-entity labels"
+)
+_ENGINE_GUIDANCE_DESC = "per-engine guidance: pros, cons, and when to prefer each"
+_STRATEGY_GUIDANCE_DESC = "per-strategy guidance: what each sanitization strategy does"
+_PARAM_GUIDANCE_DESC = "per-engine guidance for each tunable parameter"
+_FIXED_FIELDS_DESC = (
+    "policy fields pinned by the user config that must not be changed, or 'none'"
+)
+_PREVIOUS_REPORTS_DESC = "your remediation reports from earlier iterations, or 'none'"
+_RECOMMENDATION_DESC = (
+    "concise PII-free remediation report for the next pass: which detection "
+    "engine, sanitization strategy, or threshold level (low/medium/high) to "
+    "use, and any sensitive-entity labels to add"
+)
+
+_REMEDIATION_INSTRUCTION = (
+    "You are a privacy red-team adversary reporting back to the policy analyzer "
+    "after a successful attack on the sanitized context. Using the tool guidance, "
+    "write a short remediation report for the next pass: recommend a detection "
+    "engine, sanitization strategy, threshold level, and/or additional "
+    "sensitive-entity labels that would close the leak. Never recommend changing "
+    "a field listed as fixed by the user. Compare the current policy against "
+    "your previous reports: if an earlier recommendation was not applied, say so "
+    "and restate it. Do not echo raw personal values."
+)
+
+
+class _RemediationSignature(dspy.Signature):
+    context: str = dspy.InputField(desc=_CONTEXT_DESC)
+    attack: str = dspy.InputField(desc="the attack that succeeded and how it works")
+    entity_type: str = dspy.InputField(desc="the entity type that leaked, or NONE")
+    evidence: str = dspy.InputField(desc="the probe's PII-free justification")
+    current_policy: str = dspy.InputField(desc=_CURRENT_POLICY_DESC)
+    engine_guidance: str = dspy.InputField(desc=_ENGINE_GUIDANCE_DESC)
+    strategy_guidance: str = dspy.InputField(desc=_STRATEGY_GUIDANCE_DESC)
+    param_guidance: str = dspy.InputField(desc=_PARAM_GUIDANCE_DESC)
+    fixed_fields: str = dspy.InputField(desc=_FIXED_FIELDS_DESC)
+    previous_reports: str = dspy.InputField(desc=_PREVIOUS_REPORTS_DESC)
+    recommendation: str = dspy.OutputField(desc=_RECOMMENDATION_DESC)
+
+
+def _build_remediation_predictor() -> dspy.Predict:
+    return dspy.Predict(
+        _RemediationSignature.with_instructions(_REMEDIATION_INSTRUCTION)
+    )
+
+
+def _describe_policy(policy: PrivacyPolicy) -> str:
+    threshold = policy.detection_params.get("confidence_threshold", "default")
+    return (
+        f"engine={policy.detection_engine}, "
+        f"strategy={policy.sanitization_strategy}, "
+        f"threshold={threshold}, "
+        f"entities={', '.join(policy.sensitive_entities) or 'none'}"
+    )
+
+
+def _format_guidance(guidance: dict) -> str:
+    return "\n".join(f"- {name}: {desc}" for name, desc in guidance.items())
 
 
 def _clamp_confidence(value: object) -> float:
@@ -208,10 +280,64 @@ class AdversarialAgent(BaseAgent):
         ]
         return max(verdicts, key=lambda v: v.confidence)
 
+    def _fixed_policy_fields(self) -> str:
+        """List the policy fields the user pinned in the config."""
+        fixed = []
+        if self.config.detection.engine:
+            fixed.append(f"detection engine ({self.config.detection.engine.value})")
+        if self.config.detection.confidence_threshold is not None:
+            fixed.append(
+                f"confidence threshold ({self.config.detection.confidence_threshold})"
+            )
+        if self.config.sanitization.strategy:
+            fixed.append(
+                f"sanitization strategy ({self.config.sanitization.strategy.value})"
+            )
+        return "; ".join(fixed) or "none"
+
+    def recommend(
+        self,
+        policy: PrivacyPolicy,
+        context: str,
+        verdict: LeakageVerdict,
+        previous_reports: List[str],
+    ) -> Optional[str]:
+        """Write the remediation report for a leaking verdict, or None on failure."""
+        predictor = _build_remediation_predictor()
+        try:
+            with dspy.context(lm=self._ensure_dspy_lm()):
+                prediction = predictor(
+                    context=context,
+                    attack=_VECTOR_GUIDANCE[verdict.vector] if verdict.vector else "",
+                    entity_type=verdict.entity_type or "NONE",
+                    evidence=verdict.evidence,
+                    current_policy=_describe_policy(policy),
+                    engine_guidance=_format_guidance(DETECTION_GUIDANCE),
+                    strategy_guidance=_format_guidance(SANITIZATION_GUIDANCE),
+                    param_guidance=_format_guidance(DETECTION_PARAM_GUIDANCE),
+                    fixed_fields=self._fixed_policy_fields(),
+                    previous_reports="\n---\n".join(previous_reports) or "none",
+                )
+        except Exception as e:
+            logger.warning("Remediation report failed (%s), escalating without one", e)
+            return None
+        report = str(getattr(prediction, "recommendation", "")).strip()
+        return report or None
+
     def _node(self, state: PrivacyState) -> PrivacyState:
-        """Graph node: write the leakage verdict and the safety flag to state."""
+        """Graph node: write the verdict (with its report on a leak) and the safety flag."""
         policy = state.get("policy")
         if policy is None:
             raise ValueError("AdversarialAgent requires 'policy' in the state.")
-        verdict = self.probe(policy, list(state.get("sanitized_chunks", [])))
+        chunks = list(state.get("sanitized_chunks", []))
+        verdict = self.probe(policy, chunks)
+        if verdict.leaked:
+            previous = [
+                r.report
+                for r in state.get("escalation_log", [])
+                if r.report and not r.from_human_feedback
+            ]
+            context = "\n\n".join(c for c in chunks if c).strip()
+            report = self.recommend(policy, context, verdict, previous)
+            verdict = replace(verdict, recommendation=report)
         return PrivacyState(verdict=verdict, safe=not verdict.leaked)

--- a/src/mmore/privacy/agents/adversary.py
+++ b/src/mmore/privacy/agents/adversary.py
@@ -326,6 +326,8 @@ class AdversarialAgent(BaseAgent):
 
     def _node(self, state: PrivacyState) -> PrivacyState:
         """Graph node: write the verdict (with its report on a leak) and the safety flag."""
+        if not self._adversary_cfg.enabled:
+            return PrivacyState(verdict=SAFE_VERDICT, safe=True)
         policy = state.get("policy")
         if policy is None:
             raise ValueError("AdversarialAgent requires 'policy' in the state.")

--- a/src/mmore/privacy/agents/adversary.py
+++ b/src/mmore/privacy/agents/adversary.py
@@ -23,7 +23,11 @@ from typing_extensions import Self
 from ...rag.llm import LLMConfig
 from ...utils import load_config
 from ..config import AttackVector, PrivacyConfig
-from ..detection.constants import DETECTION_GUIDANCE, DETECTION_PARAM_GUIDANCE
+from ..detection.constants import (
+    DEFAULT_LLM_CONFIG,
+    DETECTION_GUIDANCE,
+    DETECTION_PARAM_GUIDANCE,
+)
 from ..dspy_llm import build_dspy_lm
 from ..leakage import SAFE_VERDICT, LeakageVerdict
 from ..policy import PrivacyPolicy
@@ -200,6 +204,16 @@ class AdversarialAgent(BaseAgent):
     ):
         self._dspy_lm: Optional[dspy.BaseLM] = None
         self._adversary_cfg = config.leakage_adversary
+        if self._adversary_cfg.enabled and llm_config is None:
+            llm_config = (
+                config.context_analyzer.llm
+                if config.context_analyzer
+                else DEFAULT_LLM_CONFIG
+            )
+            logger.warning(
+                "No leakage_adversary.llm configured, falling back to %s",
+                llm_config.llm_name,
+            )
         super().__init__(config, llm_config=llm_config, checkpointer=checkpointer)
 
     @classmethod
@@ -235,7 +249,7 @@ class AdversarialAgent(BaseAgent):
         entities: List[str],
         vector: AttackVector,
     ) -> LeakageVerdict:
-        """Run one attack vector; confidence 0.0 if the probe errors out."""
+        """Run one attack vector, if we get an error it's considered as a leak."""
         try:
             with dspy.context(lm=self._ensure_dspy_lm()):
                 prediction = predictor(

--- a/src/mmore/privacy/agents/adversary.py
+++ b/src/mmore/privacy/agents/adversary.py
@@ -7,7 +7,7 @@ Writes:    verdict, safe
 The trust-boundary probe: it attacks the sanitized context for residual PII and
 quasi-identifiers before anything leaves for the cloud answer model. It runs one
 adversarial probe per configured attack vector, keeps the strongest signal, and
-treats a probe whose confidence reaches the threashold as a leak.
+treats a probe whose confidence reaches the threshold as a leak.
 """
 
 import logging
@@ -173,14 +173,14 @@ class AdversarialAgent(BaseAgent):
                 )
         except Exception as e:
             logger.warning(
-                "Leakage probe '%s' failed (%s); treating as no leak", vector.value, e
+                "Leakage probe '%s' failed (%s), treating as a leak", vector.value, e
             )
             return LeakageVerdict(
-                leaked=False,
+                leaked=True,
                 vector=vector,
                 entity_type=None,
-                evidence="",
-                confidence=0.0,
+                evidence="probe_failed",
+                confidence=1.0,
             )
         confidence = _clamp_confidence(getattr(prediction, "confidence", 0.0))
         entity = str(getattr(prediction, "entity_type", "")).strip()

--- a/src/mmore/privacy/agents/adversary.py
+++ b/src/mmore/privacy/agents/adversary.py
@@ -14,7 +14,7 @@ feedback: which engine, strategy, threshold, or entity labels to change.
 
 import logging
 from dataclasses import replace
-from typing import List, Optional, Union
+from typing import Dict, List, Optional
 
 import dspy
 from langgraph.checkpoint.base import BaseCheckpointSaver
@@ -171,11 +171,11 @@ def _describe_policy(policy: PrivacyPolicy) -> str:
     )
 
 
-def _format_guidance(guidance: dict) -> str:
+def _format_guidance(guidance: Dict[str, str]) -> str:
     return "\n".join(f"- {name}: {desc}" for name, desc in guidance.items())
 
 
-def _clamp_confidence(value: object) -> float:
+def _clamp_confidence(value: float | int | str | None) -> float:
     """Coerce a model-provided confidence into ``[0.0, 1.0]``, 0.0 on failure."""
     if isinstance(value, (int, float)):
         return max(0.0, min(1.0, float(value)))
@@ -219,7 +219,7 @@ class AdversarialAgent(BaseAgent):
     @classmethod
     def from_config(
         cls,
-        config: Union[PrivacyConfig, str, dict],
+        config: PrivacyConfig | str,
         checkpointer: Optional[BaseCheckpointSaver] = None,
     ) -> Self:
         if not isinstance(config, PrivacyConfig):

--- a/src/mmore/privacy/agents/analyzer.py
+++ b/src/mmore/privacy/agents/analyzer.py
@@ -30,6 +30,8 @@ from ..detection.constants import (
 )
 from ..domains.profile import DOMAIN_PROFILES, get_domain_profile
 from ..dspy_llm import build_dspy_lm
+from ..escalation import escalate_policy
+from ..leakage import EscalationRecord
 from ..policy import PrivacyPolicy
 from .base import BaseAgent
 from .registry import tool_registry
@@ -68,6 +70,15 @@ _LABEL_EXPAND_INSTRUCTION = (
     "Return an empty list if the current set already covers everything."
 )
 
+_LEAK_LABEL_EXPAND_INSTRUCTION = (
+    "A leakage adversary recovered or inferred a protected identifier from the "
+    "sanitized context via the described attack. Propose additional "
+    "sensitive-entity labels that would catch this identifier and related "
+    "quasi-identifiers on the next detection pass, beyond the current set. "
+    "Return them as uppercase identifiers like GPS_COORDINATES, RARE_DIAGNOSIS, "
+    "JOB_TITLE. Return an empty list if the current set already covers it."
+)
+
 
 # ========================================================================
 # DSPy signature field descriptions
@@ -85,6 +96,9 @@ _ADDITIONAL_ENTITIES_DESC = (
     "JSON array of uppercase identifier strings, e.g. "
     '["PASSPORT_NUMBER", "BANK_ACCOUNT"]. Empty array if nothing extra is needed.'
 )
+_LEAK_VECTOR_DESC = "the attack vector that leaked, e.g. quasi_identifier"
+_LEAK_ENTITY_TYPE_DESC = "the entity type the adversary recovered, or NONE"
+_LEAK_EVIDENCE_DESC = "the adversary's justification for the leak (PII-free)"
 
 _MAX_ADDITIONAL_ENTITIES = 8
 _LABEL_NON_ID_RE = re.compile(r"[^A-Z0-9_]")
@@ -116,6 +130,16 @@ class _LabelExpandSignature(dspy.Signature):
     query: str = dspy.InputField(desc=_QUERY_DESC)
     context: str = dspy.InputField(desc=_CONTEXT_DESC)
     current_entities: List[str] = dspy.InputField(desc=_CURRENT_ENTITIES_DESC)
+    additional_entities: List[str] = dspy.OutputField(desc=_ADDITIONAL_ENTITIES_DESC)
+
+
+class _LeakLabelExpandSignature(dspy.Signature):
+    query: str = dspy.InputField(desc=_QUERY_DESC)
+    context: str = dspy.InputField(desc=_CONTEXT_DESC)
+    current_entities: List[str] = dspy.InputField(desc=_CURRENT_ENTITIES_DESC)
+    leak_vector: str = dspy.InputField(desc=_LEAK_VECTOR_DESC)
+    leak_entity_type: str = dspy.InputField(desc=_LEAK_ENTITY_TYPE_DESC)
+    leak_evidence: str = dspy.InputField(desc=_LEAK_EVIDENCE_DESC)
     additional_entities: List[str] = dspy.OutputField(desc=_ADDITIONAL_ENTITIES_DESC)
 
 
@@ -186,6 +210,12 @@ def _build_detection_engine_selector_predictor() -> dspy.Predict:
 def _build_label_expansion_predictor() -> dspy.Predict:
     return dspy.Predict(
         _LabelExpandSignature.with_instructions(_LABEL_EXPAND_INSTRUCTION)
+    )
+
+
+def _build_leak_label_expansion_predictor() -> dspy.Predict:
+    return dspy.Predict(
+        _LeakLabelExpandSignature.with_instructions(_LEAK_LABEL_EXPAND_INSTRUCTION)
     )
 
 
@@ -353,6 +383,37 @@ class ContextPolicyAnalyzerAgent(BaseAgent):
             getattr(prediction, "additional_entities", None), current
         )
 
+    def _expand_labels_for_leak(
+        self, state: PrivacyState, policy: PrivacyPolicy
+    ) -> List[str]:
+        """Propose leak-targeted sensitive labels via DSPy, biased by the verdict."""
+        if self._llm_config is None:
+            return []
+        verdict = state.get("verdict")
+        if verdict is None or not verdict.leaked:
+            return []
+        current = list(policy.sensitive_entities)
+        self._ensure_dspy_lm()
+        predictor = _build_leak_label_expansion_predictor()
+        try:
+            with dspy.context(lm=self._dspy_lm, adapter=dspy.JSONAdapter()):
+                prediction = predictor(
+                    query=state.get("query", ""),
+                    context="\n\n".join(state.get("raw_chunks", [])),
+                    current_entities=current,
+                    leak_vector=verdict.vector,
+                    leak_entity_type=verdict.entity_type,
+                    leak_evidence=verdict.evidence,
+                )
+        except Exception as e:
+            logger.warning(
+                "Leak-targeted label expansion failed (%s), using fallback list", e
+            )
+            return []
+        return _sanitize_label_additions(
+            getattr(prediction, "additional_entities", None), current
+        )
+
     def _select_params(
         self, engine: str, query: str, chunks: List[str]
     ) -> Dict[str, Union[float, bool]] | None:
@@ -429,9 +490,43 @@ class ContextPolicyAnalyzerAgent(BaseAgent):
             sanitizer_system_prompt=profile.sanitizer_system_prompt,
         )
 
-    def _node(self, state: PrivacyState) -> PrivacyState:
-        """Graph node: write the resolved policy into the pipeline state."""
-        policy = self.build_policy(
-            state.get("query", ""), list(state.get("raw_chunks", []))
+    def _escalate(self, state: PrivacyState, policy: PrivacyPolicy) -> PrivacyState:
+        """Re-entry path: adjust the policy after a leak or a gate rejection."""
+        iteration = state.get("iteration", 0)
+        extra_entities = self._expand_labels_for_leak(state, policy)
+        new_policy, label = escalate_policy(policy, iteration, extra_entities or None)
+        verdict = state.get("verdict")
+        if verdict is not None and verdict.leaked:
+            trigger_vector, trigger_entity = verdict.vector, verdict.entity_type
+        elif state.get("approved") is False:
+            trigger_vector, trigger_entity = "hitl_reject", "NONE"
+        else:
+            trigger_vector, trigger_entity = "unknown", "NONE"
+        record = EscalationRecord(
+            iteration=iteration + 1,
+            vector=trigger_vector,
+            entity_type=trigger_entity,
+            escalation=label,
         )
-        return PrivacyState(policy=policy)
+        logger.info("Policy escalation %d: %s", iteration + 1, label)
+        return PrivacyState(
+            policy=new_policy,
+            iteration=iteration + 1,
+            escalation_log=list(state.get("escalation_log", [])) + [record],
+            outcome="re-looped",
+        )
+
+    def _node(self, state: PrivacyState) -> PrivacyState:
+        """Graph node: build the policy on first entry, escalate it on re-entry.
+
+        A policy already in the state means the loop or the gate sent the
+        request back for a stricter pass, so the analyzer escalates rather than
+        rebuilding from scratch.
+        """
+        policy = state.get("policy")
+        if policy is None:
+            policy = self.build_policy(
+                state.get("query", ""), list(state.get("raw_chunks", []))
+            )
+            return PrivacyState(policy=policy)
+        return self._escalate(state, policy)

--- a/src/mmore/privacy/agents/analyzer.py
+++ b/src/mmore/privacy/agents/analyzer.py
@@ -11,7 +11,7 @@ the per-request PrivacyPolicy the next agents consume.
 
 import logging
 import re
-from dataclasses import asdict
+from dataclasses import asdict, replace
 from typing import Dict, List, Literal, Optional, Union
 
 import dspy
@@ -30,12 +30,13 @@ from ..detection.constants import (
 )
 from ..domains.profile import DOMAIN_PROFILES, get_domain_profile
 from ..dspy_llm import build_dspy_lm
-from ..escalation import escalate_policy
+from ..escalation import apply_entity_guidance, escalate_policy
 from ..leakage import EscalationRecord
 from ..policy import PrivacyPolicy
+from ..sanitization.constants import SANITIZATION_GUIDANCE, SANITIZATION_TOOL_NAMES
 from .base import BaseAgent
 from .registry import tool_registry
-from .state import PrivacyState
+from .state import PreCloudOutcome, PrivacyState
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +80,22 @@ _LEAK_LABEL_EXPAND_INSTRUCTION = (
     "JOB_TITLE. Return an empty list if the current set already covers it."
 )
 
+_FEEDBACK_LABEL_EXPAND_INSTRUCTION = (
+    "A human reviewer rejected the sanitized context and gave the feedback "
+    "below. Propose additional sensitive-entity labels that act on that "
+    "feedback, beyond the current set. Return them as uppercase identifiers "
+    "like GPS_COORDINATES, RARE_DIAGNOSIS, JOB_TITLE. Return an empty list if "
+    "the current set already covers the feedback."
+)
+
+_FEEDBACK_POLICY_INSTRUCTION = (
+    "A human reviewer gave the feedback below. Decide whether it calls for a "
+    "different detection engine or sanitization strategy, either by naming one "
+    "explicitly or by describing what they want (use the guidance to map the "
+    "description to the best fitting option). Return the chosen value from the "
+    "available options, or 'keep' for a field the feedback does not affect."
+)
+
 
 # ========================================================================
 # DSPy signature field descriptions
@@ -99,6 +116,14 @@ _ADDITIONAL_ENTITIES_DESC = (
 _LEAK_VECTOR_DESC = "the attack vector that leaked, e.g. quasi_identifier"
 _LEAK_ENTITY_TYPE_DESC = "the entity type the adversary recovered, or NONE"
 _LEAK_EVIDENCE_DESC = "the adversary's justification for the leak (PII-free)"
+_HUMAN_FEEDBACK_DESC = "the human reviewer's free-text guidance at the gate"
+_STRATEGY_GUIDANCE_DESC = "per-strategy guidance: what each sanitization strategy does"
+_AVAILABLE_ENGINES_DESC = "the detection engines you may choose from"
+_AVAILABLE_STRATEGIES_DESC = "the sanitization strategies you may choose from"
+_REQUESTED_ENGINE_DESC = "one of the available engines, or 'keep' to leave it unchanged"
+_REQUESTED_STRATEGY_DESC = (
+    "one of the available strategies, or 'keep' to leave it unchanged"
+)
 
 _MAX_ADDITIONAL_ENTITIES = 8
 _LABEL_NON_ID_RE = re.compile(r"[^A-Z0-9_]")
@@ -141,6 +166,24 @@ class _LeakLabelExpandSignature(dspy.Signature):
     leak_entity_type: str = dspy.InputField(desc=_LEAK_ENTITY_TYPE_DESC)
     leak_evidence: str = dspy.InputField(desc=_LEAK_EVIDENCE_DESC)
     additional_entities: List[str] = dspy.OutputField(desc=_ADDITIONAL_ENTITIES_DESC)
+
+
+class _FeedbackLabelExpandSignature(dspy.Signature):
+    query: str = dspy.InputField(desc=_QUERY_DESC)
+    context: str = dspy.InputField(desc=_CONTEXT_DESC)
+    current_entities: List[str] = dspy.InputField(desc=_CURRENT_ENTITIES_DESC)
+    human_feedback: str = dspy.InputField(desc=_HUMAN_FEEDBACK_DESC)
+    additional_entities: List[str] = dspy.OutputField(desc=_ADDITIONAL_ENTITIES_DESC)
+
+
+class _FeedbackPolicySignature(dspy.Signature):
+    human_feedback: str = dspy.InputField(desc=_HUMAN_FEEDBACK_DESC)
+    engine_guidance: str = dspy.InputField(desc=_DETECTION_GUIDANCE_DESC)
+    strategy_guidance: str = dspy.InputField(desc=_STRATEGY_GUIDANCE_DESC)
+    available_engines: List[str] = dspy.InputField(desc=_AVAILABLE_ENGINES_DESC)
+    available_strategies: List[str] = dspy.InputField(desc=_AVAILABLE_STRATEGIES_DESC)
+    requested_engine: str = dspy.OutputField(desc=_REQUESTED_ENGINE_DESC)
+    requested_strategy: str = dspy.OutputField(desc=_REQUESTED_STRATEGY_DESC)
 
 
 class _PresidioParamsSignature(dspy.Signature):
@@ -219,6 +262,20 @@ def _build_leak_label_expansion_predictor() -> dspy.Predict:
     )
 
 
+def _build_feedback_label_expansion_predictor() -> dspy.Predict:
+    return dspy.Predict(
+        _FeedbackLabelExpandSignature.with_instructions(
+            _FEEDBACK_LABEL_EXPAND_INSTRUCTION
+        )
+    )
+
+
+def _build_feedback_policy_predictor() -> dspy.Predict:
+    return dspy.Predict(
+        _FeedbackPolicySignature.with_instructions(_FEEDBACK_POLICY_INSTRUCTION)
+    )
+
+
 def _sanitize_label_additions(raw: object, current: List[str]) -> List[str]:
     """Clean the LLM's proposed labels: uppercase, strip, drop empties and
     labels already in ``current``, cap at the configured maximum."""
@@ -250,6 +307,12 @@ def _build_param_predictor(engine: str) -> dspy.Predict | None:
 
 def _format_engine_guidance() -> str:
     return "\n".join(f"- {name}: {desc}" for name, desc in DETECTION_GUIDANCE.items())
+
+
+def _format_strategy_guidance() -> str:
+    return "\n".join(
+        f"- {name}: {desc}" for name, desc in SANITIZATION_GUIDANCE.items()
+    )
 
 
 def _parse_param_prediction(
@@ -414,6 +477,60 @@ class ContextPolicyAnalyzerAgent(BaseAgent):
             getattr(prediction, "additional_entities", None), current
         )
 
+    def _expand_labels_from_feedback(
+        self, state: PrivacyState, policy: PrivacyPolicy, feedback: str
+    ) -> List[str]:
+        """Propose sensitive labels that act on the human's gate feedback."""
+        if self._llm_config is None or not feedback:
+            return []
+        current = list(policy.sensitive_entities)
+        self._ensure_dspy_lm()
+        predictor = _build_feedback_label_expansion_predictor()
+        try:
+            with dspy.context(lm=self._dspy_lm, adapter=dspy.JSONAdapter()):
+                prediction = predictor(
+                    query=state.get("query", ""),
+                    context="\n\n".join(state.get("raw_chunks", [])),
+                    current_entities=current,
+                    human_feedback=feedback,
+                )
+        except Exception as e:
+            logger.warning("Feedback-driven label expansion failed (%s)", e)
+            return []
+        return _sanitize_label_additions(
+            getattr(prediction, "additional_entities", None), current
+        )
+
+    def _apply_feedback_overrides(
+        self, policy: PrivacyPolicy, feedback: str
+    ) -> PrivacyPolicy:
+        """Switch the detection engine / sanitization strategy when the human
+        feedback names or describes one, otherwise leave the policy as-is."""
+        if self._llm_config is None or not feedback:
+            return policy
+        self._ensure_dspy_lm()
+        predictor = _build_feedback_policy_predictor()
+        try:
+            with dspy.context(lm=self._dspy_lm):
+                prediction = predictor(
+                    human_feedback=feedback,
+                    engine_guidance=_format_engine_guidance(),
+                    strategy_guidance=_format_strategy_guidance(),
+                    available_engines=list(DETECTION_TOOL_NAMES),
+                    available_strategies=list(SANITIZATION_TOOL_NAMES),
+                )
+        except Exception as e:
+            logger.warning("Feedback policy override failed (%s)", e)
+            return policy
+        engine = str(getattr(prediction, "requested_engine", "")).strip().lower()
+        strategy = str(getattr(prediction, "requested_strategy", "")).strip().lower()
+        updates: Dict[str, str] = {}
+        if engine in DETECTION_TOOL_NAMES:
+            updates["detection_engine"] = engine
+        if strategy in SANITIZATION_TOOL_NAMES:
+            updates["sanitization_strategy"] = strategy
+        return replace(policy, **updates) if updates else policy
+
     def _select_params(
         self, engine: str, query: str, chunks: List[str]
     ) -> Dict[str, Union[float, bool]] | None:
@@ -493,27 +610,49 @@ class ContextPolicyAnalyzerAgent(BaseAgent):
     def _escalate(self, state: PrivacyState, policy: PrivacyPolicy) -> PrivacyState:
         """Re-entry path: adjust the policy after a leak or a gate rejection."""
         iteration = state.get("iteration", 0)
-        extra_entities = self._expand_labels_for_leak(state, policy)
-        new_policy, label = escalate_policy(policy, iteration, extra_entities or None)
+        leak_iterations = state.get("leak_iterations", 0)
         verdict = state.get("verdict")
+        feedback = state.get("human_feedback")
+        trigger_vector, trigger_entity = None, None
+        label, from_human_feedback = None, False
         if verdict is not None and verdict.leaked:
+            # Automatic leak escalation with ladder
+            extra_entities = self._expand_labels_for_leak(state, policy)
+            new_policy, label = escalate_policy(
+                policy, iteration, extra_entities or None
+            )
             trigger_vector, trigger_entity = verdict.vector, verdict.entity_type
+            leak_iterations += 1  # only leak escalations count toward the budget
+        elif state.get("approved") is False and feedback:
+            # Human revise with guidance: apply exactly what they asked, no ladder
+            extra_entities = self._expand_labels_from_feedback(state, policy, feedback)
+            new_policy = apply_entity_guidance(policy, extra_entities or None, feedback)
+            new_policy = self._apply_feedback_overrides(new_policy, feedback)
+            from_human_feedback = True
         elif state.get("approved") is False:
-            trigger_vector, trigger_entity = "hitl_reject", "NONE"
+            # Human revise without guidance: use the ladder
+            new_policy, label = escalate_policy(policy, iteration)
         else:
-            trigger_vector, trigger_entity = "unknown", "NONE"
+            raise ValueError("escalate called without a leak or rejection")
         record = EscalationRecord(
             iteration=iteration + 1,
+            escalation=label,
+            from_human_feedback=from_human_feedback,
             vector=trigger_vector,
             entity_type=trigger_entity,
-            escalation=label,
         )
-        logger.info("Policy escalation %d: %s", iteration + 1, label)
+        logger.info(
+            "Policy escalation %d: %s",
+            iteration + 1,
+            "human feedback" if from_human_feedback else label,
+        )
         return PrivacyState(
             policy=new_policy,
             iteration=iteration + 1,
+            leak_iterations=leak_iterations,
             escalation_log=list(state.get("escalation_log", [])) + [record],
-            outcome="re-looped",
+            outcome=PreCloudOutcome.RE_LOOPED,
+            human_feedback=None,  # was taken into account already
         )
 
     def _node(self, state: PrivacyState) -> PrivacyState:

--- a/src/mmore/privacy/agents/analyzer.py
+++ b/src/mmore/privacy/agents/analyzer.py
@@ -30,7 +30,7 @@ from ..detection.constants import (
 )
 from ..domains.profile import DOMAIN_PROFILES, get_domain_profile
 from ..dspy_llm import build_dspy_lm
-from ..escalation import apply_entity_guidance, escalate_policy
+from ..escalation import apply_entity_guidance
 from ..leakage import EscalationRecord
 from ..policy import PrivacyPolicy
 from ..sanitization.constants import SANITIZATION_GUIDANCE, SANITIZATION_TOOL_NAMES
@@ -71,26 +71,19 @@ _LABEL_EXPAND_INSTRUCTION = (
     "Return an empty list if the current set already covers everything."
 )
 
-_LEAK_LABEL_EXPAND_INSTRUCTION = (
-    "A leakage adversary recovered or inferred a protected identifier from the "
-    "sanitized context via the described attack. Propose additional "
-    "sensitive-entity labels that would catch this identifier and related "
-    "quasi-identifiers on the next detection pass, beyond the current set. "
-    "Return them as uppercase identifiers like GPS_COORDINATES, RARE_DIAGNOSIS, "
-    "JOB_TITLE. Return an empty list if the current set already covers it."
-)
-
 _FEEDBACK_LABEL_EXPAND_INSTRUCTION = (
-    "A human reviewer rejected the sanitized context and gave the feedback "
-    "below. Propose additional sensitive-entity labels that act on that "
-    "feedback, beyond the current set. Return them as uppercase identifiers "
-    "like GPS_COORDINATES, RARE_DIAGNOSIS, JOB_TITLE. Return an empty list if "
-    "the current set already covers the feedback."
+    "A reviewer (the human at the gate or the leakage adversary) rejected the "
+    "sanitized context and gave the feedback below. Propose additional "
+    "sensitive-entity labels that act on that feedback, beyond the current "
+    "set. Return them as uppercase identifiers like GPS_COORDINATES, "
+    "RARE_DIAGNOSIS, JOB_TITLE. Return an empty list if the current set "
+    "already covers the feedback."
 )
 
 _FEEDBACK_POLICY_INSTRUCTION = (
-    "A human reviewer gave the feedback below. Decide whether it calls for a "
-    "different detection engine or sanitization strategy, either by naming one "
+    "A reviewer (the human at the gate or the leakage adversary) gave the "
+    "feedback below. Decide whether it calls for a different detection engine, "
+    "sanitization strategy, or detection threshold level, either by naming one "
     "explicitly or by describing what they want (use the guidance to map the "
     "description to the best fitting option). Return the chosen value from the "
     "available options, or 'keep' for a field the feedback does not affect."
@@ -113,16 +106,19 @@ _ADDITIONAL_ENTITIES_DESC = (
     "JSON array of uppercase identifier strings, e.g. "
     '["PASSPORT_NUMBER", "BANK_ACCOUNT"]. Empty array if nothing extra is needed.'
 )
-_LEAK_VECTOR_DESC = "the attack vector that leaked, e.g. quasi_identifier"
-_LEAK_ENTITY_TYPE_DESC = "the entity type the adversary recovered, or NONE"
-_LEAK_EVIDENCE_DESC = "the adversary's justification for the leak (PII-free)"
-_HUMAN_FEEDBACK_DESC = "the human reviewer's free-text guidance at the gate"
+_FEEDBACK_DESC = (
+    "the reviewer's free-text guidance: human gate feedback or the adversary's "
+    "remediation report"
+)
 _STRATEGY_GUIDANCE_DESC = "per-strategy guidance: what each sanitization strategy does"
 _AVAILABLE_ENGINES_DESC = "the detection engines you may choose from"
 _AVAILABLE_STRATEGIES_DESC = "the sanitization strategies you may choose from"
 _REQUESTED_ENGINE_DESC = "one of the available engines, or 'keep' to leave it unchanged"
 _REQUESTED_STRATEGY_DESC = (
     "one of the available strategies, or 'keep' to leave it unchanged"
+)
+_REQUESTED_THRESHOLD_DESC = (
+    "one of: low, medium, high, or 'keep' to leave the detection threshold unchanged"
 )
 
 _MAX_ADDITIONAL_ENTITIES = 8
@@ -158,32 +154,23 @@ class _LabelExpandSignature(dspy.Signature):
     additional_entities: List[str] = dspy.OutputField(desc=_ADDITIONAL_ENTITIES_DESC)
 
 
-class _LeakLabelExpandSignature(dspy.Signature):
-    query: str = dspy.InputField(desc=_QUERY_DESC)
-    context: str = dspy.InputField(desc=_CONTEXT_DESC)
-    current_entities: List[str] = dspy.InputField(desc=_CURRENT_ENTITIES_DESC)
-    leak_vector: str = dspy.InputField(desc=_LEAK_VECTOR_DESC)
-    leak_entity_type: str = dspy.InputField(desc=_LEAK_ENTITY_TYPE_DESC)
-    leak_evidence: str = dspy.InputField(desc=_LEAK_EVIDENCE_DESC)
-    additional_entities: List[str] = dspy.OutputField(desc=_ADDITIONAL_ENTITIES_DESC)
-
-
 class _FeedbackLabelExpandSignature(dspy.Signature):
     query: str = dspy.InputField(desc=_QUERY_DESC)
     context: str = dspy.InputField(desc=_CONTEXT_DESC)
     current_entities: List[str] = dspy.InputField(desc=_CURRENT_ENTITIES_DESC)
-    human_feedback: str = dspy.InputField(desc=_HUMAN_FEEDBACK_DESC)
+    feedback: str = dspy.InputField(desc=_FEEDBACK_DESC)
     additional_entities: List[str] = dspy.OutputField(desc=_ADDITIONAL_ENTITIES_DESC)
 
 
 class _FeedbackPolicySignature(dspy.Signature):
-    human_feedback: str = dspy.InputField(desc=_HUMAN_FEEDBACK_DESC)
+    feedback: str = dspy.InputField(desc=_FEEDBACK_DESC)
     engine_guidance: str = dspy.InputField(desc=_DETECTION_GUIDANCE_DESC)
     strategy_guidance: str = dspy.InputField(desc=_STRATEGY_GUIDANCE_DESC)
     available_engines: List[str] = dspy.InputField(desc=_AVAILABLE_ENGINES_DESC)
     available_strategies: List[str] = dspy.InputField(desc=_AVAILABLE_STRATEGIES_DESC)
     requested_engine: str = dspy.OutputField(desc=_REQUESTED_ENGINE_DESC)
     requested_strategy: str = dspy.OutputField(desc=_REQUESTED_STRATEGY_DESC)
+    requested_threshold: str = dspy.OutputField(desc=_REQUESTED_THRESHOLD_DESC)
 
 
 class _PresidioParamsSignature(dspy.Signature):
@@ -256,12 +243,6 @@ def _build_label_expansion_predictor() -> dspy.Predict:
     )
 
 
-def _build_leak_label_expansion_predictor() -> dspy.Predict:
-    return dspy.Predict(
-        _LeakLabelExpandSignature.with_instructions(_LEAK_LABEL_EXPAND_INSTRUCTION)
-    )
-
-
 def _build_feedback_label_expansion_predictor() -> dspy.Predict:
     return dspy.Predict(
         _FeedbackLabelExpandSignature.with_instructions(
@@ -303,6 +284,23 @@ def _build_param_predictor(engine: str) -> dspy.Predict | None:
     if sig is None:
         return None
     return dspy.Predict(sig.with_instructions(_PARAM_SELECT_INSTRUCTION))
+
+
+def _describe_policy_changes(old: PrivacyPolicy, new: PrivacyPolicy) -> str:
+    """Short escalation-log label for what the guidance actually changed."""
+    changes: List[str] = []
+    if new.detection_engine != old.detection_engine:
+        changes.append(f"engine->{new.detection_engine}")
+    if new.sanitization_strategy != old.sanitization_strategy:
+        changes.append(f"strategy->{new.sanitization_strategy}")
+    old_threshold = old.detection_params.get("confidence_threshold")
+    new_threshold = new.detection_params.get("confidence_threshold")
+    if new_threshold != old_threshold:
+        changes.append(f"threshold->{new_threshold}")
+    added_labels = len(new.sensitive_entities) - len(old.sensitive_entities)
+    if added_labels:
+        changes.append(f"+{added_labels}_labels")
+    return " ".join(changes) if changes else "note_only"
 
 
 def _format_engine_guidance() -> str:
@@ -446,41 +444,10 @@ class ContextPolicyAnalyzerAgent(BaseAgent):
             getattr(prediction, "additional_entities", None), current
         )
 
-    def _expand_labels_for_leak(
-        self, state: PrivacyState, policy: PrivacyPolicy
-    ) -> List[str]:
-        """Propose leak-targeted sensitive labels via DSPy, biased by the verdict."""
-        if self._llm_config is None:
-            return []
-        verdict = state.get("verdict")
-        if verdict is None or not verdict.leaked:
-            return []
-        current = list(policy.sensitive_entities)
-        self._ensure_dspy_lm()
-        predictor = _build_leak_label_expansion_predictor()
-        try:
-            with dspy.context(lm=self._dspy_lm, adapter=dspy.JSONAdapter()):
-                prediction = predictor(
-                    query=state.get("query", ""),
-                    context="\n\n".join(state.get("raw_chunks", [])),
-                    current_entities=current,
-                    leak_vector=verdict.vector if verdict.vector else "none",
-                    leak_entity_type=verdict.entity_type,
-                    leak_evidence=verdict.evidence,
-                )
-        except Exception as e:
-            logger.warning(
-                "Leak-targeted label expansion failed (%s), using fallback list", e
-            )
-            return []
-        return _sanitize_label_additions(
-            getattr(prediction, "additional_entities", None), current
-        )
-
     def _expand_labels_from_feedback(
         self, state: PrivacyState, policy: PrivacyPolicy, feedback: str
     ) -> List[str]:
-        """Propose sensitive labels that act on the human's gate feedback."""
+        """Propose sensitive labels that act on the reviewer's guidance."""
         if self._llm_config is None or not feedback:
             return []
         current = list(policy.sensitive_entities)
@@ -492,7 +459,7 @@ class ContextPolicyAnalyzerAgent(BaseAgent):
                     query=state.get("query", ""),
                     context="\n\n".join(state.get("raw_chunks", [])),
                     current_entities=current,
-                    human_feedback=feedback,
+                    feedback=feedback,
                 )
         except Exception as e:
             logger.warning("Feedback-driven label expansion failed (%s)", e)
@@ -502,10 +469,9 @@ class ContextPolicyAnalyzerAgent(BaseAgent):
         )
 
     def _apply_feedback_overrides(
-        self, policy: PrivacyPolicy, feedback: str
+        self, policy: PrivacyPolicy, feedback: str, respect_config_pins: bool
     ) -> PrivacyPolicy:
-        """Switch the detection engine / sanitization strategy when the human
-        feedback names or describes one, otherwise leave the policy as-is."""
+        """Switch engine/strategy/threshold per the guidance; pins bind the adversary only."""
         if self._llm_config is None or not feedback:
             return policy
         self._ensure_dspy_lm()
@@ -513,7 +479,7 @@ class ContextPolicyAnalyzerAgent(BaseAgent):
         try:
             with dspy.context(lm=self._dspy_lm):
                 prediction = predictor(
-                    human_feedback=feedback,
+                    feedback=feedback,
                     engine_guidance=_format_engine_guidance(),
                     strategy_guidance=_format_strategy_guidance(),
                     available_engines=list(DETECTION_TOOL_NAMES),
@@ -524,11 +490,22 @@ class ContextPolicyAnalyzerAgent(BaseAgent):
             return policy
         engine = str(getattr(prediction, "requested_engine", "")).strip().lower()
         strategy = str(getattr(prediction, "requested_strategy", "")).strip().lower()
-        updates: Dict[str, str] = {}
-        if engine in DETECTION_TOOL_NAMES:
+        threshold = str(getattr(prediction, "requested_threshold", "")).strip().lower()
+        engine_pinned = respect_config_pins and self.config.detection.engine
+        strategy_pinned = respect_config_pins and self.config.sanitization.strategy
+        threshold_pinned = (
+            respect_config_pins
+            and self.config.detection.confidence_threshold is not None
+        )
+        updates: Dict[str, object] = {}
+        if engine in DETECTION_TOOL_NAMES and not engine_pinned:
             updates["detection_engine"] = engine
-        if strategy in SANITIZATION_TOOL_NAMES:
+        if strategy in SANITIZATION_TOOL_NAMES and not strategy_pinned:
             updates["sanitization_strategy"] = strategy
+        if threshold in THRESHOLD_LEVELS and not threshold_pinned:
+            params = dict(policy.detection_params)
+            params["confidence_threshold"] = THRESHOLD_LEVELS[threshold]
+            updates["detection_params"] = params
         return replace(policy, **updates) if updates else policy
 
     def _select_params(
@@ -607,45 +584,63 @@ class ContextPolicyAnalyzerAgent(BaseAgent):
             sanitizer_system_prompt=profile.sanitizer_system_prompt,
         )
 
+    def _apply_guidance(
+        self,
+        state: PrivacyState,
+        policy: PrivacyPolicy,
+        guidance: str,
+        note_label: str,
+        respect_config_pins: bool,
+    ) -> PrivacyPolicy:
+        """Act on a reviewer's guidance text; note-only hardening without one."""
+        if not guidance:
+            return apply_entity_guidance(policy)
+        extra_entities = self._expand_labels_from_feedback(state, policy, guidance)
+        new_policy = apply_entity_guidance(
+            policy, extra_entities or None, guidance, note_label=note_label
+        )
+        return self._apply_feedback_overrides(new_policy, guidance, respect_config_pins)
+
     def _escalate(self, state: PrivacyState, policy: PrivacyPolicy) -> PrivacyState:
-        """Re-entry path: adjust the policy after a leak or a gate rejection."""
+        """Re-entry path: harden the policy from the adversary report or gate feedback."""
         iteration = state.get("iteration", 0)
         leak_iterations = state.get("leak_iterations", 0)
         verdict = state.get("verdict")
-        feedback = state.get("human_feedback")
         trigger_vector, trigger_entity = None, None
-        label, from_human_feedback = None, False
+        from_human_feedback = False
         if verdict is not None and verdict.leaked:
-            # Automatic leak escalation with ladder
-            extra_entities = self._expand_labels_for_leak(state, policy)
-            new_policy, label = escalate_policy(
-                policy, iteration, extra_entities or None
+            report = (verdict.recommendation or "").strip()
+            new_policy = self._apply_guidance(
+                state,
+                policy,
+                report,
+                note_label="Adversary guidance",
+                respect_config_pins=True,
             )
             trigger_vector, trigger_entity = verdict.vector, verdict.entity_type
             leak_iterations += 1  # only leak escalations count toward the budget
-        elif state.get("approved") is False and feedback:
-            # Human revise with guidance: apply exactly what they asked, no ladder
-            extra_entities = self._expand_labels_from_feedback(state, policy, feedback)
-            new_policy = apply_entity_guidance(policy, extra_entities or None, feedback)
-            new_policy = self._apply_feedback_overrides(new_policy, feedback)
-            from_human_feedback = True
         elif state.get("approved") is False:
-            # Human revise without guidance: use the ladder
-            new_policy, label = escalate_policy(policy, iteration)
+            report = (state.get("human_feedback") or "").strip()
+            new_policy = self._apply_guidance(
+                state,
+                policy,
+                report,
+                note_label="Human guidance",
+                respect_config_pins=False,
+            )
+            from_human_feedback = bool(report)
         else:
             raise ValueError("escalate called without a leak or rejection")
+        label = _describe_policy_changes(policy, new_policy)
         record = EscalationRecord(
             iteration=iteration + 1,
             escalation=label,
             from_human_feedback=from_human_feedback,
             vector=trigger_vector,
             entity_type=trigger_entity,
+            report=report or None,
         )
-        logger.info(
-            "Policy escalation %d: %s",
-            iteration + 1,
-            "human feedback" if from_human_feedback else label,
-        )
+        logger.info("Policy escalation %d: %s", iteration + 1, label)
         return PrivacyState(
             policy=new_policy,
             iteration=iteration + 1,

--- a/src/mmore/privacy/agents/analyzer.py
+++ b/src/mmore/privacy/agents/analyzer.py
@@ -353,7 +353,7 @@ class ContextPolicyAnalyzerAgent(BaseAgent):
     @classmethod
     def from_config(
         cls,
-        config: Union[PrivacyConfig, str, dict],
+        config: PrivacyConfig | str,
         checkpointer: Optional[BaseCheckpointSaver] = None,
     ) -> Self:
         if not isinstance(config, PrivacyConfig):
@@ -628,7 +628,7 @@ class ContextPolicyAnalyzerAgent(BaseAgent):
                 note_label="Human guidance",
                 respect_config_pins=False,
             )
-            from_human_feedback = bool(report)
+            from_human_feedback = True
         else:
             raise ValueError("escalate called without a leak or rejection")
         label = _describe_policy_changes(policy, new_policy)

--- a/src/mmore/privacy/agents/analyzer.py
+++ b/src/mmore/privacy/agents/analyzer.py
@@ -464,7 +464,7 @@ class ContextPolicyAnalyzerAgent(BaseAgent):
                     query=state.get("query", ""),
                     context="\n\n".join(state.get("raw_chunks", [])),
                     current_entities=current,
-                    leak_vector=verdict.vector,
+                    leak_vector=verdict.vector if verdict.vector else "none",
                     leak_entity_type=verdict.entity_type,
                     leak_evidence=verdict.evidence,
                 )

--- a/src/mmore/privacy/agents/detector.py
+++ b/src/mmore/privacy/agents/detector.py
@@ -11,7 +11,7 @@ risk assessment the next agents consume.
 
 import logging
 from collections import Counter
-from typing import Callable, Dict, List, Optional, Union
+from typing import Callable, Dict, List, Optional
 
 from langgraph.checkpoint.base import BaseCheckpointSaver
 from typing_extensions import Self
@@ -116,7 +116,7 @@ class DetectorAgent(BaseAgent):
     @classmethod
     def from_config(
         cls,
-        config: Union[PrivacyConfig, str, dict],
+        config: PrivacyConfig | str,
         checkpointer: Optional[BaseCheckpointSaver] = None,
     ) -> Self:
         if not isinstance(config, PrivacyConfig):

--- a/src/mmore/privacy/agents/gate.py
+++ b/src/mmore/privacy/agents/gate.py
@@ -1,0 +1,188 @@
+"""Pre-cloud HITL approval gate.
+
+Pipeline:  ... -> sanitizer -> leakage_adversary -> [gate] -> ...
+Reads:     policy, risk, verdict, iteration, escalation_log
+Writes:    summary, approved, outcome
+
+The last step before the trust boundary: once the adversary clears the
+sanitized context, the gate builds a concise, PII-free summary of everything
+that was done and pauses for human approval via an interruption on the graph.
+"""
+
+import logging
+from enum import Enum
+from typing import List, Optional, Tuple, Union
+
+from langgraph.checkpoint.base import BaseCheckpointSaver
+from langgraph.types import interrupt
+from typing_extensions import Self
+
+from ...utils import load_config
+from ..config import PrivacyConfig
+from .base import BaseAgent
+from .state import PreCloudOutcome, PrivacyState
+
+logger = logging.getLogger(__name__)
+
+
+class GateDecision(str, Enum):
+    """The human's choice at the gate."""
+
+    APPROVE = "approve"
+    RETRY = "retry"
+    REJECT = "reject"
+
+
+_GATE_CHOICES: List[Tuple[GateDecision, str]] = [
+    (GateDecision.APPROVE, "Approve: clear the sanitized context for the cloud call"),
+    (GateDecision.RETRY, "Revise: tighten the policy and retry (optional feedback)"),
+    (GateDecision.REJECT, "Reject: abort the request"),
+]
+_CHOICE_BY_NUMBER = {i + 1: decision for i, (decision, _) in enumerate(_GATE_CHOICES)}
+_DECISION_BY_VALUE = {decision.value: decision for decision, _ in _GATE_CHOICES}
+
+
+def _gate_options() -> List[dict]:
+    """The numbered menu surfaced to the human in the interrupt payload."""
+    return [
+        {"choice": i + 1, "action": decision.value, "label": label}
+        for i, (decision, label) in enumerate(_GATE_CHOICES)
+    ]
+
+
+def _as_choice_number(value: object) -> Optional[int]:
+    """Read a menu number from an int or numeric string."""
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.strip().isdigit():
+        return int(value.strip())
+    return None
+
+
+def _interpret_decision(decision: object) -> Optional[GateDecision]:
+    """Map a resume value (a menu number, an action name, or a dict) to a decision."""
+    number = _as_choice_number(decision)
+    if number is not None:
+        return _CHOICE_BY_NUMBER.get(number)
+    if isinstance(decision, str):
+        return _DECISION_BY_VALUE.get(decision.strip().lower())
+    if isinstance(decision, dict):
+        return _interpret_decision(decision.get("choice"))
+    return None
+
+
+def _extract_feedback(decision: object) -> Optional[str]:
+    """Pull the human's free-text guidance from a structured resume value."""
+    if isinstance(decision, dict):
+        value = decision.get("feedback")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def build_gate_summary(state: PrivacyState) -> str:
+    """Build a concise, PII-free summary of the pre-cloud pipeline run."""
+    policy = state.get("policy")
+    risk = state.get("risk")
+    verdict = state.get("verdict")
+    iteration = state.get("iteration", 0)
+    escalation_log = state.get("escalation_log") or []
+
+    domain = policy.domain if policy else "unknown"
+    strategy = policy.sanitization_strategy if policy else "unknown"
+
+    if risk and risk.entity_counts:
+        detection = ", ".join(
+            f"{label}: {count}" for label, count in sorted(risk.entity_counts.items())
+        )
+    else:
+        detection = "no sensitive entities detected"
+    total = risk.count if risk else 0
+
+    escalations = (
+        ", ".join(r.escalation or "human feedback" for r in escalation_log)
+        if escalation_log
+        else "none"
+    )
+
+    if verdict is not None:
+        probe = verdict.vector.value if verdict.vector else "none"
+        gate_verdict = (
+            f"adversary cleared the context (strongest probe {probe} "
+            f"at confidence {verdict.confidence:.2f})"
+        )
+    else:
+        gate_verdict = "adversary verdict unavailable"
+
+    return "\n".join(
+        [
+            "Pre-cloud privacy review",
+            f"- Domain: {domain}",
+            f"- Detected (type: count): {detection}",
+            f"- Total sensitive spans: {total}",
+            f"- Sanitization strategy: {strategy}",
+            f"- Escalation iterations: {iteration} ({escalations})",
+            f"- Gate verdict: {gate_verdict}",
+        ]
+    )
+
+
+class HITLGateAgent(BaseAgent):
+    """Human approval gate at the pre-cloud trust boundary."""
+
+    state_schema = PrivacyState
+    node_name = "gate"
+
+    def __init__(
+        self,
+        config: PrivacyConfig,
+        checkpointer: Optional[BaseCheckpointSaver] = None,
+    ):
+        self._interactive = bool(config.interactive)
+        super().__init__(config, llm_config=None, checkpointer=checkpointer)
+
+    @classmethod
+    def from_config(
+        cls,
+        config: Union[PrivacyConfig, str, dict],
+        checkpointer: Optional[BaseCheckpointSaver] = None,
+    ) -> Self:
+        if not isinstance(config, PrivacyConfig):
+            config = load_config(config, PrivacyConfig)
+        return cls(config, checkpointer=checkpointer)
+
+    def _node(self, state: PrivacyState) -> PrivacyState:
+        """Build the summary and, when interactive, pause for human approval."""
+        summary = build_gate_summary(state)
+        if not self._interactive:
+            return PrivacyState(
+                summary=summary, approved=True, outcome=PreCloudOutcome.APPROVED
+            )
+        base = {"summary": summary, "options": _gate_options()}
+        payload = base
+        resume: object = None
+        decision = None
+        while decision is None:  # re-prompt until the human gives a valid choice
+            resume = interrupt(payload)
+            decision = _interpret_decision(resume)
+            if decision is None:
+                payload = {
+                    **base,
+                    "error": "Unrecognized choice: reply with 1, 2, or 3.",
+                }
+        if decision is GateDecision.APPROVE:
+            return PrivacyState(
+                summary=summary, approved=True, outcome=PreCloudOutcome.APPROVED
+            )
+        if decision is GateDecision.REJECT:
+            return PrivacyState(
+                summary=summary, approved=False, outcome=PreCloudOutcome.REJECTED
+            )
+
+        # Else re-enter the privacy pipeline with Analyzer next
+        return PrivacyState(
+            summary=summary,
+            approved=False,
+            outcome=PreCloudOutcome.RE_LOOPED,
+            human_feedback=_extract_feedback(resume),
+        )

--- a/src/mmore/privacy/agents/gate.py
+++ b/src/mmore/privacy/agents/gate.py
@@ -19,6 +19,7 @@ from typing_extensions import Self
 
 from ...utils import load_config
 from ..config import PrivacyConfig
+from ..leakage import SAFE_VERDICT
 from .base import BaseAgent
 from .state import PreCloudOutcome, PrivacyState
 
@@ -114,14 +115,15 @@ def build_gate_summary(state: PrivacyState) -> str:
         else "none"
     )
 
-    if verdict is not None:
-        probe = verdict.vector.value if verdict.vector else "none"
+    if verdict is None:
+        gate_verdict = "adversary verdict unavailable"
+    elif verdict == SAFE_VERDICT or verdict.vector is None:
+        gate_verdict = "adversary did not probe (disabled or no sanitized context)"
+    else:
         gate_verdict = (
-            f"adversary cleared the context (strongest probe {probe} "
+            f"adversary cleared the context (strongest probe {verdict.vector.value} "
             f"at confidence {verdict.confidence:.2f})"
         )
-    else:
-        gate_verdict = "adversary verdict unavailable"
 
     return "\n".join(
         [

--- a/src/mmore/privacy/agents/gate.py
+++ b/src/mmore/privacy/agents/gate.py
@@ -143,7 +143,7 @@ class HITLGateAgent(BaseAgent):
         config: PrivacyConfig,
         checkpointer: Optional[BaseCheckpointSaver] = None,
     ):
-        self._interactive = bool(config.interactive)
+        self._interactive = config.interactive
         super().__init__(config, llm_config=None, checkpointer=checkpointer)
 
     @classmethod

--- a/src/mmore/privacy/agents/gate.py
+++ b/src/mmore/privacy/agents/gate.py
@@ -39,7 +39,6 @@ _GATE_CHOICES: List[Tuple[GateDecision, str]] = [
     (GateDecision.REJECT, "Reject: abort the request"),
 ]
 _CHOICE_BY_NUMBER = {i + 1: decision for i, (decision, _) in enumerate(_GATE_CHOICES)}
-_DECISION_BY_VALUE = {decision.value: decision for decision, _ in _GATE_CHOICES}
 
 
 def _gate_options() -> List[dict]:
@@ -52,6 +51,8 @@ def _gate_options() -> List[dict]:
 
 def _as_choice_number(value: object) -> Optional[int]:
     """Read a menu number from an int or numeric string."""
+    if isinstance(value, bool):
+        return None
     if isinstance(value, int):
         return value
     if isinstance(value, str) and value.strip().isdigit():
@@ -61,13 +62,17 @@ def _as_choice_number(value: object) -> Optional[int]:
 
 def _interpret_decision(decision: object) -> Optional[GateDecision]:
     """Map a resume value (a menu number, an action name, or a dict) to a decision."""
+    if isinstance(decision, dict):
+        return _interpret_decision(decision.get("choice") or decision.get("action"))
+
     number = _as_choice_number(decision)
     if number is not None:
         return _CHOICE_BY_NUMBER.get(number)
     if isinstance(decision, str):
-        return _DECISION_BY_VALUE.get(decision.strip().lower())
-    if isinstance(decision, dict):
-        return _interpret_decision(decision.get("choice"))
+        try:
+            return GateDecision(decision.strip().lower())
+        except ValueError:
+            return None
     return None
 
 

--- a/src/mmore/privacy/agents/gate.py
+++ b/src/mmore/privacy/agents/gate.py
@@ -11,7 +11,7 @@ that was done and pauses for human approval via an interruption on the graph.
 
 import logging
 from enum import Enum
-from typing import List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple
 
 from langgraph.checkpoint.base import BaseCheckpointSaver
 from langgraph.types import interrupt
@@ -41,7 +41,7 @@ _GATE_CHOICES: List[Tuple[GateDecision, str]] = [
 _CHOICE_BY_NUMBER = {i + 1: decision for i, (decision, _) in enumerate(_GATE_CHOICES)}
 
 
-def _gate_options() -> List[dict]:
+def _gate_options() -> List[Dict[str, int | str]]:
     """The numbered menu surfaced to the human in the interrupt payload."""
     return [
         {"choice": i + 1, "action": decision.value, "label": label}
@@ -49,7 +49,7 @@ def _gate_options() -> List[dict]:
     ]
 
 
-def _as_choice_number(value: object) -> Optional[int]:
+def _as_choice_number(value: int | str | None) -> Optional[int]:
     """Read a menu number from an int or numeric string."""
     if isinstance(value, bool):
         return None
@@ -60,7 +60,9 @@ def _as_choice_number(value: object) -> Optional[int]:
     return None
 
 
-def _interpret_decision(decision: object) -> Optional[GateDecision]:
+def _interpret_decision(
+    decision: Dict[str, int | str | None] | int | str | None,
+) -> Optional[GateDecision]:
     """Map a resume value (a menu number, an action name, or a dict) to a decision."""
     if isinstance(decision, dict):
         return _interpret_decision(decision.get("choice") or decision.get("action"))
@@ -76,7 +78,9 @@ def _interpret_decision(decision: object) -> Optional[GateDecision]:
     return None
 
 
-def _extract_feedback(decision: object) -> Optional[str]:
+def _extract_feedback(
+    decision: Dict[str, int | str | None] | int | str | None,
+) -> Optional[str]:
     """Pull the human's free-text guidance from a structured resume value."""
     if isinstance(decision, dict):
         value = decision.get("feedback")
@@ -149,7 +153,7 @@ class HITLGateAgent(BaseAgent):
     @classmethod
     def from_config(
         cls,
-        config: Union[PrivacyConfig, str, dict],
+        config: PrivacyConfig | str,
         checkpointer: Optional[BaseCheckpointSaver] = None,
     ) -> Self:
         if not isinstance(config, PrivacyConfig):
@@ -165,7 +169,7 @@ class HITLGateAgent(BaseAgent):
             )
         base = {"summary": summary, "options": _gate_options()}
         payload = base
-        resume: object = None
+        resume = None
         decision = None
         while decision is None:  # re-prompt until the human gives a valid choice
             resume = interrupt(payload)

--- a/src/mmore/privacy/agents/sanitizer.py
+++ b/src/mmore/privacy/agents/sanitizer.py
@@ -9,7 +9,7 @@ sanitization strategy from the tool registry and applies it to each chunk.
 """
 
 import logging
-from typing import Callable, List, Optional, Union
+from typing import Callable, List, Optional
 
 import dspy
 from langgraph.checkpoint.base import BaseCheckpointSaver
@@ -73,7 +73,7 @@ class SanitizerAgent(BaseAgent):
     @classmethod
     def from_config(
         cls,
-        config: Union[PrivacyConfig, str, dict],
+        config: PrivacyConfig | str,
         checkpointer: Optional[BaseCheckpointSaver] = None,
     ) -> Self:
         if not isinstance(config, PrivacyConfig):

--- a/src/mmore/privacy/agents/state.py
+++ b/src/mmore/privacy/agents/state.py
@@ -5,6 +5,7 @@ sanitizer -> leakage_adversary -> HITL gate. Each agent contributes a node
 that reads what it needs and writes its output back.
 """
 
+from enum import Enum
 from typing import List, Optional
 
 from ..detection.base import PIISpan
@@ -12,6 +13,15 @@ from ..leakage import EscalationRecord, LeakageVerdict
 from ..policy import PrivacyPolicy
 from ..risk import RiskAssessment
 from .base import NodeOutput
+
+
+class PreCloudOutcome(str, Enum):
+    """Outcome of a request at the pre-cloud trust boundary."""
+
+    APPROVED = "approved"
+    RE_LOOPED = "re-looped"
+    ABORTED = "aborted"  # leak loop exhausted
+    REJECTED = "rejected"
 
 
 class PrivacyState(NodeOutput, total=False):
@@ -32,10 +42,12 @@ class PrivacyState(NodeOutput, total=False):
     # Leakage adversary + escalation loop
     verdict: Optional[LeakageVerdict]
     safe: bool
-    iteration: int
+    iteration: int  # total escalations
+    leak_iterations: int  # leak-driven escalations only
     escalation_log: List[EscalationRecord]
 
     # Pre-cloud HITL gate
     summary: str
     approved: Optional[bool]
-    outcome: Optional[str]
+    outcome: Optional[PreCloudOutcome]
+    human_feedback: Optional[str]

--- a/src/mmore/privacy/agents/state.py
+++ b/src/mmore/privacy/agents/state.py
@@ -1,13 +1,14 @@
 """Shared state for the privacy pipeline graph.
 
 A single ``StateGraph(PrivacyState)`` flows through analyzer -> detector ->
-sanitizer (and more later). Each agent contributes a node that reads what
-it needs and writes its output back.
+sanitizer -> leakage_adversary -> HITL gate. Each agent contributes a node
+that reads what it needs and writes its output back.
 """
 
 from typing import List, Optional
 
 from ..detection.base import PIISpan
+from ..leakage import EscalationRecord, LeakageVerdict
 from ..policy import PrivacyPolicy
 from ..risk import RiskAssessment
 from .base import NodeOutput
@@ -27,3 +28,14 @@ class PrivacyState(NodeOutput, total=False):
     spans: List[List[PIISpan]]
     risk: Optional[RiskAssessment]
     sanitized_chunks: List[str]
+
+    # Leakage adversary + escalation loop
+    verdict: Optional[LeakageVerdict]
+    safe: bool
+    iteration: int
+    escalation_log: List[EscalationRecord]
+
+    # Pre-cloud HITL gate
+    summary: str
+    approved: Optional[bool]
+    outcome: Optional[str]

--- a/src/mmore/privacy/config.py
+++ b/src/mmore/privacy/config.py
@@ -25,6 +25,16 @@ class SanitizationStrategyType(str, Enum):
     PRESIDIO = "presidio"
 
 
+class AttackVector(str, Enum):
+    """Adversarial attack vectors probed by the leakage adversary."""
+
+    RESIDUAL_SPAN = "residual_span"
+    QUASI_IDENTIFIER = "quasi_identifier"
+    STRUCTURAL_REID = "structural_reid"
+    CONTEXT_RECONSTRUCTION = "context_reconstruction"
+    MEMBERSHIP_INFERENCE = "membership_inference"
+
+
 @dataclass
 class AnalyzerConfig:
     llm: LLMConfig
@@ -47,8 +57,20 @@ class SanitizationConfig:
 
 
 @dataclass
+class LeakageAdversaryConfig:
+    max_iterations: int = 3
+    leakage_threshold: float = 0.1
+    strategies: List[AttackVector] = field(default_factory=lambda: list(AttackVector))
+    llm: Optional[LLMConfig] = None
+
+
+@dataclass
 class PrivacyConfig:
     domain: Optional[str] = None
+    interactive: Optional[bool] = None
     context_analyzer: Optional[AnalyzerConfig] = None
     detection: DetectionConfig = field(default_factory=DetectionConfig)
     sanitization: SanitizationConfig = field(default_factory=SanitizationConfig)
+    leakage_adversary: LeakageAdversaryConfig = field(
+        default_factory=LeakageAdversaryConfig
+    )

--- a/src/mmore/privacy/config.py
+++ b/src/mmore/privacy/config.py
@@ -68,7 +68,7 @@ class LeakageAdversaryConfig:
 @dataclass
 class PrivacyConfig:
     domain: Optional[str] = None
-    interactive: Optional[bool] = None
+    interactive: bool = False
     context_analyzer: Optional[AnalyzerConfig] = None
     detection: DetectionConfig = field(default_factory=DetectionConfig)
     sanitization: SanitizationConfig = field(default_factory=SanitizationConfig)

--- a/src/mmore/privacy/config.py
+++ b/src/mmore/privacy/config.py
@@ -58,6 +58,7 @@ class SanitizationConfig:
 
 @dataclass
 class LeakageAdversaryConfig:
+    enabled: bool = True
     max_iterations: int = 3
     leakage_threshold: float = 0.1
     strategies: List[AttackVector] = field(default_factory=lambda: list(AttackVector))

--- a/src/mmore/privacy/escalation.py
+++ b/src/mmore/privacy/escalation.py
@@ -1,30 +1,31 @@
 """Bounded escalation of the privacy policy for the leakage loop.
 
 When the leakage adversary flags the sanitized context, the loop re-enters the
-Detector and Sanitizer under a stricter policy. ``escalate_policy`` returns a
-new, more aggressive ``PrivacyPolicy`` (it never mutates its input) plus a
-short label of what changed, for the escalation log read by PR #7.
-
-The escalation ladder follows the spec: merge the analyzer's leak-targeted
-entity labels, then lower the detection threshold, then bring in a detection
-engine not used on the previous pass, then switch to a stricter sanitization
-strategy (masking -> synthetic rewrite). Steps apply cumulatively because each
-call receives the policy already escalated by the previous iterations.
-"""
+Detector and Sanitizer under a stricter policy. Returns a new and stricter
+PrivacyPolicy plus a short label of what changed."""
 
 from dataclasses import replace
 from typing import Callable, List, Optional, Tuple
 
+from .config import DetectionEngineType, SanitizationStrategyType
 from .policy import PrivacyPolicy
 
 _CONFIDENCE_FLOOR = 0.1
 _THRESHOLD_DECAY = 0.5
 
 # Detection-engine ladder (might change after experiments)
-_ENGINE_LADDER = ["presidio", "gliner", "llm"]
+_ENGINE_LADDER = [
+    DetectionEngineType.PRESIDIO.value,
+    DetectionEngineType.GLINER.value,
+    DetectionEngineType.LLM.value,
+]
 
 # Stricter-sanitization ladder (might change after experiments)
-_STRATEGY_LADDER = ["token_masking", "entity_replacement", "synthetic_rewrite"]
+_STRATEGY_LADDER = [
+    SanitizationStrategyType.TOKEN_MASKING.value,
+    SanitizationStrategyType.ENTITY_REPLACEMENT.value,
+    SanitizationStrategyType.SYNTHETIC_REWRITE.value,
+]
 
 _ESCALATION_NOTE = (
     "Escalation: a prior sanitization pass leaked: treat every quasi-identifier "
@@ -42,16 +43,23 @@ def _next_in_ladder(ladder: List[str], current: str, cap: bool) -> str:
     return ladder[nxt]
 
 
-def _broaden_entities(
-    policy: PrivacyPolicy, extra_entities: Optional[List[str]]
+def apply_entity_guidance(
+    policy: PrivacyPolicy,
+    extra_entities: Optional[List[str]] = None,
+    context_note: Optional[str] = None,
 ) -> PrivacyPolicy:
-    """Merge the analyzer's leak-targeted labels and pin the escalation note."""
+    """Merge targeted entity labels and pin the escalation note plus any human
+    guidance into the domain prompt."""
     entities = list(policy.sensitive_entities) + [
         e for e in (extra_entities or []) if e not in policy.sensitive_entities
     ]
     prompt = policy.domain_prompt
     if _ESCALATION_NOTE not in prompt:
         prompt = prompt + _ESCALATION_NOTE
+    if context_note:
+        guidance = f" Human guidance: {context_note}"
+        if guidance not in prompt:
+            prompt = prompt + guidance
     return replace(policy, sensitive_entities=entities, domain_prompt=prompt)
 
 
@@ -86,12 +94,7 @@ def escalate_policy(
     iteration: int,
     extra_entities: Optional[List[str]] = None,
 ) -> Tuple[PrivacyPolicy, str]:
-    """Return a stricter ``PrivacyPolicy`` and a label for the escalation log.
-
-    Each round merges the analyzer's leak-targeted ``extra_entities`` (if any)
-    and applies one progressive knob: lower threshold, then switch detection
-    engine, then stricter sanitization.
-    """
-    broadened = _broaden_entities(policy, extra_entities)
+    """Return a stricter ``PrivacyPolicy`` and a label for the escalation log."""
+    broadened = apply_entity_guidance(policy, extra_entities)
     step = _STEPS[min(iteration, len(_STEPS) - 1)]
     return step(broadened)

--- a/src/mmore/privacy/escalation.py
+++ b/src/mmore/privacy/escalation.py
@@ -1,0 +1,97 @@
+"""Bounded escalation of the privacy policy for the leakage loop.
+
+When the leakage adversary flags the sanitized context, the loop re-enters the
+Detector and Sanitizer under a stricter policy. ``escalate_policy`` returns a
+new, more aggressive ``PrivacyPolicy`` (it never mutates its input) plus a
+short label of what changed, for the escalation log read by PR #7.
+
+The escalation ladder follows the spec: merge the analyzer's leak-targeted
+entity labels, then lower the detection threshold, then bring in a detection
+engine not used on the previous pass, then switch to a stricter sanitization
+strategy (masking -> synthetic rewrite). Steps apply cumulatively because each
+call receives the policy already escalated by the previous iterations.
+"""
+
+from dataclasses import replace
+from typing import Callable, List, Optional, Tuple
+
+from .policy import PrivacyPolicy
+
+_CONFIDENCE_FLOOR = 0.1
+_THRESHOLD_DECAY = 0.5
+
+# Detection-engine ladder (might change after experiments)
+_ENGINE_LADDER = ["presidio", "gliner", "llm"]
+
+# Stricter-sanitization ladder (might change after experiments)
+_STRATEGY_LADDER = ["token_masking", "entity_replacement", "synthetic_rewrite"]
+
+_ESCALATION_NOTE = (
+    "Escalation: a prior sanitization pass leaked: treat every quasi-identifier "
+    "and rare attribute as sensitive and redact aggressively."
+)
+
+
+def _next_in_ladder(ladder: List[str], current: str, cap: bool) -> str:
+    """Next entry after ``current``, cap at the last entry or wrap around."""
+    if current not in ladder:
+        return ladder[0]
+    nxt = ladder.index(current) + 1
+    if nxt >= len(ladder):
+        return ladder[-1] if cap else ladder[0]
+    return ladder[nxt]
+
+
+def _broaden_entities(
+    policy: PrivacyPolicy, extra_entities: Optional[List[str]]
+) -> PrivacyPolicy:
+    """Merge the analyzer's leak-targeted labels and pin the escalation note."""
+    entities = list(policy.sensitive_entities) + [
+        e for e in (extra_entities or []) if e not in policy.sensitive_entities
+    ]
+    prompt = policy.domain_prompt
+    if _ESCALATION_NOTE not in prompt:
+        prompt = prompt + _ESCALATION_NOTE
+    return replace(policy, sensitive_entities=entities, domain_prompt=prompt)
+
+
+def _lower_threshold(policy: PrivacyPolicy) -> Tuple[PrivacyPolicy, str]:
+    params = dict(policy.detection_params)
+    current = float(params.get("confidence_threshold", 0.7))
+    params["confidence_threshold"] = max(
+        _CONFIDENCE_FLOOR, round(current * _THRESHOLD_DECAY, 2)
+    )
+    return replace(policy, detection_params=params), "lower_threshold"
+
+
+def _switch_detection_engine(policy: PrivacyPolicy) -> Tuple[PrivacyPolicy, str]:
+    nxt = _next_in_ladder(_ENGINE_LADDER, policy.detection_engine, cap=False)
+    return replace(policy, detection_engine=nxt), f"switch_engine_to_{nxt}"
+
+
+def _stricter_sanitization(policy: PrivacyPolicy) -> Tuple[PrivacyPolicy, str]:
+    nxt = _next_in_ladder(_STRATEGY_LADDER, policy.sanitization_strategy, cap=True)
+    return replace(policy, sanitization_strategy=nxt), f"stricter_strategy_{nxt}"
+
+
+_STEPS: List[Callable[[PrivacyPolicy], Tuple[PrivacyPolicy, str]]] = [
+    _lower_threshold,
+    _switch_detection_engine,
+    _stricter_sanitization,
+]
+
+
+def escalate_policy(
+    policy: PrivacyPolicy,
+    iteration: int,
+    extra_entities: Optional[List[str]] = None,
+) -> Tuple[PrivacyPolicy, str]:
+    """Return a stricter ``PrivacyPolicy`` and a label for the escalation log.
+
+    Each round merges the analyzer's leak-targeted ``extra_entities`` (if any)
+    and applies one progressive knob: lower threshold, then switch detection
+    engine, then stricter sanitization.
+    """
+    broadened = _broaden_entities(policy, extra_entities)
+    step = _STEPS[min(iteration, len(_STEPS) - 1)]
+    return step(broadened)

--- a/src/mmore/privacy/escalation.py
+++ b/src/mmore/privacy/escalation.py
@@ -5,10 +5,7 @@ from typing import List, Optional
 
 from .policy import PrivacyPolicy
 
-_ESCALATION_NOTE = (
-    "Escalation: a prior sanitization pass leaked: treat every quasi-identifier "
-    "and rare attribute as sensitive and redact aggressively."
-)
+_ESCALATION_NOTE = "Escalation: a prior sanitization pass leaked, or was not in line with the user's needs."
 
 
 def apply_entity_guidance(
@@ -17,10 +14,11 @@ def apply_entity_guidance(
     context_note: Optional[str] = None,
     note_label: str = "Human guidance",
 ) -> PrivacyPolicy:
-    """Merge entity labels; pin the escalation note and guidance into the prompt."""
-    entities = list(policy.sensitive_entities) + [
-        e for e in (extra_entities or []) if e not in policy.sensitive_entities
-    ]
+    """Merge entity labels, add the escalation note and guidance into the prompt."""
+    entities = list(policy.sensitive_entities)
+    for e in extra_entities or []:
+        if e not in entities:
+            entities.append(e)
     prompt = policy.domain_prompt
     if _ESCALATION_NOTE not in prompt:
         prompt += " " + _ESCALATION_NOTE

--- a/src/mmore/privacy/escalation.py
+++ b/src/mmore/privacy/escalation.py
@@ -55,11 +55,11 @@ def apply_entity_guidance(
     ]
     prompt = policy.domain_prompt
     if _ESCALATION_NOTE not in prompt:
-        prompt = prompt + _ESCALATION_NOTE
+        prompt += " " + _ESCALATION_NOTE
     if context_note:
-        guidance = f" Human guidance: {context_note}"
+        guidance = f"Human guidance: {context_note}"
         if guidance not in prompt:
-            prompt = prompt + guidance
+            prompt += " " + guidance
     return replace(policy, sensitive_entities=entities, domain_prompt=prompt)
 
 

--- a/src/mmore/privacy/escalation.py
+++ b/src/mmore/privacy/escalation.py
@@ -1,31 +1,9 @@
-"""Bounded escalation of the privacy policy for the leakage loop.
-
-When the leakage adversary flags the sanitized context, the loop re-enters the
-Detector and Sanitizer under a stricter policy. Returns a new and stricter
-PrivacyPolicy plus a short label of what changed."""
+"""Policy hardening on re-entry: merge entity labels, pin guidance in the prompt."""
 
 from dataclasses import replace
-from typing import Callable, List, Optional, Tuple
+from typing import List, Optional
 
-from .config import DetectionEngineType, SanitizationStrategyType
 from .policy import PrivacyPolicy
-
-_CONFIDENCE_FLOOR = 0.1
-_THRESHOLD_DECAY = 0.5
-
-# Detection-engine ladder (might change after experiments)
-_ENGINE_LADDER = [
-    DetectionEngineType.PRESIDIO.value,
-    DetectionEngineType.GLINER.value,
-    DetectionEngineType.LLM.value,
-]
-
-# Stricter-sanitization ladder (might change after experiments)
-_STRATEGY_LADDER = [
-    SanitizationStrategyType.TOKEN_MASKING.value,
-    SanitizationStrategyType.ENTITY_REPLACEMENT.value,
-    SanitizationStrategyType.SYNTHETIC_REWRITE.value,
-]
 
 _ESCALATION_NOTE = (
     "Escalation: a prior sanitization pass leaked: treat every quasi-identifier "
@@ -33,23 +11,13 @@ _ESCALATION_NOTE = (
 )
 
 
-def _next_in_ladder(ladder: List[str], current: str, cap: bool) -> str:
-    """Next entry after ``current``, cap at the last entry or wrap around."""
-    if current not in ladder:
-        return ladder[0]
-    nxt = ladder.index(current) + 1
-    if nxt >= len(ladder):
-        return ladder[-1] if cap else ladder[0]
-    return ladder[nxt]
-
-
 def apply_entity_guidance(
     policy: PrivacyPolicy,
     extra_entities: Optional[List[str]] = None,
     context_note: Optional[str] = None,
+    note_label: str = "Human guidance",
 ) -> PrivacyPolicy:
-    """Merge targeted entity labels and pin the escalation note plus any human
-    guidance into the domain prompt."""
+    """Merge entity labels; pin the escalation note and guidance into the prompt."""
     entities = list(policy.sensitive_entities) + [
         e for e in (extra_entities or []) if e not in policy.sensitive_entities
     ]
@@ -57,44 +25,7 @@ def apply_entity_guidance(
     if _ESCALATION_NOTE not in prompt:
         prompt += " " + _ESCALATION_NOTE
     if context_note:
-        guidance = f"Human guidance: {context_note}"
+        guidance = f"{note_label}: {context_note}"
         if guidance not in prompt:
             prompt += " " + guidance
     return replace(policy, sensitive_entities=entities, domain_prompt=prompt)
-
-
-def _lower_threshold(policy: PrivacyPolicy) -> Tuple[PrivacyPolicy, str]:
-    params = dict(policy.detection_params)
-    current = float(params.get("confidence_threshold", 0.7))
-    params["confidence_threshold"] = max(
-        _CONFIDENCE_FLOOR, round(current * _THRESHOLD_DECAY, 2)
-    )
-    return replace(policy, detection_params=params), "lower_threshold"
-
-
-def _switch_detection_engine(policy: PrivacyPolicy) -> Tuple[PrivacyPolicy, str]:
-    nxt = _next_in_ladder(_ENGINE_LADDER, policy.detection_engine, cap=False)
-    return replace(policy, detection_engine=nxt), f"switch_engine_to_{nxt}"
-
-
-def _stricter_sanitization(policy: PrivacyPolicy) -> Tuple[PrivacyPolicy, str]:
-    nxt = _next_in_ladder(_STRATEGY_LADDER, policy.sanitization_strategy, cap=True)
-    return replace(policy, sanitization_strategy=nxt), f"stricter_strategy_{nxt}"
-
-
-_STEPS: List[Callable[[PrivacyPolicy], Tuple[PrivacyPolicy, str]]] = [
-    _lower_threshold,
-    _switch_detection_engine,
-    _stricter_sanitization,
-]
-
-
-def escalate_policy(
-    policy: PrivacyPolicy,
-    iteration: int,
-    extra_entities: Optional[List[str]] = None,
-) -> Tuple[PrivacyPolicy, str]:
-    """Return a stricter ``PrivacyPolicy`` and a label for the escalation log."""
-    broadened = apply_entity_guidance(policy, extra_entities)
-    step = _STEPS[min(iteration, len(_STEPS) - 1)]
-    return step(broadened)

--- a/src/mmore/privacy/leakage.py
+++ b/src/mmore/privacy/leakage.py
@@ -1,6 +1,6 @@
 """The verdict produced by the pre-cloud Leakage Adversary.
 
-Emitted by the ``LeakageAdversaryAgent`` after probing the sanitized context
+Emitted by the ``AdversarialAgent`` after probing the sanitized context
 for residual PII and quasi-identifiers, and consumed by the escalation loop
 and the HITL gate.
 """

--- a/src/mmore/privacy/leakage.py
+++ b/src/mmore/privacy/leakage.py
@@ -1,0 +1,34 @@
+"""The verdict produced by the pre-cloud Leakage Adversary.
+
+Emitted by the ``LeakageAdversaryAgent`` after probing the sanitized context
+for residual PII and quasi-identifiers, and consumed by the escalation loop
+and the HITL gate.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class EscalationRecord:
+    """One escalation iteration: the leak that triggered it and the fix applied."""
+
+    iteration: int
+    vector: str
+    entity_type: str
+    escalation: str
+
+
+@dataclass
+class LeakageVerdict:
+    """Structured outcome of one adversarial probe over the sanitized context.
+
+    ``vector`` is the attack strategy that produced the strongest signal,
+    ``entity_type`` and ``evidence`` describe the residual identifier without
+    echoing the raw value beyond what is needed to justify the verdict.
+    """
+
+    leaked: bool
+    vector: str
+    entity_type: str
+    evidence: str
+    confidence: float

--- a/src/mmore/privacy/leakage.py
+++ b/src/mmore/privacy/leakage.py
@@ -1,34 +1,39 @@
 """The verdict produced by the pre-cloud Leakage Adversary.
 
-Emitted by the ``AdversarialAgent`` after probing the sanitized context
+Emitted by the AdversarialAgent after probing the sanitized context
 for residual PII and quasi-identifiers, and consumed by the escalation loop
 and the HITL gate.
 """
 
 from dataclasses import dataclass
+from typing import Optional
+
+from .config import AttackVector
 
 
 @dataclass
 class EscalationRecord:
-    """One escalation iteration: the leak that triggered it and the fix applied."""
+    """One escalation iteration: what triggered it and the fix applied."""
 
     iteration: int
-    vector: str
-    entity_type: str
-    escalation: str
+    escalation: Optional[str] = None
+    from_human_feedback: bool = False
+    vector: Optional[AttackVector] = None
+    entity_type: Optional[str] = None
 
 
 @dataclass
 class LeakageVerdict:
-    """Structured outcome of one adversarial probe over the sanitized context.
-
-    ``vector`` is the attack strategy that produced the strongest signal,
-    ``entity_type`` and ``evidence`` describe the residual identifier without
-    echoing the raw value beyond what is needed to justify the verdict.
-    """
+    """Structured outcome of one adversarial probe over the sanitized context."""
 
     leaked: bool
-    vector: str
-    entity_type: str
+    vector: Optional[AttackVector]
+    entity_type: Optional[str]
     evidence: str
     confidence: float
+
+
+# Verdict for a context with nothing to attack
+SAFE_VERDICT = LeakageVerdict(
+    leaked=False, vector=None, entity_type=None, evidence="", confidence=0.0
+)

--- a/src/mmore/privacy/leakage.py
+++ b/src/mmore/privacy/leakage.py
@@ -20,6 +20,7 @@ class EscalationRecord:
     from_human_feedback: bool = False
     vector: Optional[AttackVector] = None
     entity_type: Optional[str] = None
+    report: Optional[str] = None  # the guidance text for the escalation
 
 
 @dataclass
@@ -31,6 +32,7 @@ class LeakageVerdict:
     entity_type: Optional[str]
     evidence: str
     confidence: float
+    recommendation: Optional[str] = None
 
 
 # Verdict for a context with nothing to attack

--- a/src/mmore/privacy/pipeline.py
+++ b/src/mmore/privacy/pipeline.py
@@ -20,16 +20,16 @@ from langgraph.graph import END, START, StateGraph
 
 from .agents.adversary import AdversarialAgent
 from .agents.analyzer import ContextPolicyAnalyzerAgent
-from .agents.base import NodeOutput
 from .agents.detector import DetectorAgent
+from .agents.gate import HITLGateAgent
 from .agents.sanitizer import SanitizerAgent
-from .agents.state import PrivacyState
+from .agents.state import PreCloudOutcome, PrivacyState
 from .config import PrivacyConfig
 
 logger = logging.getLogger(__name__)
 
-# A pipeline node: reads the shared state and returns a partial update
-NodeFn = Callable[..., NodeOutput]
+# A pipeline node: reads the shared state and returns a partial PrivacyState
+NodeFn = Callable[..., PrivacyState]
 
 
 class _Node(str, Enum):
@@ -39,29 +39,43 @@ class _Node(str, Enum):
     DETECTOR = "detector"
     SANITIZER = "sanitizer"
     ADVERSARY = "leakage_adversary"
+    GATE = "gate"
     MARK_UNSAFE = "mark_unsafe"
 
 
 class _Route(str, Enum):
-    """Branches out of the adversary node in the pre-cloud loop."""
+    """Branches out of the adversary and gate nodes in the pre-cloud loop."""
 
     PROCEED = "proceed"
     ESCALATE = "escalate"
     UNSAFE = "unsafe"
+    REJECTED = "rejected"
 
 
 def _route_after_adversary(state: PrivacyState, max_iterations: int) -> _Route:
-    """Decide branch once the adversary attacked the sanitized context."""
+    """Decide branch once the adversary attacked the sanitized context.
+
+    Only leak-driven escalations count against ``max_iterations``.
+    """
     if state.get("safe", False):
         return _Route.PROCEED
-    if state.get("iteration", 0) >= max_iterations:
+    if state.get("leak_iterations", 0) >= max_iterations:
         return _Route.UNSAFE
+    return _Route.ESCALATE
+
+
+def _route_after_gate(state: PrivacyState) -> _Route:
+    """Decide branch once the gate has recorded the human's decision."""
+    if state.get("approved", False):
+        return _Route.PROCEED
+    if state.get("outcome") == PreCloudOutcome.REJECTED:
+        return _Route.REJECTED
     return _Route.ESCALATE
 
 
 def _mark_unsafe_node(state: PrivacyState) -> PrivacyState:
     """Terminal for an exhausted loop: the request cannot reach the gate."""
-    return PrivacyState(safe=False, outcome="aborted-unsafe")
+    return PrivacyState(safe=False, outcome=PreCloudOutcome.ABORTED)
 
 
 def build_pipeline_graph(
@@ -70,6 +84,7 @@ def build_pipeline_graph(
     detector: NodeFn,
     sanitizer: NodeFn,
     adversary: NodeFn,
+    gate: NodeFn,
     max_iterations: int = 3,
     checkpointer: Optional[BaseCheckpointSaver] = None,
 ):
@@ -79,6 +94,7 @@ def build_pipeline_graph(
     graph.add_node(_Node.DETECTOR, detector)
     graph.add_node(_Node.SANITIZER, sanitizer)
     graph.add_node(_Node.ADVERSARY, adversary)
+    graph.add_node(_Node.GATE, gate)
     graph.add_node(_Node.MARK_UNSAFE, _mark_unsafe_node)
 
     graph.add_edge(START, _Node.ANALYZER)
@@ -89,9 +105,18 @@ def build_pipeline_graph(
         _Node.ADVERSARY,
         lambda state: _route_after_adversary(state, max_iterations),
         {
-            _Route.PROCEED: END,
+            _Route.PROCEED: _Node.GATE,
             _Route.ESCALATE: _Node.ANALYZER,
             _Route.UNSAFE: _Node.MARK_UNSAFE,
+        },
+    )
+    graph.add_conditional_edges(
+        _Node.GATE,
+        _route_after_gate,
+        {
+            _Route.PROCEED: END,
+            _Route.REJECTED: END,
+            _Route.ESCALATE: _Node.ANALYZER,
         },
     )
     graph.add_edge(_Node.MARK_UNSAFE, END)
@@ -104,7 +129,7 @@ def build_privacy_pipeline(
 ):
     """Build the pre-cloud pipeline from a ``PrivacyConfig``.
 
-    The agents provide the node callables; the compiled graph owns the single
+    The agents provide the node callables: the compiled graph owns the single
     shared checkpointer (the agents are used only as node providers, so they
     are built without their own).
     """
@@ -112,11 +137,14 @@ def build_privacy_pipeline(
     detector = DetectorAgent.from_config(config)
     sanitizer = SanitizerAgent.from_config(config)
     adversary = AdversarialAgent.from_config(config)
+    gate = HITLGateAgent.from_config(config)
+
     return build_pipeline_graph(
-        analyzer=analyzer.node,
-        detector=detector.node,
-        sanitizer=sanitizer.node,
-        adversary=adversary.node,
+        analyzer=analyzer._node,
+        detector=detector._node,
+        sanitizer=sanitizer._node,
+        adversary=adversary._node,
+        gate=gate._node,
         max_iterations=config.leakage_adversary.max_iterations,
         checkpointer=checkpointer,
     )

--- a/src/mmore/privacy/pipeline.py
+++ b/src/mmore/privacy/pipeline.py
@@ -1,0 +1,117 @@
+"""Pre-cloud privacy pipeline graph.
+
+Wires the graph that runs the chain
+
+    analyzer -> detector -> sanitizer -> leakage_adversary -> (HITL gate)
+
+with a bounded escalation loop. The analyzer is the single policy authority:
+when the adversary flags a leak and the iteration budget is not spent, the
+graph loops back to the analyzer, which escalates the policy before the chain
+re-detects and re-sanitizes. On exhaustion the request is marked unsafe and
+cannot proceed.
+"""
+
+import logging
+from enum import Enum
+from typing import Callable, Optional
+
+from langgraph.checkpoint.base import BaseCheckpointSaver
+from langgraph.graph import END, START, StateGraph
+
+from .agents.adversary import AdversarialAgent
+from .agents.analyzer import ContextPolicyAnalyzerAgent
+from .agents.base import NodeOutput
+from .agents.detector import DetectorAgent
+from .agents.sanitizer import SanitizerAgent
+from .agents.state import PrivacyState
+from .config import PrivacyConfig
+
+logger = logging.getLogger(__name__)
+
+# A pipeline node: reads the shared state and returns a partial update
+NodeFn = Callable[..., NodeOutput]
+
+
+class _Route(str, Enum):
+    """Branches out of the adversary node in the pre-cloud loop."""
+
+    PROCEED = "proceed"
+    ESCALATE = "escalate"
+    UNSAFE = "unsafe"
+
+
+def _route_after_adversary(state: PrivacyState, max_iterations: int) -> _Route:
+    """Decide branch once the adversary attacked the sanitized context."""
+    if state.get("safe", False):
+        return _Route.PROCEED
+    if state.get("iteration", 0) >= max_iterations:
+        return _Route.UNSAFE
+    return _Route.ESCALATE
+
+
+def _mark_unsafe_node(state: PrivacyState) -> PrivacyState:
+    """Terminal for an exhausted loop: the request cannot reach the gate."""
+    return PrivacyState(safe=False, outcome="aborted-unsafe")
+
+
+def build_pipeline_graph(
+    *,
+    analyzer: NodeFn,
+    detector: NodeFn,
+    sanitizer: NodeFn,
+    adversary: NodeFn,
+    max_iterations: int = 3,
+    checkpointer: Optional[BaseCheckpointSaver] = None,
+):
+    """Compile the pre-cloud loop from explicit node callables.
+
+    On a leak the adversary routes back to the analyzer, which escalates the
+    policy. ``_PROCEED`` routes to ``END`` here; PR #4's HITL gate (and PR #5
+    beyond it) replace that terminal edge with the gate node.
+    """
+    graph = StateGraph(PrivacyState)
+    graph.add_node("analyzer", analyzer)
+    graph.add_node("detector", detector)
+    graph.add_node("sanitizer", sanitizer)
+    graph.add_node("leakage_adversary", adversary)
+    graph.add_node("mark_unsafe", _mark_unsafe_node)
+
+    graph.add_edge(START, "analyzer")
+    graph.add_edge("analyzer", "detector")
+    graph.add_edge("detector", "sanitizer")
+    graph.add_edge("sanitizer", "leakage_adversary")
+    graph.add_conditional_edges(
+        "leakage_adversary",
+        lambda state: _route_after_adversary(state, max_iterations),
+        {
+            _Route.PROCEED: END,
+            _Route.ESCALATE: "analyzer",
+            _Route.UNSAFE: "mark_unsafe",
+        },
+    )
+    graph.add_edge("mark_unsafe", END)
+    return graph.compile(checkpointer=checkpointer)
+
+
+def build_privacy_pipeline(
+    config: PrivacyConfig,
+    checkpointer: Optional[BaseCheckpointSaver] = None,
+):
+    """Build the pre-cloud pipeline from a ``PrivacyConfig``.
+
+    The agents provide the node callables; the compiled graph owns the single
+    shared checkpointer (the agents are used only as node providers, so they
+    are built without their own).
+    """
+    analyzer = ContextPolicyAnalyzerAgent.from_config(config)
+    detector = DetectorAgent.from_config(config)
+    sanitizer = SanitizerAgent.from_config(config)
+    adversary = AdversarialAgent.from_config(config)
+    return build_pipeline_graph(
+        analyzer=analyzer.node,
+        detector=detector.node,
+        sanitizer=sanitizer.node,
+        adversary=adversary.node,
+        max_iterations=config.leakage_adversary.max_iterations,
+        checkpointer=checkpointer,
+    )

--- a/src/mmore/privacy/pipeline.py
+++ b/src/mmore/privacy/pipeline.py
@@ -32,6 +32,16 @@ logger = logging.getLogger(__name__)
 NodeFn = Callable[..., NodeOutput]
 
 
+class _Node(str, Enum):
+    """Graph node ids in the pre-cloud pipeline."""
+
+    ANALYZER = "analyzer"
+    DETECTOR = "detector"
+    SANITIZER = "sanitizer"
+    ADVERSARY = "leakage_adversary"
+    MARK_UNSAFE = "mark_unsafe"
+
+
 class _Route(str, Enum):
     """Branches out of the adversary node in the pre-cloud loop."""
 
@@ -63,33 +73,28 @@ def build_pipeline_graph(
     max_iterations: int = 3,
     checkpointer: Optional[BaseCheckpointSaver] = None,
 ):
-    """Compile the pre-cloud loop from explicit node callables.
-
-    On a leak the adversary routes back to the analyzer, which escalates the
-    policy. ``_PROCEED`` routes to ``END`` here; PR #4's HITL gate (and PR #5
-    beyond it) replace that terminal edge with the gate node.
-    """
+    """Compile the pre-cloud loop from explicit node callables."""
     graph = StateGraph(PrivacyState)
-    graph.add_node("analyzer", analyzer)
-    graph.add_node("detector", detector)
-    graph.add_node("sanitizer", sanitizer)
-    graph.add_node("leakage_adversary", adversary)
-    graph.add_node("mark_unsafe", _mark_unsafe_node)
+    graph.add_node(_Node.ANALYZER, analyzer)
+    graph.add_node(_Node.DETECTOR, detector)
+    graph.add_node(_Node.SANITIZER, sanitizer)
+    graph.add_node(_Node.ADVERSARY, adversary)
+    graph.add_node(_Node.MARK_UNSAFE, _mark_unsafe_node)
 
-    graph.add_edge(START, "analyzer")
-    graph.add_edge("analyzer", "detector")
-    graph.add_edge("detector", "sanitizer")
-    graph.add_edge("sanitizer", "leakage_adversary")
+    graph.add_edge(START, _Node.ANALYZER)
+    graph.add_edge(_Node.ANALYZER, _Node.DETECTOR)
+    graph.add_edge(_Node.DETECTOR, _Node.SANITIZER)
+    graph.add_edge(_Node.SANITIZER, _Node.ADVERSARY)
     graph.add_conditional_edges(
-        "leakage_adversary",
+        _Node.ADVERSARY,
         lambda state: _route_after_adversary(state, max_iterations),
         {
             _Route.PROCEED: END,
-            _Route.ESCALATE: "analyzer",
-            _Route.UNSAFE: "mark_unsafe",
+            _Route.ESCALATE: _Node.ANALYZER,
+            _Route.UNSAFE: _Node.MARK_UNSAFE,
         },
     )
-    graph.add_edge("mark_unsafe", END)
+    graph.add_edge(_Node.MARK_UNSAFE, END)
     return graph.compile(checkpointer=checkpointer)
 
 

--- a/src/mmore/privacy/pipeline.py
+++ b/src/mmore/privacy/pipeline.py
@@ -13,7 +13,7 @@ cannot proceed.
 
 import logging
 from enum import Enum
-from typing import Callable, Optional
+from typing import Optional, Protocol
 
 from langgraph.checkpoint.base import BaseCheckpointSaver
 from langgraph.graph import END, START, StateGraph
@@ -28,8 +28,10 @@ from .config import PrivacyConfig
 
 logger = logging.getLogger(__name__)
 
+
 # A pipeline node: reads the shared state and returns a partial PrivacyState
-NodeFn = Callable[..., PrivacyState]
+class NodeFn(Protocol):
+    def __call__(self, state: PrivacyState) -> PrivacyState: ...
 
 
 class _Node(str, Enum):

--- a/src/mmore/privacy/sanitization/constants.py
+++ b/src/mmore/privacy/sanitization/constants.py
@@ -9,3 +9,21 @@ SANITIZATION_TOOL_NAMES: Dict[str, str] = {
     "synthetic_rewrite": "sanitize_synthetic_rewrite",
     "presidio": "sanitize_presidio",
 }
+
+
+# Per-strategy guidance so the analyzer can map descriptive feedback to a choice
+SANITIZATION_GUIDANCE: Dict[str, str] = {
+    "token_masking": (
+        "replace each detected entity with a typed placeholder like [PERSON_1], "
+        "the original value is removed entirely"
+    ),
+    "entity_replacement": (
+        "swap each entity for a realistic fake value (Faker), consistent per "
+        "subject across chunks, keeps the text natural while hiding the real value"
+    ),
+    "synthetic_rewrite": (
+        "an LLM rewrites the passage so it carries no identifiers while "
+        "preserving the domain meaning"
+    ),
+    "presidio": "apply Presidio's built-in anonymization operators to detected spans",
+}


### PR DESCRIPTION
## Summary

Related issue: #294
Depends on: #337

_Note that these commits were originally on a fork repo, a rebase was needed to target the branch on the origin repo `feat/privacy-agents-clean`_

The privacy pipeline cleaned the retrieved context but never checked that the cleaned text was actually safe before sending it to the cloud model. After cleaning, an adversary agent looks for leftover identifiers. If it finds one, it writes a short PII-free remediation report (which detection engine, cleaning strategy, threshold, or entity labels to change) and the pipeline applies it and runs detection and cleaning again, up to a set number of tries. Once the text is clean, a human approves it (HITL)

## Changes

- Added `AdversarialAgent` (`agents/adversary.py`): probes the cleaned text for leftover identifiers and flags a leak when confidence is high enough. On a leak it also emits a remediation report, with knowledge of the available engines/strategies/params and of its own past reports, so it can see whether they were applied
- Added report-driven escalation: the analyzer applies the adversary's report through the same path as human gate feedback (extra entity labels, engine/strategy/threshold overrides, guidance pinned into the prompt). No fixed escalation ladder; without a usable report the policy is only hardened with the escalation note. Stops after `max_iterations` and marks the request unsafe
- Added the HITL gate (`agents/gate.py`): shows a short PII-free summary and waits for a human choice (approve / revise / reject)
- Wired the graph (`pipeline.py`) with the loop and the routing for the adversary and gate
- Added config (`config.py`): `AttackVector` enum, `LeakageAdversaryConfig`, and an `interactive` flag

## Notes

- Only leaks count against `max_iterations`, a human revision does not so he/she can ask changes as many times as wanted
- The adversary's report cannot override fields the user pinned in the config (engine, strategy, threshold), but human feedback at the gate can
- The gate summary has no PII, so the review itself does not leak