### PR TITLE
issue #191 : Add configurable processor selection by file extension

### DIFF
--- a/docs/source/getting_started/process.md
+++ b/docs/source/getting_started/process.md
@@ -163,11 +163,29 @@ The project supports multiple file types and utilizes various AI-based tools for
 mmore also uses [Dask Distributed](https://distributed.dask.org/en/latest/) to manage distributed execution.
 
 ## 🔧 Customization
+### Custom Processors
 The system is designed to be extensible, allowing you to register custom processors for handling new file types or specialized processing. To implement a new processor you need to inherit the `Processor` class and implement only two methods:
 - `accepts`: defines which file types your processor supports (e.g. docx)
 - `process`: how to process a single file (input:file type, output: Multimodal sample, see other processors for reference)
 
 For a minimal example, see [`TextProcessor`](https://github.com/EPFLiGHT/mmore/blob/main/src/mmore/process/processors/txt_processor.py).
+
+### Processor Preferences
+For file extensions supported by multiple processors, a preferred processor can be selected in `dispatcher_config`.
+You can add a processor preference by specifying the file extension and the processor name in `processor_selection`, for example:
+
+```yaml
+dispatcher_config:
+  processor_selection:
+    ".pdf": PDFProcessor
+    ".docx": DOCXProcessor
+```
+
+Each key is a file extension, including the leading dot, and each value is the processor class name.
+
+If no processor is specified for an extension, the first compatible processor is used.
+
+⚠️ If the selected processor is not compatible with the file, the file is skipped.
 
 ## 🧹 Post-processing
 

--- a/examples/process/config.yaml
+++ b/examples/process/config.yaml
@@ -36,3 +36,7 @@ dispatcher_config:
       - LAYOUT_BATCH_SIZE: 1
       - ORDER_BATCH_SIZE: 1
       - TABLE_REC_BATCH_SIZE: 1
+  
+  # AJ : adding dictionnary 'file_extension' -> 'processor'
+  processor_selection: {}
+  

--- a/examples/process/config.yaml
+++ b/examples/process/config.yaml
@@ -36,7 +36,6 @@ dispatcher_config:
       - LAYOUT_BATCH_SIZE: 1
       - ORDER_BATCH_SIZE: 1
       - TABLE_REC_BATCH_SIZE: 1
-  
-  # AJ : adding dictionnary 'file_extension' -> 'processor'
-  processor_selection: {}
-  
+
+  processor_selection:
+    ".pdf": PDFProcessor

--- a/src/mmore/process/dispatcher.py
+++ b/src/mmore/process/dispatcher.py
@@ -72,6 +72,10 @@ class DispatcherConfig:
     distributed: bool = False
     scheduler_file: Optional[str] = None
     processor_config: Optional[Dict] = None
+
+    ## AJ : adding new variable, represents map PDF EXTENSION -> PROCESSOR (set pref for each document format)
+    processor_selection: Optional[Dict[str, str]] = None
+
     process_batch_sizes: Optional[List[Dict[str, float]]] = None
     batch_multiplier: int = 1
     extract_images: bool = False
@@ -91,6 +95,9 @@ class DispatcherConfig:
             distributed=config.get("distributed", False),
             scheduler_file=config.get("scheduler_file"),
             processor_config=config.get("processor_config"),
+
+            # AJ ; RETRIEVING PROCESSOR_SELECTION FROM YAML
+            processor_selection=config.get("processor_selection"),
             process_batch_sizes=config.get("process_batch_sizes"),
             batch_multiplier=config.get("batch_multiplier", 1),
             extract_images=config.get("extract_images", False),
@@ -116,6 +123,9 @@ class DispatcherConfig:
             "scheduler_file": self.scheduler_file,
             "output_path": self.output_path,
             "processor_config": self.processor_config,
+
+            #AJ : GET PROCESSOR PREF DICTS 
+            "processor_selection": self.processor_selection,
             "process_batch_sizes": self.process_batch_sizes,
             "batch_multiplier": self.batch_multiplier,
             "extract_images": self.extract_images,
@@ -194,9 +204,20 @@ class Dispatcher:
             processor: [] for processor in ProcessorRegistry.get_processors()
         }
 
+         # AJ : get all preferred processors from the configuration file
+        all_processor_preferences = self.config.processor_selection or {} # empty dic if config.selection EMPTY
+
         for file_path_list in self.result.file_paths.values():
             for file in file_path_list:
-                processor = AutoProcessor.from_file(file)
+
+                # AJ : retrieve preferred processor for current file (using file extension), give it to AutoProcessor
+                preferred_processor_for_file = all_processor_preferences.get(file.file_extension)
+                processor = AutoProcessor.from_file(file, preferred_processor_for_file)
+
+                # AJ : if no processor found, ignore the file
+                if processor is None:
+                    continue 
+
                 logger.debug(
                     f"Assigned file {file.file_path} to processor: {processor}"
                 )

--- a/src/mmore/process/dispatcher.py
+++ b/src/mmore/process/dispatcher.py
@@ -72,10 +72,7 @@ class DispatcherConfig:
     distributed: bool = False
     scheduler_file: Optional[str] = None
     processor_config: Optional[Dict] = None
-
-    ## AJ : adding new variable, represents map PDF EXTENSION -> PROCESSOR (set pref for each document format)
     processor_selection: Optional[Dict[str, str]] = None
-
     process_batch_sizes: Optional[List[Dict[str, float]]] = None
     batch_multiplier: int = 1
     extract_images: bool = False
@@ -95,8 +92,6 @@ class DispatcherConfig:
             distributed=config.get("distributed", False),
             scheduler_file=config.get("scheduler_file"),
             processor_config=config.get("processor_config"),
-
-            # AJ ; RETRIEVING PROCESSOR_SELECTION FROM YAML
             processor_selection=config.get("processor_selection"),
             process_batch_sizes=config.get("process_batch_sizes"),
             batch_multiplier=config.get("batch_multiplier", 1),
@@ -123,8 +118,6 @@ class DispatcherConfig:
             "scheduler_file": self.scheduler_file,
             "output_path": self.output_path,
             "processor_config": self.processor_config,
-
-            #AJ : GET PROCESSOR PREF DICTS 
             "processor_selection": self.processor_selection,
             "process_batch_sizes": self.process_batch_sizes,
             "batch_multiplier": self.batch_multiplier,
@@ -204,19 +197,16 @@ class Dispatcher:
             processor: [] for processor in ProcessorRegistry.get_processors()
         }
 
-         # AJ : get all preferred processors from the configuration file
-        all_processor_preferences = self.config.processor_selection or {} # empty dic if config.selection EMPTY
+        all_processor_preferences = self.config.processor_selection or {}
 
         for file_path_list in self.result.file_paths.values():
             for file in file_path_list:
 
-                # AJ : retrieve preferred processor for current file (using file extension), give it to AutoProcessor
                 preferred_processor_for_file = all_processor_preferences.get(file.file_extension)
                 processor = AutoProcessor.from_file(file, preferred_processor_for_file)
 
-                # AJ : if no processor found, ignore the file
                 if processor is None:
-                    continue 
+                    continue
 
                 logger.debug(
                     f"Assigned file {file.file_path} to processor: {processor}"

--- a/src/mmore/process/dispatcher.py
+++ b/src/mmore/process/dispatcher.py
@@ -201,8 +201,9 @@ class Dispatcher:
 
         for file_path_list in self.result.file_paths.values():
             for file in file_path_list:
-
-                preferred_processor_for_file = all_processor_preferences.get(file.file_extension)
+                preferred_processor_for_file = all_processor_preferences.get(
+                    file.file_extension
+                )
                 processor = AutoProcessor.from_file(file, preferred_processor_for_file)
 
                 if processor is None:

--- a/src/mmore/process/processors/base.py
+++ b/src/mmore/process/processors/base.py
@@ -66,45 +66,33 @@ class ProcessorRegistry:
         return cls._registry
 
 
-# AJ : Added processor preferrences in the method's arguments
 class AutoProcessor:
     @classmethod
     def from_file(
-        cls, 
+        cls,
         file: FileDescriptor,
-        preferred_processor: Optional[str] = None, #new argument
+        preferred_processor: Optional[str] = None,
     ):
         """
         Determine and return the appropriate processor for the given file.
 
         Args:
             file (FileDescriptor): The file descriptor to process.
+            preferred_processor (Optional[str]): the preferred processor to process the file.
 
         Returns:
             Processor: The appropriate processor for the file, or None if no processor is found.
         """
 
+        for processor in ProcessorRegistry.get_processors():
+            if processor.accepts(file) and (
+                preferred_processor is None
+                or processor.__name__ == preferred_processor
+            ):
+                return processor
 
-        # AJ : if there is a preference, return processor corresponding to preferrence if it exists.
-        # AJ : No preference => return first processor which accepts the file
-
-        if(preferred_processor is not None):
-            for processor in ProcessorRegistry.get_processors():
-                if(
-                    processor.__name__ == preferred_processor
-                    and processor.accepts(file)
-                ):
-                    return processor
-
-            return None
-        
-        else:
-            for processor in ProcessorRegistry.get_processors():
-                if processor.accepts(file):
-                    return processor
-
-            logger.warning(f"No registered processor found for file {file}")
-            return None
+        logger.warning(f"No registered processor found for file {file}")
+        return None
 
 
 class Processor(ABC):

--- a/src/mmore/process/processors/base.py
+++ b/src/mmore/process/processors/base.py
@@ -66,9 +66,14 @@ class ProcessorRegistry:
         return cls._registry
 
 
+# AJ : Added processor preferrences in the method's arguments
 class AutoProcessor:
     @classmethod
-    def from_file(cls, file: FileDescriptor):
+    def from_file(
+        cls, 
+        file: FileDescriptor,
+        preferred_processor: Optional[str] = None, #new argument
+    ):
         """
         Determine and return the appropriate processor for the given file.
 
@@ -79,12 +84,27 @@ class AutoProcessor:
             Processor: The appropriate processor for the file, or None if no processor is found.
         """
 
-        for processor in ProcessorRegistry.get_processors():
-            if processor.accepts(file):
-                return processor
 
-        logger.warning(f"No registered processor found for file {file}")
-        return None
+        # AJ : if there is a preference, return processor corresponding to preferrence if it exists.
+        # AJ : No preference => return first processor which accepts the file
+
+        if(preferred_processor is not None):
+            for processor in ProcessorRegistry.get_processors():
+                if(
+                    processor.__name__ == preferred_processor
+                    and processor.accepts(file)
+                ):
+                    return processor
+
+            return None
+        
+        else:
+            for processor in ProcessorRegistry.get_processors():
+                if processor.accepts(file):
+                    return processor
+
+            logger.warning(f"No registered processor found for file {file}")
+            return None
 
 
 class Processor(ABC):

--- a/src/mmore/process/processors/base.py
+++ b/src/mmore/process/processors/base.py
@@ -86,8 +86,7 @@ class AutoProcessor:
 
         for processor in ProcessorRegistry.get_processors():
             if processor.accepts(file) and (
-                preferred_processor is None
-                or processor.__name__ == preferred_processor
+                preferred_processor is None or processor.__name__ == preferred_processor
             ):
                 return processor
 

--- a/tests/test_processor_selection.py
+++ b/tests/test_processor_selection.py
@@ -1,9 +1,15 @@
+import logging
+
+from mmore.process.crawler import DispatcherReadyResult
+from mmore.process.dispatcher import Dispatcher, DispatcherConfig
 from mmore.process.processors.base import AutoProcessor, ProcessorRegistry
+from mmore.process.processors.url_processor import URLProcessor
 from mmore.type import FileDescriptor
 
 # ---------------------------------------------------------------------------
-# Definition of two dummy processors : ProcessorA, ProcessorB
+# Definition of dummy processors: ProcessorA, ProcessorB, IncompatibleProcessor
 # ---------------------------------------------------------------------------
+
 
 class ProcessorA:
     @classmethod
@@ -17,21 +23,35 @@ class ProcessorB:
         return file.file_extension == ".dummy"
 
 
+class IncompatibleProcessor:
+    @classmethod
+    def accepts(cls, file):
+        return file.file_extension == ".other"
+
+
 # ---------------------------------------------------------------------------
-# Dummy file instantiation, creating list of processors with ProcessorA coming
-# first, and setting preference for processorB for the processor selection
+# Helper function used to instantiate dummy files without creating real files
+# ---------------------------------------------------------------------------
+
+
+def make_file_descriptor(file_name, file_extension):
+    return FileDescriptor(
+        file_path=file_name,
+        file_name=file_name,
+        file_size=0,
+        created_at="",
+        modified_at="",
+        file_extension=file_extension,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Preferred processor selection when multiple processors accept the file
 # ---------------------------------------------------------------------------
 
 
 def test_preferred_processor_is_selected(monkeypatch):
-    dummy_file = FileDescriptor(
-        file_path="test.dummy",
-        file_name="test.dummy",
-        file_size=0,
-        created_at="",
-        modified_at="",
-        file_extension=".dummy",
-    )
+    dummy_file = make_file_descriptor("test.dummy", ".dummy")
 
     monkeypatch.setattr(
         ProcessorRegistry,
@@ -45,3 +65,105 @@ def test_preferred_processor_is_selected(monkeypatch):
     )
 
     assert selected_processor is ProcessorB
+
+
+# ---------------------------------------------------------------------------
+# Default selection when no preferred processor is configured
+# ---------------------------------------------------------------------------
+
+
+def test_first_compatible_processor_is_selected_without_preference(monkeypatch):
+    dummy_file = make_file_descriptor("test.dummy", ".dummy")
+
+    monkeypatch.setattr(
+        ProcessorRegistry,
+        "_registry",
+        [ProcessorA, ProcessorB],
+    )
+
+    selected_processor = AutoProcessor.from_file(dummy_file)
+
+    assert selected_processor is ProcessorA
+
+
+# ---------------------------------------------------------------------------
+# No processor selection when none of the registered processors accept the file
+# ---------------------------------------------------------------------------
+
+
+def test_no_processor_is_selected_when_none_accepts(monkeypatch, caplog):
+    unsupported_file = make_file_descriptor("test.unsupported", ".unsupported")
+
+    monkeypatch.setattr(
+        ProcessorRegistry,
+        "_registry",
+        [ProcessorA, ProcessorB],
+    )
+
+    with caplog.at_level(logging.WARNING):
+        selected_processor = AutoProcessor.from_file(unsupported_file)
+
+    assert selected_processor is None
+    assert "No registered processor found" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# No fallback when the preferred processor does not accept the file
+# ---------------------------------------------------------------------------
+
+
+def test_incompatible_preferred_processor_does_not_fallback(monkeypatch):
+    dummy_file = make_file_descriptor("test.dummy", ".dummy")
+
+    monkeypatch.setattr(
+        ProcessorRegistry,
+        "_registry",
+        [ProcessorA, IncompatibleProcessor],
+    )
+
+    selected_processor = AutoProcessor.from_file(
+        dummy_file,
+        preferred_processor="IncompatibleProcessor",
+    )
+
+    assert selected_processor is None
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher selection with multiple files, including an unsupported file
+# ---------------------------------------------------------------------------
+
+
+def test_dispatcher_buckets_multiple_files_and_ignores_unsupported(
+    monkeypatch, tmp_path
+):
+    first_dummy_file = make_file_descriptor("first.dummy", ".dummy")
+    unsupported_file = make_file_descriptor("test.unsupported", ".unsupported")
+    second_dummy_file = make_file_descriptor("second.dummy", ".dummy")
+
+    monkeypatch.setattr(
+        ProcessorRegistry,
+        "_registry",
+        [ProcessorA, ProcessorB, URLProcessor],
+    )
+
+    result = DispatcherReadyResult(
+        urls=[],
+        file_paths={"local": [first_dummy_file, unsupported_file, second_dummy_file]},
+    )
+    config = DispatcherConfig(
+        output_path=str(tmp_path),
+        processor_selection={".dummy": "ProcessorB"},
+    )
+    dispatcher = Dispatcher(result=result, config=config)
+
+    dispatcher._bucket_files()
+
+    assert dispatcher.intermediate_map[ProcessorA] == []
+    assert dispatcher.intermediate_map[ProcessorB] == [
+        first_dummy_file,
+        second_dummy_file,
+    ]
+    assert all(
+        unsupported_file not in files for files in dispatcher.intermediate_map.values()
+    )

--- a/tests/test_processor_selection.py
+++ b/tests/test_processor_selection.py
@@ -1,0 +1,47 @@
+from mmore.process.processors.base import AutoProcessor, ProcessorRegistry
+from mmore.type import FileDescriptor
+
+# ---------------------------------------------------------------------------
+# Definition of two dummy processors : ProcessorA, ProcessorB
+# ---------------------------------------------------------------------------
+
+class ProcessorA:
+    @classmethod
+    def accepts(cls, file):
+        return file.file_extension == ".dummy"
+
+
+class ProcessorB:
+    @classmethod
+    def accepts(cls, file):
+        return file.file_extension == ".dummy"
+
+
+# ---------------------------------------------------------------------------
+# Dummy file instantiation, creating list of processors with ProcessorA coming
+# first, and setting preference for processorB for the processor selection
+# ---------------------------------------------------------------------------
+
+
+def test_preferred_processor_is_selected(monkeypatch):
+    dummy_file = FileDescriptor(
+        file_path="test.dummy",
+        file_name="test.dummy",
+        file_size=0,
+        created_at="",
+        modified_at="",
+        file_extension=".dummy",
+    )
+
+    monkeypatch.setattr(
+        ProcessorRegistry,
+        "_registry",
+        [ProcessorA, ProcessorB],
+    )
+
+    selected_processor = AutoProcessor.from_file(
+        dummy_file,
+        preferred_processor="ProcessorB",
+    )
+
+    assert selected_processor is ProcessorB


### PR DESCRIPTION
## Summary

- add an extension-to-processor mapping to `DispatcherConfig`
- use the configured processor when it is compatible
- preserve the first-compatible fallback when no preference is configured
- ignores files when the configured processor cannot process them
- created a unitary test for this behavior

## Tests

- added a regression test with two processors accepting `.dummy` custom file extension
- the processor list has two custom processors in this order : [ProcessorA, ProcessorB]
- Preference is ProcessorB, the test checks that the later is used instead of falling on ProcessorA

