### PR TITLE
Fix marker dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ process = [
     # Document processing + post-processing
     "transformers>=4.44",
     "PyMuPDF",
-    "marker-pdf>=1.6",
+    "marker-pdf>=1.10.2,<2",
     "surya-ocr>=0.8.3",
     "moviepy>=2.0",
     "mammoth>=1.8",

--- a/uv.lock
+++ b/uv.lock
@@ -5368,7 +5368,7 @@ requires-dist = [
     { name = "mammoth", marker = "extra == 'process'", specifier = ">=1.8" },
     { name = "markdown", marker = "extra == 'process'", specifier = ">=3.5" },
     { name = "markdownify", marker = "extra == 'process'", specifier = ">=0.12" },
-    { name = "marker-pdf", marker = "extra == 'process'", specifier = ">=1.6" },
+    { name = "marker-pdf", marker = "extra == 'process'", specifier = ">=1.10.2,<2" },
     { name = "milvus-lite", marker = "extra == 'index'", specifier = "==2.5.1" },
     { name = "milvus-model", marker = "extra == 'index'", specifier = ">=0.2.12" },
     { name = "mmore", extras = ["api", "index"], marker = "extra == 'colvision'" },


### PR DESCRIPTION
## Summary

Fix an error related to the `marker-pdf` that leads to errors during process of documents when we use a version`>=2`